### PR TITLE
Fix crash on resume app from background & rename app theme

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.0'
+        classpath 'com.android.tools.build:gradle:2.2.2'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7'
         classpath 'com.google.gms:google-services:3.0.0'
         // NOTE: Do not place your application dependencies here; they belong

--- a/core/src/main/java/in/testpress/util/ImageUtils.java
+++ b/core/src/main/java/in/testpress/util/ImageUtils.java
@@ -1,0 +1,41 @@
+package in.testpress.util;
+
+import android.content.Context;
+
+import com.nostra13.universalimageloader.cache.memory.impl.WeakMemoryCache;
+import com.nostra13.universalimageloader.core.DisplayImageOptions;
+import com.nostra13.universalimageloader.core.ImageLoader;
+import com.nostra13.universalimageloader.core.ImageLoaderConfiguration;
+import com.nostra13.universalimageloader.core.assist.ImageScaleType;
+import com.nostra13.universalimageloader.core.display.FadeInBitmapDisplayer;
+
+public class ImageUtils {
+
+    /**
+     * Init the ImageLoader with custom configuration.
+     *
+     * @param context Context
+     * @return Initialized ImageLoader.
+     */
+    public static ImageLoader initImageLoader(Context context) {
+        ImageLoader imageLoader = ImageLoader.getInstance();
+        if (imageLoader.isInited()) {
+            return imageLoader;
+        } else {
+            DisplayImageOptions defaultOptions = new DisplayImageOptions.Builder()
+                    .cacheOnDisk(true).cacheInMemory(true)
+                    .imageScaleType(ImageScaleType.EXACTLY)
+                    .displayer(new FadeInBitmapDisplayer(300)).build();
+
+            ImageLoaderConfiguration config =
+                    new ImageLoaderConfiguration.Builder(context.getApplicationContext())
+                            .defaultDisplayImageOptions(defaultOptions)
+                            .memoryCache(new WeakMemoryCache())
+                            .diskCacheSize(500 * 1024 * 1024).build();
+
+            imageLoader.init(config);
+            return imageLoader;
+        }
+    }
+
+}

--- a/core/src/main/java/in/testpress/util/UILImageGetter.java
+++ b/core/src/main/java/in/testpress/util/UILImageGetter.java
@@ -10,7 +10,6 @@ import android.util.Log;
 import android.view.View;
 import android.widget.TextView;
 
