### PR TITLE
Add support to upload sdk to bintray

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.1.3'
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7'
         classpath 'com.google.gms:google-services:3.0.0'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -26,3 +26,5 @@ dependencies {
     compile rootProject.okHttpUrlConnection
     compile rootProject.gson
 }
+
+apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/core/gradle.properties
+++ b/core/gradle.properties
@@ -1,0 +1,3 @@
+POM_ARTIFACT_ID=core
+POM_NAME=Testpress Core
+POM_PACKAGING=aar

--- a/exam/build.gradle
+++ b/exam/build.gradle
@@ -30,3 +30,5 @@ dependencies {
     compile rootProject.universalImageLoader
     compile rootProject.chart
 }
+
+apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/exam/gradle.properties
+++ b/exam/gradle.properties
@@ -1,0 +1,3 @@
+POM_ARTIFACT_ID=exam
+POM_NAME=Testpress Exam
+POM_PACKAGING=aar

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,3 +16,11 @@
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+GROUP=com.github.testpress
+VERSION_NAME=1.0.0
+POM_DESCRIPTION=Used to integrate android apps with Testpress Platform
+POM_URL=https://github.com/testpress/android-sdk/
+POM_SCM_URL=https://github.com/testpress/android-sdk/
+POM_SCM_CONNECTION=scm:git@https://github.com/testpress/android-sdk.git
+POM_SCM_DEV_CONNECTION=scm:git@https://github.com/testpress/android-sdk.git
+GIT_URL=https://github.com/testpress/android-sdk.git

--- a/gradle/gradle-mvn-push.gradle
+++ b/gradle/gradle-mvn-push.gradle
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2013 Chris Banes
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+apply plugin: 'maven'
+apply plugin: 'com.jfrog.bintray'
+
+version = VERSION_NAME
+group = GROUP
+
+def bin_user = ""
+def bin_key = ""
+try {
+  bin_user = BINTRAY_USER
+  bin_key = BINTRAY_KEY
+} catch (Exception ignored) {
+  println 'Failed to find credentials. Maven deploy disabled'
+}
+
+afterEvaluate { project ->
+  bintray {
+    user = bin_user
+    key = bin_key
+    configurations = ['archives']
+    publish = true
+    pkg {
+      repo = 'maven'
+      name = POM_ARTIFACT_ID
+      desc = POM_DESCRIPTION
+      websiteUrl = POM_URL
+      vcsUrl = GIT_URL
+      version {
+        name = VERSION_NAME
+        vcsTag = VERSION_NAME
+        gpg {
+          sign = true
+          try {
+            passphrase = PASS_PHRASE
+          } catch (Exception ignored) {
+            println 'Failed to find credentials. GPG sign disabled'
+          }
+        }
+      }
+    }
+  }
+
+  if (project.getPlugins().hasPlugin('com.android.application') ||
+          project.getPlugins().hasPlugin('com.android.library')) {
+    task install(type: Upload, dependsOn: assemble) {
+      repositories.mavenInstaller {
+        configuration = configurations.archives
+
+        pom.groupId = GROUP
+        pom.artifactId = POM_ARTIFACT_ID
+        pom.version = VERSION_NAME
+
+        pom.project {
+          name POM_NAME
+          packaging POM_PACKAGING
+          description POM_DESCRIPTION
+          url POM_URL
+
+          scm {
+            url POM_SCM_URL
+            connection POM_SCM_CONNECTION
+            developerConnection POM_SCM_DEV_CONNECTION
+          }
+
+        }
+      }
+    }
+
+    task androidJavadocs(type: Javadoc) {
+      source = android.sourceSets.main.java.source
+      classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+    }
+
+    task androidJavadocsJar(type: Jar, dependsOn: androidJavadocs) {
+      classifier = 'javadoc'
+      from androidJavadocs.destinationDir
+    }
+
+    task androidSourcesJar(type: Jar) {
+      classifier = 'sources'
+      from android.sourceSets.main.java.source
+    }
+  } else {
+    install {
+      repositories.mavenInstaller {
+        pom.groupId = GROUP
+        pom.artifactId = POM_ARTIFACT_ID
+        pom.version = VERSION_NAME
+
+        pom.project {
+          name POM_NAME
+          packaging POM_PACKAGING
+          description POM_DESCRIPTION
+          url POM_URL
+
+          scm {
+            url POM_SCM_URL
+            connection POM_SCM_CONNECTION
+            developerConnection POM_SCM_DEV_CONNECTION
+          }
+
+          licenses {
+            license {
+              name POM_LICENCE_NAME
+              url POM_LICENCE_URL
+              distribution POM_LICENCE_DIST
+            }
+          }
+
+          developers {
+            developer {
+              id POM_DEVELOPER_ID
+              name POM_DEVELOPER_NAME
+            }
+          }
+        }
+      }
+    }
+
+    task sourcesJar(type: Jar, dependsOn:classes) {
+      classifier = 'sources'
+      from sourceSets.main.allSource
+    }
+
+    task javadocJar(type: Jar, dependsOn:javadoc) {
+      classifier = 'javadoc'
+      from javadoc.destinationDir
+    }
+  }
+
+  if (JavaVersion.current().isJava8Compatible()) {
+    allprojects {
+      tasks.withType(Javadoc) {
+        options.addStringOption('Xdoclint:none', '-quiet')
+      }
+    }
+  }
+
+  artifacts {
+    if (project.getPlugins().hasPlugin('com.android.application') ||
+            project.getPlugins().hasPlugin('com.android.library')) {
+      archives androidSourcesJar
+      archives androidJavadocsJar
+    } else {
+      archives sourcesJar
+      archives javadocJar
+    }
+  }
+}


### PR DESCRIPTION
New versions of sdk modules can be upload to bintray repository using
two commands
  1. ./gradlew install
  2. ./gradlew bintrayUpload