### PR TITLE
Provide API to start exam using the slug

### DIFF
--- a/exam/src/main/java/in/testpress/exam/TestpressExam.java
+++ b/exam/src/main/java/in/testpress/exam/TestpressExam.java
@@ -1,5 +1,6 @@
 package in.testpress.exam;
 
+import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.support.annotation.IdRes;
@@ -12,9 +13,12 @@ import in.testpress.exam.ui.CarouselFragment;
 import in.testpress.exam.ui.CategoriesGridFragment;
 import in.testpress.exam.ui.CategoryGridActivity;
 import in.testpress.exam.ui.ExamsListActivity;
+import in.testpress.exam.ui.TestActivity;
 import in.testpress.util.ImageUtils;
 
 public class TestpressExam {
+
+    public static final String ACTION_PRESSED_HOME = "pressedHome";
 
     /**
      * Use when testpress exam need to be open in a container as a fragment.
@@ -123,6 +127,38 @@ public class TestpressExam {
         init(context, testpressSession);
         Intent intent = new Intent(context, CategoryGridActivity.class);
         context.startActivity(intent);
+    }
+
+    /**
+     * Use to start a particular exam.
+     *
+     * <p> Usage example:
+     *
+     * <p> TestpressSdk.initialize(this, "baseUrl", "userId", "accessToken", provider,
+     * <p>             new TestpressCallback/<TestpressSession>() {
+     * <p>             @Override
+     * <p>             public void onSuccess(TestpressSession testpressSession) {
+     * <p>                 <b>TestpressExam.startExam(this, testpressSession);</b>
+     * <p>             }
+     * <p> });
+     *
+     * @param activity Context to start the new activity.
+     * @param examSlug Slug of the exam which need to be start.
+     * @param testpressSession TestpressSession got from the core module.
+     */
+    @SuppressWarnings("ConstantConditions")
+    public static void startExam(@NonNull Activity activity, @NonNull String examSlug,
+                                 @NonNull TestpressSession testpressSession) {
+        if (activity == null) {
+            throw new IllegalArgumentException("Activity must not be null.");
+        }
+        if (examSlug == null || examSlug.isEmpty()) {
+            throw new IllegalArgumentException("PARAM_EXAM_SLUG must not be null or empty.");
+        }
+        init(activity, testpressSession);
+        Intent intent = new Intent(activity, TestActivity.class);
+        intent.putExtra(TestActivity.PARAM_EXAM_SLUG, examSlug);
+        activity.startActivityForResult(intent, CarouselFragment.TEST_TAKEN_REQUEST_CODE);
     }
 
     private static void init(Context context, TestpressSession testpressSession) {

--- a/exam/src/main/java/in/testpress/exam/network/ExamService.java
+++ b/exam/src/main/java/in/testpress/exam/network/ExamService.java
@@ -22,6 +22,9 @@ public interface ExamService {
     @GET(TestpressExamApiClient.EXAMS_LIST_PATH)
     RetrofitCall<TestpressApiResponse<Exam>> getExams(@QueryMap Map<String, Object> options);
 
+    @GET(TestpressExamApiClient.EXAMS_LIST_PATH + "{exam_slug}")
+    RetrofitCall<Exam> getExam(@Path(value = "exam_slug", encoded = true) String examSlug);
+
     @GET("/{mail_pdf_url}")
     RetrofitCall<Void> mailQuestionsPdf(
             @Path(value = "mail_pdf_url", encoded = true) String mailPdfUrlFrag);

--- a/exam/src/main/java/in/testpress/exam/network/TestpressExamApiClient.java
+++ b/exam/src/main/java/in/testpress/exam/network/TestpressExamApiClient.java
@@ -57,6 +57,10 @@ public class TestpressExamApiClient extends TestpressApiClient {
         return getExamService().getExams(queryParams);
     }
 
+    public RetrofitCall<Exam> getExam(String examSlug) {
+        return getExamService().getExam(examSlug);
+    }
+
     public RetrofitCall<Void> mailQuestionsPdf(String mailPdfUrlFrag) {
         return getExamService().mailQuestionsPdf(mailPdfUrlFrag);
     }

--- a/exam/src/main/res/values/strings.xml
+++ b/exam/src/main/res/values/strings.xml
@@ -17,12 +17,14 @@
     <string name="testpress_no_internet_connection">No internet connection</string>
     <string name="testpress_try_again">Try again</string>
 
+    <string name="testpress_exam_no_permission">You do not have permission to view this exam.</string>
     <string name="testpress_loading_questions">Loading questions</string>
     <string name="testpress_no_exams">No Exams</string>
     <string name="testpress_no_exams_description">You can buy exams from the store.</string>
     <string name="testpress_no_attempts">No Attempts</string>
     <string name="testpress_no_attempts_description">To review, start and complete your exams.</string>
     <string name="testpress_error_loading_exams">Loading exams failed</string>
+    <string name="testpress_error_loading_exam">Loading exam failed</string>
     <string name="testpress_error_loading_attempts">Loading attempts failed</string>
     <string name="testpress_error_loading_questions">Loading questions failed</string>
     <string name="testpress_please_login">Please login to see this exams</string>
@@ -31,6 +33,8 @@
     <string name="testpress_no_categories">No Categories</string>
     <string name="testpress_no_categories_description">We\'ll be adding new categories here soon.\nCheck back later. Thanks!</string>
     <string name="testpress_error_loading_categories">Loading categories failed</string>
+    <string name="testpress_exam_not_available">Exam not available</string>
+    <string name="testpress_exam_not_available_description">This is no longer available or not published yet.</string>
 
     <string name="testpress_page_available_exams">Available</string>
     <string name="testpress_page_upcoming_exams">Upcoming</string>

--- a/exam/src/test/java/in/testpress/exam/TestpressExamTest.java
+++ b/exam/src/test/java/in/testpress/exam/TestpressExamTest.java
@@ -74,4 +74,34 @@ public class TestpressExamTest {
             assertEquals("TestpressSession must not be null.", e.getMessage());
         }
     }
+
+    @Test
+    public void testStartExam_withNullValues() throws Exception {
+        TestpressSession testpressSession = mock(TestpressSession.class);
+        try {
+            TestpressExam.startExam(null, "DummySlug", testpressSession);
+            fail();
+        } catch (IllegalArgumentException e) {
+            assertEquals("Activity must not be null.", e.getMessage());
+        }
+        FragmentActivity activity = mock(FragmentActivity.class);
+        try {
+            TestpressExam.startExam(activity, "DummySlug", null);
+            fail();
+        } catch (IllegalArgumentException e) {
+            assertEquals("TestpressSession must not be null.", e.getMessage());
+        }
+        try {
+            TestpressExam.startExam(activity, null, testpressSession);
+            fail();
+        } catch (IllegalArgumentException e) {
+            assertEquals("PARAM_EXAM_SLUG must not be null or empty.", e.getMessage());
+        }
+        try {
+            TestpressExam.startExam(activity, "", testpressSession);
+            fail();
+        } catch (IllegalArgumentException e) {
+            assertEquals("PARAM_EXAM_SLUG must not be null or empty.", e.getMessage());
+        }
+    }
 }

--- a/samples/src/main/java/in/testpress/samples/exam/ExamSampleActivity.java
+++ b/samples/src/main/java/in/testpress/samples/exam/ExamSampleActivity.java
@@ -1,9 +1,13 @@
 package in.testpress.samples.exam;
 
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
+import android.support.v7.app.AlertDialog;
 import android.view.View;
+import android.widget.EditText;
+import android.widget.Toast;
 
 import in.testpress.core.TestpressSdk;
 import in.testpress.exam.TestpressExam;
@@ -11,11 +15,13 @@ import in.testpress.samples.BaseToolBarActivity;
 import in.testpress.samples.R;
 import in.testpress.samples.core.TestpressCoreSampleActivity;
 
+import static in.testpress.exam.ui.CarouselFragment.TEST_TAKEN_REQUEST_CODE;
 import static in.testpress.samples.core.TestpressCoreSampleActivity.AUTHENTICATE_REQUEST_CODE;
 
 public class ExamSampleActivity extends BaseToolBarActivity {
 
     private int selectedItem;
+    private String examSlug;
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
@@ -24,6 +30,12 @@ public class ExamSampleActivity extends BaseToolBarActivity {
         //noinspection ConstantConditions
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
         findViewById(R.id.exam).setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                getExamSlug();
+            }
+        });
+        findViewById(R.id.exam_list).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
                 showSDK(view.getId());
