### PR TITLE
Fix video playing after backpress due to incomplete network load.

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -30,6 +30,11 @@ dependencies {
     api rootProject.greendao
     testImplementation rootProject.junit
     testImplementation rootProject.mockito
+    testImplementation rootProject.powermockJunit
+    testImplementation (rootProject.powermockMockio) {
+        exclude group: 'org.mockito'
+    }
+
     androidTestImplementation rootProject.junit
     androidTestImplementation rootProject.testRunner
 }

--- a/core/src/main/java/in/testpress/core/TestpressUserDetails.java
+++ b/core/src/main/java/in/testpress/core/TestpressUserDetails.java
@@ -29,14 +29,15 @@ public class TestpressUserDetails {
         this.profileDetails = profileDetails;
     }
 
-    public void load(Context context, TestpressCallback<ProfileDetails> testpressCallback) {
+    public RetrofitCall<ProfileDetails> load(Context context,
+                                             TestpressCallback<ProfileDetails> testpressCallback) {
         callBack = testpressCallback;
-        load(context);
+        return load(context);
     }
 
-    public void load(Context context) {
+    public RetrofitCall<ProfileDetails> load(Context context) {
         if (!TestpressSdk.hasActiveSession(context)) {
-            return;
+            return retrofitCall;
         }
         if (retrofitCall != null) {
             retrofitCall.cancel();
@@ -59,6 +60,7 @@ public class TestpressUserDetails {
                         }
                     }
                 });
+        return retrofitCall;
     }
 
 }

--- a/core/src/main/java/in/testpress/ui/BaseToolBarActivity.java
+++ b/core/src/main/java/in/testpress/ui/BaseToolBarActivity.java
@@ -10,6 +10,8 @@ import android.view.MenuItem;
 import in.testpress.R;
 import in.testpress.core.TestpressSdk;
 import in.testpress.core.TestpressSession;
+import in.testpress.network.RetrofitCall;
+import in.testpress.util.CommonUtils;
 
 import static android.view.WindowManager.LayoutParams.FLAG_SECURE;
 import static in.testpress.core.TestpressSdk.ACTION_PRESSED_HOME;
@@ -90,6 +92,16 @@ public abstract class BaseToolBarActivity extends AppCompatActivity {
         Bundle bundle = new Bundle();
         bundle.putBoolean(ACTION_PRESSED_HOME, true);
         return bundle;
+    }
+
+    public RetrofitCall[] getRetrofitCalls() {
+        return new RetrofitCall[] {};
+    }
+
+    @Override
+    protected void onStop() {
+        CommonUtils.cancelAPIRequests(getRetrofitCalls());
+        super.onStop();
     }
 
 }

--- a/core/src/test/java/in/testpress/ui/BaseToolBarActivityTest.java
+++ b/core/src/test/java/in/testpress/ui/BaseToolBarActivityTest.java
@@ -1,0 +1,60 @@
+package in.testpress.ui;
+
+import android.support.v7.app.AppCompatActivity;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import in.testpress.network.RetrofitCall;
+import in.testpress.util.CommonUtils;
+
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.powermock.api.mockito.PowerMockito.doCallRealMethod;
+import static org.powermock.api.mockito.PowerMockito.doNothing;
+import static org.powermock.api.mockito.PowerMockito.when;
+import static org.powermock.api.support.membermodification.MemberMatcher.methodsDeclaredIn;
+
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ BaseToolBarActivity.class, CommonUtils.class })
+public class BaseToolBarActivityTest {
+
+    @Mock
+    private RetrofitCall retrofitCall;
+
+    @Test
+    public void test_onStop_cancelAPIRequests_isCalled() {
+        PowerMockito.suppress(methodsDeclaredIn(AppCompatActivity.class));
+        BaseToolBarActivity activity = mock(BaseToolBarActivity.class);
+
+        RetrofitCall[] retrofitCalls = new RetrofitCall[] { retrofitCall };
+
+        when(activity.getRetrofitCalls()).thenReturn(retrofitCalls);
+
+        doCallRealMethod().when(activity).onStop();
+        activity.onStop();
+
+        verify(activity, times(1)).getRetrofitCalls();
+        verify(retrofitCall, times(1)).cancel();
+
+        PowerMockito.mockStatic(CommonUtils.class);
+        try {
+            doNothing().when(CommonUtils.class, "cancelAPIRequests", (Object) retrofitCalls);
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail();
+        }
+
+        activity.onStop();
+
+        PowerMockito.verifyStatic(times(1));
+        CommonUtils.cancelAPIRequests(retrofitCalls);
+    }
+}