-import com.nostra13.universalimageloader.core.ImageLoader;
 import com.nostra13.universalimageloader.core.listener.SimpleImageLoadingListener;
 
 public class UILImageGetter implements Html.ImageGetter {
@@ -33,7 +32,7 @@ public class UILImageGetter implements Html.ImageGetter {
     public Drawable getDrawable(String source) {
         UrlImageDownloader urlDrawable = new UrlImageDownloader(activity.getApplicationContext()
                 .getResources(), source);
-        ImageLoader.getInstance().loadImage(source, new SimpleListener(urlDrawable));
+        ImageUtils.initImageLoader(activity).loadImage(source, new SimpleListener(urlDrawable));
         return urlDrawable;
     }
 

--- a/core/src/main/res/layout/testpress_toolbar.xml
+++ b/core/src/main/res/layout/testpress_toolbar.xml
@@ -8,14 +8,14 @@
     android:fitsSystemWindows="true"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:theme="@style/TestpressAppThemeDark">
+    android:theme="@style/TestpressTheme">
 
     <android.support.v7.widget.Toolbar
         android:id="@+id/toolbar"
         android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize"
         android:background="?attr/colorPrimary"
-        app:popupTheme="@style/TestpressAppThemeDark.PopupOverlay"
+        app:popupTheme="@style/TestpressTheme.PopupOverlay"
         app:layout_scrollFlags="scroll|enterAlways" />
 
 </android.support.design.widget.AppBarLayout>

--- a/core/src/main/res/values/styles.xml
+++ b/core/src/main/res/values/styles.xml
@@ -3,7 +3,7 @@
     tools:ignore="UnusedResources">
 
     <!-- Base application theme. -->
-    <style name="TestpressAppThemeDark" parent="Theme.AppCompat.Light.DarkActionBar">
+    <style name="TestpressTheme" parent="Theme.AppCompat.Light.DarkActionBar">
         <item name="colorPrimary">@color/testpress_actionbar_background</item>
         <item name="colorAccent">@color/testpress_color_primary</item>
         <item name="windowActionBar">false</item>
@@ -13,7 +13,7 @@
         <item name="colorButtonNormal">@color/testpress_color_primary</item>
     </style>
 
-    <style name="TestpressAppThemeDark.PopupOverlay" parent="ThemeOverlay.AppCompat.Light" />
+    <style name="TestpressTheme.PopupOverlay" parent="ThemeOverlay.AppCompat.Light" />
 
     <style name="TestpressAppCompatAlertDialogStyle" parent="Theme.AppCompat.Light.Dialog.Alert">
         <item name="colorAccent">#08AE9E</item>

--- a/exam/src/main/AndroidManifest.xml
+++ b/exam/src/main/AndroidManifest.xml
@@ -7,26 +7,26 @@
 
         <activity android:name=".ui.ExamsListActivity"
             android:label="@string/testpress_exams"
-            android:theme="@style/TestpressAppThemeDark"
+            android:theme="@style/TestpressTheme"
             android:configChanges="orientation|keyboard|screenSize" />
 
         <activity android:name=".ui.TestActivity"
             android:label="@string/testpress_start_exam"
-            android:theme="@style/TestpressAppThemeDark.NoToolBar"
+            android:theme="@style/TestpressTheme.NoToolBar"
             android:configChanges="orientation|keyboard|screenSize" />
 
         <activity android:name=".ui.AttemptsListActivity"
-            android:theme="@style/TestpressAppThemeDark"
+            android:theme="@style/TestpressTheme"
             android:configChanges="orientation|keyboard|screenSize" />
 
         <activity android:name=".ui.ReviewActivity"
             android:label="@string/testpress_review_label"
-            android:theme="@style/TestpressAppThemeDark"
+            android:theme="@style/TestpressTheme"
             android:configChanges="orientation|keyboard|screenSize" />
 
         <activity android:name=".ui.SearchActivity"
             android:windowSoftInputMode="stateVisible"
-            android:theme="@style/TestpressAppThemeDark"
+            android:theme="@style/TestpressTheme"
             android:configChanges="orientation|keyboard|screenSize" />
 
     </application>

--- a/exam/src/main/java/in/testpress/exam/TestpressExam.java
+++ b/exam/src/main/java/in/testpress/exam/TestpressExam.java
@@ -6,17 +6,11 @@ import android.support.annotation.IdRes;
 import android.support.annotation.NonNull;
 import android.support.v4.app.FragmentActivity;
 
-import com.nostra13.universalimageloader.cache.memory.impl.WeakMemoryCache;
-import com.nostra13.universalimageloader.core.DisplayImageOptions;
-import com.nostra13.universalimageloader.core.ImageLoader;
-import com.nostra13.universalimageloader.core.ImageLoaderConfiguration;
-import com.nostra13.universalimageloader.core.assist.ImageScaleType;
-import com.nostra13.universalimageloader.core.display.FadeInBitmapDisplayer;
-
 import in.testpress.core.TestpressSdk;
 import in.testpress.core.TestpressSession;
 import in.testpress.exam.ui.CarouselFragment;
 import in.testpress.exam.ui.ExamsListActivity;
+import in.testpress.util.ImageUtils;
 
 public class TestpressExam {
 
@@ -40,13 +34,11 @@ public class TestpressExam {
     public static void show(@NonNull FragmentActivity activity,
                             @NonNull @IdRes Integer containerViewId,
                             @NonNull TestpressSession testpressSession) {
+        //noinspection ConstantConditions
         if (activity == null) {
             throw new IllegalArgumentException("Activity must not be null.");
-        } else if (testpressSession == null) {
-            throw new IllegalArgumentException("TestpressSession must not be null.");
         }
-        TestpressSdk.setTestpressSession(activity, testpressSession);
-        initImageLoader(activity);
+        init(activity, testpressSession);
         CarouselFragment.show(activity, containerViewId);
     }
 
@@ -67,29 +59,21 @@ public class TestpressExam {
      * @param testpressSession TestpressSession got from the core module.
      */
     public static void show(@NonNull Context context, @NonNull TestpressSession testpressSession) {
+        //noinspection ConstantConditions
         if (context == null) {
             throw new IllegalArgumentException("Context must not be null.");
-        } else if (testpressSession == null) {
-            throw new IllegalArgumentException("TestpressSession must not be null.");
         }
-        TestpressSdk.setTestpressSession(context, testpressSession);
-        initImageLoader(context);
+        init(context, testpressSession);
         Intent intent = new Intent(context, ExamsListActivity.class);
         context.startActivity(intent);
     }
 
-    public static void initImageLoader(Context context) {
-        DisplayImageOptions defaultOptions = new DisplayImageOptions.Builder()
-                .cacheOnDisk(true).cacheInMemory(true)
-                .imageScaleType(ImageScaleType.EXACTLY)
-                .displayer(new FadeInBitmapDisplayer(300)).build();
-
-        ImageLoaderConfiguration config = new ImageLoaderConfiguration.Builder(context)
-                .defaultDisplayImageOptions(defaultOptions)
-                .memoryCache(new WeakMemoryCache())
-                .diskCacheSize(500 * 1024 * 1024).build();
-
-        ImageLoader.getInstance().init(config);
+    private static void init(Context context, TestpressSession testpressSession) {
+        if (testpressSession == null) {
+            throw new IllegalArgumentException("TestpressSession must not be null.");
+        }
+        TestpressSdk.setTestpressSession(context, testpressSession);
+        ImageUtils.initImageLoader(context);
     }
 
 }

--- a/exam/src/main/java/in/testpress/exam/ui/ReviewFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/ReviewFragment.java
@@ -2,6 +2,7 @@ package in.testpress.exam.ui;
 
 import android.graphics.PorterDuff;
 import android.graphics.drawable.Drawable;
+import android.os.Build;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.design.widget.TabLayout;
@@ -32,6 +33,9 @@ public class ReviewFragment extends Fragment {
 
     static final String PRAM_EXAM = "exam";
     static final String PRAM_ATTEMPT = "attempt";
+    private View tabContainer;
+    private TabLayout tabLayout;
+    private ViewPager pager;
     private ProgressBar progressBar;
     private View emptyView;
     private TextView emptyTitleView;
@@ -52,6 +56,8 @@ public class ReviewFragment extends Fragment {
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        exam = getArguments().getParcelable(PRAM_EXAM);
+        attempt = getArguments().getParcelable(PRAM_ATTEMPT);
         setHasOptionsMenu(true);
     }
 
@@ -72,10 +78,11 @@ public class ReviewFragment extends Fragment {
     public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container,
                              @Nullable Bundle savedInstanceState) {
         final View view = inflater.inflate(R.layout.testpress_fragment_review, container, false);
-        exam = getArguments().getParcelable(PRAM_EXAM);
-        attempt = getArguments().getParcelable(PRAM_ATTEMPT);
         progressBar = (ProgressBar) view.findViewById(R.id.pb_loading);
         UIUtils.setIndeterminateDrawable(getActivity(), progressBar, 4);
+        tabContainer = view.findViewById(R.id.tab_container);
+        tabLayout = (TabLayout) view.findViewById(R.id.tab_layout);
+        pager = (ViewPager) view.findViewById(R.id.viewpager);
         if (attempt == null) {
             emptyView = view.findViewById(R.id.empty_container);
             emptyTitleView = (TextView) view.findViewById(R.id.empty_title);
@@ -85,36 +92,48 @@ public class ReviewFragment extends Fragment {
                 public void onClick(View v) {
                     progressBar.setVisibility(View.VISIBLE);
                     emptyView.setVisibility(View.GONE);
-                    fetchAndRenderAttempt(view, exam);
+                    fetchAndRenderAttempt(exam);
                 }
             });
-            fetchAndRenderAttempt(view, exam);
-        } else {
-            setViewPager(view, exam, attempt);
         }
         return view;
     }
 
-    private void setViewPager(View view, Exam exam, Attempt attempt) {
+    @Override
+    public void onActivityCreated(@Nullable Bundle savedInstanceState) {
+        super.onActivityCreated(savedInstanceState);
+        if (attempt == null) {
+            fetchAndRenderAttempt(exam);
+        } else {
+            setViewPager(exam, attempt);
+        }
+    }
+
+    private void setViewPager(Exam exam, Attempt attempt) {
         progressBar.setVisibility(View.GONE);
-        view.findViewById(R.id.tab_container).setVisibility(View.VISIBLE);
-        TabLayout tabLayout = (TabLayout) view.findViewById(R.id.tab_layout);
-        ViewPager pager = (ViewPager) view.findViewById(R.id.viewpager);
+        tabContainer.setVisibility(View.VISIBLE);
         pager.setAdapter(new ReviewPagerAdapter(this, exam, attempt));
         tabLayout.setupWithViewPager(pager);
     }
 
-    private void fetchAndRenderAttempt(final View view, final Exam exam) {
+    private void fetchAndRenderAttempt(final Exam exam) {
         new TestpressExamApiClient(getActivity()).getAttempts(exam.getAttemptsFrag(),
                 new HashMap<String, Object>())
                 .enqueue(new TestpressCallback<TestpressApiResponse<Attempt>>() {
                     @Override
                     public void onSuccess(TestpressApiResponse<Attempt> response) {
+                        if (getActivity() == null) {
+                            return;
+                        }
                         attempt = response.getResults().get(0);
                         if (exam.getAllowPdf()) {
-                            emailPdfMenu.setVisible(true);
+                            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
+                                getActivity().invalidateOptionsMenu();
+                            } else {
+                                getActivity().supportInvalidateOptionsMenu();
+                            }
                         }
-                        setViewPager(view, exam, attempt);
+                        setViewPager(exam, attempt);
                     }
 
                     @Override

--- a/exam/src/main/res/values/styles.xml
+++ b/exam/src/main/res/values/styles.xml
@@ -99,7 +99,7 @@
         <item name="android:textSize">@dimen/testpress_text_size_xlarge</item>
     </style>
 
-    <style name="TestpressAppThemeDark.NoToolBar">
+    <style name="TestpressTheme.NoToolBar">
         <item name="colorControlNormal">#808080</item>
     </style>
 

--- a/samples/lint.xml
+++ b/samples/lint.xml
@@ -11,5 +11,6 @@
     <issue id="RtlHardcoded" severity="ignore" />
     <issue id="AllowBackup" severity="ignore" />
     <issue id="GoogleAppIndexingWarning" severity="ignore" />
+    <issue id="GradleDependency" severity="ignore" />
 
 </lint>


### PR DESCRIPTION
On resuming app from background state, ReviewFragment will crash due to
accessing activity before it completely creates, it is fixed by
accessing activity on the onActivityCreated. And ImageLoader which has
initiated previously will destroy in the background state. So that app
may crash while it tries to access it, it is fixed by initiating the
ImageLoader if  an instance not exist.
Renamed app theme.