@@ -44,15 +56,13 @@ public class ExamSampleActivity extends BaseToolBarActivity {
         });
     }
 
-    private void displayExams() {
-
-    }
-
     @SuppressWarnings("ConstantConditions")
     private void showSDK(int id) {
         selectedItem = id;
         if (TestpressSdk.hasActiveSession(this)) {
             if (id == R.id.exam) {
+                TestpressExam.startExam(this, examSlug, TestpressSdk.getTestpressSession(this));
+            } else if (id == R.id.exam_list) {
                 TestpressExam.show(this, TestpressSdk.getTestpressSession(this));
             } else {
                 TestpressExam.showCategories(this, TestpressSdk.getTestpressSession(this));
@@ -68,7 +78,38 @@ public class ExamSampleActivity extends BaseToolBarActivity {
         super.onActivityResult(requestCode, resultCode, data);
         if (requestCode == AUTHENTICATE_REQUEST_CODE && resultCode == RESULT_OK) {
             showSDK(selectedItem);
+        } else if (requestCode == TEST_TAKEN_REQUEST_CODE) {
+            if (resultCode == RESULT_OK) {
+                Toast.makeText(this, "User attempted the exam", Toast.LENGTH_SHORT).show();
+            } else if (resultCode == RESULT_CANCELED) {
+                if (data.getBooleanExtra(TestpressExam.ACTION_PRESSED_HOME, false)) {
+                    Toast.makeText(this, "User pressed home button", Toast.LENGTH_SHORT).show();
+                } else {
+                    Toast.makeText(this, "User pressed back button", Toast.LENGTH_SHORT).show();
+                }
+            }
         }
+    }
+
+    void getExamSlug() {
+        final View dialog = getLayoutInflater().inflate(R.layout.edit_text_dialog_box, null);
+        AlertDialog.Builder builder = new AlertDialog.Builder(this,
+                R.style.TestpressAppCompatAlertDialogStyle);
+        builder.setTitle("Enter exam slug");
+        builder.setView(dialog);
+        final EditText editText = (EditText) dialog.findViewById(R.id.edit_text);
+        builder.setPositiveButton("Ok", new DialogInterface.OnClickListener() {
+            public void onClick(DialogInterface dialog, int whichButton) {
+                examSlug = editText.getText().toString();
+                if (examSlug.trim().isEmpty()) {
+                    return;
+                }
+                showSDK(R.id.exam);
+                dialog.dismiss();
+            }
+        });
+        builder.setNegativeButton("Cancel", null);
+        builder.create().show();
     }
 
 }

--- a/samples/src/main/res/layout/activity_login.xml
+++ b/samples/src/main/res/layout/activity_login.xml
@@ -42,7 +42,7 @@
                 android:layout_height="wrap_content" />
 
             <android.support.design.widget.TextInputLayout
-                android:theme="@style/EditText"
+                android:theme="@style/TextInputLayoutTheme"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="40dp" >
@@ -55,7 +55,7 @@
             </android.support.design.widget.TextInputLayout>
 
             <android.support.design.widget.TextInputLayout
-                android:theme="@style/EditText"
+                android:theme="@style/TextInputLayoutTheme"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="20dp" >

--- a/samples/src/main/res/layout/activity_open_exams_as.xml
+++ b/samples/src/main/res/layout/activity_open_exams_as.xml
@@ -17,8 +17,15 @@
         <android.support.v7.widget.AppCompatButton
             style="@style/Button"
             android:layout_width="match_parent"
-            android:text="Exams"
+            android:text="Exam"
             android:id="@+id/exam" />
+
+        <android.support.v7.widget.AppCompatButton
+            style="@style/Button"
+            android:layout_width="match_parent"
+            android:layout_marginTop="40dp"
+            android:text="Exams List"
+            android:id="@+id/exam_list" />
 
         <android.support.v7.widget.AppCompatButton
             style="@style/Button"

--- a/samples/src/main/res/layout/edit_text_dialog_box.xml
+++ b/samples/src/main/res/layout/edit_text_dialog_box.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:paddingLeft="22dp"
+    android:paddingRight="22dp">
+
+    <android.support.design.widget.TextInputLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="5dp"
+        android:theme="@style/TextInputLayoutTheme">
+        <android.support.v7.widget.AppCompatEditText
+            style="@style/EditTextStyle"
+            android:id="@+id/edit_text"
+            android:inputType="textMultiLine"
+            android:textSize="16sp"
+            android:maxLines="6"
+            android:imeOptions="actionDone" />
+    </android.support.design.widget.TextInputLayout>
+
+</LinearLayout>

--- a/samples/src/main/res/values/styles.xml
+++ b/samples/src/main/res/values/styles.xml
@@ -11,7 +11,7 @@
 
     <style name="AppTheme.PopupOverlay" parent="ThemeOverlay.AppCompat.Light" />
 
-    <style name="EditText" parent="Theme.AppCompat.Light.DarkActionBar">
+    <style name="TextInputLayoutTheme" parent="Theme.AppCompat.Light.DarkActionBar">
         <item name="android:textSize">14sp</item>
         <!--Bar Color in False State-->
         <item name="colorControlNormal">#c5c5c5</item>
@@ -33,6 +33,16 @@
         <item name="android:layout_height">wrap_content</item>
         <item name="android:textStyle">bold</item>
         <item name="android:textColor">@color/color_primary_text</item>
+    </style>
+
+    <style name="EditTextStyle">
+        <item name="android:layout_width">match_parent</item>
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:autoText">false</item>
+        <item name="android:capitalize">none</item>
+        <item name="android:scrollHorizontally">true</item>
+        <item name="android:singleLine">true</item>
+        <item name="android:imeOptions">actionNext</item>
     </style>
 
 </resources>


### PR DESCRIPTION
An exam can directly start using exam slug.

Result code sent to the onActivityResult() of activity which calls the
start exam API.(To support refresh & deep linking on user app).
* RESULT_OK - If the user started the exam(started the exam & pause or
completed).
* RESULT_CANCELLED - If the user didn't start the exam and navigated
back from the start exam screen. Additionally, an Intent is passed in
the result with a boolean based on the user action as below.
   * True - If the user pressed home icon(left navigation arrow) in the
            app.
   * False - If the user pressed back button on the device.

Provided sample implementation.
Fix #47 