### PR TITLE
Allow cancel dialog if no internet during writing exam

### DIFF
--- a/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
@@ -457,7 +457,14 @@ public class TestFragment extends Fragment implements LoaderManager.LoaderCallba
                                         progressDialog.show();
                                         saveResult(position);
                                     }
-                        })
+                                })
+                        .setNegativeButton(R.string.testpress_not_now,
+                                new DialogInterface.OnClickListener() {
+                                    @Override
+                                    public void onClick(DialogInterface dialogInterface, int i) {
+                                        returnToHistory();
+                                    }
+                                })
                         .show();
             }
 
@@ -499,6 +506,13 @@ public class TestFragment extends Fragment implements LoaderManager.LoaderCallba
                                     sendHeartBeat.execute();
                                 }
                             })
+                    .setNegativeButton(R.string.testpress_not_now,
+                            new DialogInterface.OnClickListener() {
+                                @Override
+                                public void onClick(DialogInterface dialogInterface, int i) {
+                                    returnToHistory();
+                                }
+                            })
                     .show();
         }
 
@@ -533,6 +547,13 @@ public class TestFragment extends Fragment implements LoaderManager.LoaderCallba
                                 public void onClick(DialogInterface dialogInterface, int i) {
                                     progressDialog.show();
                                     endExam.execute();
+                                }
+                            })
+                    .setNegativeButton(R.string.testpress_not_now,
+                            new DialogInterface.OnClickListener() {
+                                @Override
+                                public void onClick(DialogInterface dialogInterface, int i) {
+                                    returnToHistory();
                                 }
                             })
                     .show();

--- a/exam/src/main/res/values/strings.xml
+++ b/exam/src/main/res/values/strings.xml
@@ -51,6 +51,7 @@
     <string name="testpress_review">REVIEW</string>
     <string name="testpress_start_exam">Start Exam</string>
     <string name="testpress_resume_exam">Resume Exam</string>
+    <string name="testpress_not_now">Not Now</string>
     <string name="testpress_next">NEXT</string>
     <string name="testpress_previous">PREV</string>
     <string name="testpress_paused">PAUSED</string>


### PR DESCRIPTION
When writing an exam and if internet gets disconnected, a dialog is
shown with Retry button. To make it cancelable 'Not Now' button is
added. So that user can pause the exam and return to main page.
Fixes #21