--- a/course/src/main/java/in/testpress/course/ui/ContentActivity.java
+++ b/course/src/main/java/in/testpress/course/ui/ContentActivity.java
@@ -153,6 +153,12 @@ public class ContentActivity extends BaseToolBarActivity {
     private RetrofitCall<CourseAttempt> createAttemptApiRequest;
     private RetrofitCall<Content> updateContentApiRequest;
     private RetrofitCall<ProfileDetails> profileDetailApiRequest;
+    private RetrofitCall<TestpressApiResponse<CourseAttempt>> attemptsApiRequest;
+    private RetrofitCall<TestpressApiResponse<Language>> languagesApiRequest;
+    private RetrofitCall<ApiResponse<FolderListResponse>> bookmarkFoldersApiRequest;
+    private RetrofitCall<Bookmark> bookmarkApiRequest;
+    private RetrofitCall<Void> deleteBookmarkApiRequest;
+    private RetrofitCall<HtmlContent> htmlContentApiRequest;
 
     public static Intent createIntent(int position, long chapterId, AppCompatActivity activity) {
         Intent intent = new Intent(activity, ContentActivity.class);
@@ -381,7 +387,7 @@ public class ContentActivity extends BaseToolBarActivity {
 
     private void loadContentHtmlFromServer() {
         showLoadingProgress();
-        courseApiClient.getHtmlContent(content.getHtmlContentUrl())
+        htmlContentApiRequest = courseApiClient.getHtmlContent(content.getHtmlContentUrl())
                 .enqueue(new TestpressCallback<HtmlContent>() {
                     @Override
                     public void onSuccess(HtmlContent htmlContent) {
@@ -587,7 +593,7 @@ public class ContentActivity extends BaseToolBarActivity {
         } else {
             showLoadingProgress();
         }
-        examApiClient.getContentAttempts(attemptsUrl)
+        attemptsApiRequest = examApiClient.getContentAttempts(attemptsUrl)
                 .enqueue(new TestpressCallback<TestpressApiResponse<CourseAttempt>>() {
                     @Override
                     public void onSuccess(TestpressApiResponse<CourseAttempt> response) {
@@ -612,7 +618,7 @@ public class ContentActivity extends BaseToolBarActivity {
 
     void fetchLanguages(final CourseAttempt pausedCourseAttempt) {
         showLoadingProgress();
-        examApiClient.getLanguages(content.getRawExam().getSlug())
+        languagesApiRequest = examApiClient.getLanguages(content.getRawExam().getSlug())
                 .enqueue(new TestpressCallback<TestpressApiResponse<Language>>() {
                     @Override
                     public void onSuccess(TestpressApiResponse<Language> apiResponse) {
@@ -870,7 +876,7 @@ public class ContentActivity extends BaseToolBarActivity {
 
     void loadBookmarkFolders(String url) {
         setBookmarkProgress(true);
-        examApiClient.getBookmarkFolders(url)
+        bookmarkFoldersApiRequest = examApiClient.getBookmarkFolders(url)
                 .enqueue(new TestpressCallback<ApiResponse<FolderListResponse>>() {
                     @Override
                     public void onSuccess(ApiResponse<FolderListResponse> apiResponse) {
@@ -894,7 +900,7 @@ public class ContentActivity extends BaseToolBarActivity {
 
     void bookmark(String folder) {
         setBookmarkProgress(true);
-        examApiClient.bookmark(content.getId(), folder, "chaptercontent", "courses")
+        bookmarkApiRequest = examApiClient.bookmark(content.getId(), folder, "chaptercontent", "courses")
                 .enqueue(new TestpressCallback<Bookmark>() {
                     @Override
                     public void onSuccess(Bookmark bookmark) {
@@ -915,7 +921,7 @@ public class ContentActivity extends BaseToolBarActivity {
 
     void deleteBookmark(Long bookmarkId) {
         setBookmarkProgress(true);
-        examApiClient.deleteBookmark(bookmarkId)
+        deleteBookmarkApiRequest = examApiClient.deleteBookmark(bookmarkId)
                 .enqueue(new TestpressCallback<Void>() {
                     @Override
                     public void onSuccess(Void data) {
@@ -1146,11 +1152,12 @@ public class ContentActivity extends BaseToolBarActivity {
     }
 
     @Override
-    protected void onDestroy() {
-        CommonUtils.cancelAPIRequests(new RetrofitCall[] {
-                createAttemptApiRequest, updateContentApiRequest, profileDetailApiRequest
-        });
-        super.onDestroy();
+    public RetrofitCall[] getRetrofitCalls() {
+        return new RetrofitCall[] {
+                createAttemptApiRequest, updateContentApiRequest, profileDetailApiRequest,
+                attemptsApiRequest, languagesApiRequest, bookmarkFoldersApiRequest,
+                bookmarkApiRequest, deleteBookmarkApiRequest, htmlContentApiRequest
+        };
     }
 
     @Override

--- a/course/src/test/java/in/testpress/course/ui/ContentActivityTest.java
+++ b/course/src/test/java/in/testpress/course/ui/ContentActivityTest.java
@@ -1,0 +1,23 @@
+package in.testpress.course.ui;
+
+import org.junit.Test;
+
+import in.testpress.network.RetrofitCall;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class ContentActivityTest {
+
+    private static final int NUMBER_OF_RETROFIT_CALLS = 9;
+
+    @Test
+    public void test_getRetrofitCalls_returnCorrectValues() {
+        ContentActivity activity = new ContentActivity();
+        RetrofitCall[] retrofitCalls = activity.getRetrofitCalls();
+        assertThat("Check number of RetrofitCalls returned is " + NUMBER_OF_RETROFIT_CALLS,
+                retrofitCalls.length,
+                is(NUMBER_OF_RETROFIT_CALLS));
+    }
+
+}


### PR DESCRIPTION
### Changes done
- Cancel async network loading on activity destroy.

### Reason for the changes
- To fix video playing after backpress due to incomplete network load.
