### PR TITLE
Send watched time range to server on video attempt update

### DIFF
--- a/course/src/main/java/in/testpress/course/network/TestpressCourseApiClient.java
+++ b/course/src/main/java/in/testpress/course/network/TestpressCourseApiClient.java
@@ -22,6 +22,7 @@ public class TestpressCourseApiClient extends TestpressApiClient {
      */
     public static final String COURSE_ID = "course_id";
     public static final String LAST_POSITION =  "last_position";
+    public static final String TIME_RANGES =  "time_ranges";
 
     /**
      * Course List Url

--- a/course/src/main/java/in/testpress/course/ui/ContentActivity.java
+++ b/course/src/main/java/in/testpress/course/ui/ContentActivity.java
@@ -425,14 +425,13 @@ public class ContentActivity extends BaseToolBarActivity {
         if (videoAttempt == null) {
             createContentAttempt();
         } else {
-            long lastPosition;
+            float startPosition;
             try {
-                // Convert seconds to ms
-                lastPosition = (long) Float.parseFloat(videoAttempt.getLastPosition()) * 1000;
+                startPosition = Float.parseFloat(videoAttempt.getLastPosition());
             } catch (NumberFormatException e) {
-                lastPosition = 0;
+                startPosition = 0;
             }
-            exoPlayerUtil = new ExoPlayerUtil(this, exoPlayerMainFrame, videoUrl, lastPosition);
+            exoPlayerUtil = new ExoPlayerUtil(this, exoPlayerMainFrame, videoUrl, startPosition);
             exoPlayerUtil.setVideoAttemptId(videoAttempt.getId());
             exoPlayerMainFrame.setVisibility(View.VISIBLE);
             exoPlayerUtil.initializePlayer();

--- a/course/src/main/java/in/testpress/course/ui/ExoPlayerActivity.java
+++ b/course/src/main/java/in/testpress/course/ui/ExoPlayerActivity.java
@@ -33,7 +33,7 @@ public class ExoPlayerActivity extends AppCompatActivity {
         playerView.setLayoutParams(new ConstraintLayout.LayoutParams(matchParent, matchParent));
         findViewById(R.id.exo_fullscreen_button).setVisibility(View.GONE);
         String url = getIntent().getStringExtra(VIDEO_URL);
-        long startPosition = getIntent().getLongExtra(START_POSITION, 0);
+        float startPosition = getIntent().getFloatExtra(START_POSITION, 0);
         float speedRate = getIntent().getFloatExtra(SPEED_RATE, 1);
         FrameLayout exoPlayerMainFrame = findViewById(R.id.exo_player_main_frame);
         exoPlayerUtil =

--- a/course/src/test/java/in/testpress/course/util/ExoPlayerUtilTest.java
+++ b/course/src/test/java/in/testpress/course/util/ExoPlayerUtilTest.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import static in.testpress.course.network.TestpressCourseApiClient.LAST_POSITION;
 import static in.testpress.course.network.TestpressCourseApiClient.TIME_RANGES;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.when;
 
@@ -34,11 +35,20 @@ public class ExoPlayerUtilTest {
         Mockito.doCallRealMethod().when(exoPlayerUtilMocked).getVideoAttemptParameters();
         Map<String, Object> parameters = exoPlayerUtilMocked.getVideoAttemptParameters();
         float lastPosition = (float) parameters.get(LAST_POSITION);
+
+        assertThat("last_position field needs to present on the video attempt parameters",
+                lastPosition,
+                is(notNullValue()));
+
         assertThat("last_position value needs to same as current content position of exo player",
                 lastPosition,
                 is(TEST_CURRENT_POSITION));
 
         String[][] timeRanges = (String[][]) parameters.get(TIME_RANGES);
+
+        assertThat("time_ranges field needs to present on the video attempt parameters",
+                timeRanges,
+                is(notNullValue()));
 
         assertThat("time_ranges start position needs to be start position given to exo player",
                 timeRanges[0][0],

--- a/course/src/test/java/in/testpress/course/util/ExoPlayerUtilTest.java
+++ b/course/src/test/java/in/testpress/course/util/ExoPlayerUtilTest.java
@@ -1,0 +1,52 @@
+package in.testpress.course.util;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.Map;
+
+import static in.testpress.course.network.TestpressCourseApiClient.LAST_POSITION;
+import static in.testpress.course.network.TestpressCourseApiClient.TIME_RANGES;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ExoPlayerUtilTest {
+
+    private static final float TEST_START_POSITION = 111.111f;
+    private static final float TEST_CURRENT_POSITION = 222.222f;
+
+    @Mock
+    private ExoPlayerUtil exoPlayerUtilMocked;
+
+    @Test
+    public void testExoPlayerUtil_getVideoAttemptParameters_returnCorrectValue() {
+
+        when(exoPlayerUtilMocked.getCurrentPosition()).thenReturn(TEST_CURRENT_POSITION);
+
+        Mockito.doCallRealMethod().when(exoPlayerUtilMocked).setStartPosition(TEST_START_POSITION);
+        exoPlayerUtilMocked.setStartPosition(TEST_START_POSITION);
+
+        Mockito.doCallRealMethod().when(exoPlayerUtilMocked).getVideoAttemptParameters();
+        Map<String, Object> parameters = exoPlayerUtilMocked.getVideoAttemptParameters();
+        float lastPosition = (float) parameters.get(LAST_POSITION);
+        assertThat("last_position value needs to same as current content position of exo player",
+                lastPosition,
+                is(TEST_CURRENT_POSITION));
+
+        String[][] timeRanges = (String[][]) parameters.get(TIME_RANGES);
+
+        assertThat("time_ranges start position needs to be start position given to exo player",
+                timeRanges[0][0],
+                is(String.valueOf(TEST_START_POSITION)));
+
+        assertThat("time_ranges current position needs to be current content position of exo player",
+                timeRanges[0][1],
+                is(String.valueOf(lastPosition)));
+    }
+
+}


### PR DESCRIPTION
### Changes done
- Sent watched time range to the server on video attempt update
- Use `startPosition` field in all the places as `float` since server gives & gets
  as `float` and convert to `long` only on get/set in the player.

### Reason for the changes
- To calculate video watched duration in server
