### PR TITLE
Cancel network loads on activity/fragment destroy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
   global:
     - ANDROID_API_LEVEL=27  # Compile SDK version
     - EMULATOR_API_LEVEL=19
-    - ANDROID_BUILD_TOOLS_VERSION=28.0.2
+    - ANDROID_BUILD_TOOLS_VERSION=28.0.3
     - ANDROID_ABI=armeabi-v7a
     - ANDROID_TAG=google_apis
     - ADB_INSTALL_TIMEOUT=20 # minutes (2 minutes by default)

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.0'
+        classpath 'com.android.tools.build:gradle:3.2.1'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
         classpath 'com.google.gms:google-services:3.2.0'
         // NOTE: Do not place your application dependencies here; they belong
@@ -31,7 +31,7 @@ ext {
     minSdkVersion = 16
     targetSdkVersion = 27
     minSdkVersionForUITest = 18
-    buildToolsVersion = '28.0.2'
+    buildToolsVersion = '28.0.3'
     supportLib = '27.1.1'
     exoPlayer = '2.8.2'
     powermock = '1.6.2'

--- a/core/src/main/java/in/testpress/ui/BaseFragment.java
+++ b/core/src/main/java/in/testpress/ui/BaseFragment.java
@@ -1,0 +1,20 @@
+package in.testpress.ui;
+
+import android.support.v4.app.Fragment;
+
+import in.testpress.network.RetrofitCall;
+import in.testpress.util.CommonUtils;
+
+public abstract class BaseFragment extends Fragment {
+
+    public RetrofitCall[] getRetrofitCalls() {
+        return new RetrofitCall[] {};
+    }
+
+    @Override
+    public void onDestroyView() {
+        CommonUtils.cancelAPIRequests(getRetrofitCalls());
+        super.onDestroyView();
+    }
+
+}

--- a/core/src/main/java/in/testpress/ui/BaseGridFragment.java
+++ b/core/src/main/java/in/testpress/ui/BaseGridFragment.java
@@ -205,6 +205,7 @@ public abstract class BaseGridFragment<E> extends Fragment
         if (!isUsable()) {
             return;
         }
+        getLoaderManager().destroyLoader(loader.getId());
         final TestpressException exception = getException(loader);
         if (exception != null) {
             this.exception = exception;
@@ -213,7 +214,6 @@ public abstract class BaseGridFragment<E> extends Fragment
                 showError(errorMessage);
             }
             showGrid();
-            getLoaderManager().destroyLoader(loader.getId());
             return;
         }
         this.exception = null;

--- a/core/src/main/java/in/testpress/ui/BaseListViewFragment.java
+++ b/core/src/main/java/in/testpress/ui/BaseListViewFragment.java
@@ -217,6 +217,7 @@ public abstract class BaseListViewFragment<E> extends Fragment
 
     public void onLoadFinished(final Loader<List<E>> loader, final List<E> items) {
         final TestpressException exception = getException(loader);
+        getLoaderManager().destroyLoader(loader.getId());
         if (exception != null) {
             this.exception = exception;
             int errorMessage = getErrorMessage(exception);
@@ -224,7 +225,6 @@ public abstract class BaseListViewFragment<E> extends Fragment
                 showError(errorMessage);
             }
             showList();
-            getLoaderManager().destroyLoader(loader.getId());
             return;
         }
         this.exception = null;

--- a/core/src/main/java/in/testpress/ui/BaseToolBarActivity.java
+++ b/core/src/main/java/in/testpress/ui/BaseToolBarActivity.java
@@ -99,9 +99,9 @@ public abstract class BaseToolBarActivity extends AppCompatActivity {
     }
 
     @Override
-    protected void onStop() {
+    protected void onDestroy() {
         CommonUtils.cancelAPIRequests(getRetrofitCalls());
-        super.onStop();
+        super.onDestroy();
     }
 
 }

--- a/core/src/main/java/in/testpress/util/CommonTestUtils.java
+++ b/core/src/main/java/in/testpress/util/CommonTestUtils.java
@@ -1,0 +1,30 @@
+package in.testpress.util;
+
+import junit.framework.Assert;
+
+import in.testpress.network.RetrofitCall;
+import in.testpress.ui.BaseFragment;
+import in.testpress.ui.BaseToolBarActivity;
+
+public class CommonTestUtils {
+
+    public static void testGetRetrofitCallsReturnCorrectValues(BaseToolBarActivity activity,
+                                                               int numberOfCalls) {
+
+        testGetRetrofitCallsReturnCorrectValues(activity.getRetrofitCalls(), numberOfCalls);
+    }
+
+    public static void testGetRetrofitCallsReturnCorrectValues(BaseFragment fragment,
+                                                               int numberOfCalls) {
+
+        testGetRetrofitCallsReturnCorrectValues(fragment.getRetrofitCalls(), numberOfCalls);
+    }
+
+    private static void testGetRetrofitCallsReturnCorrectValues(RetrofitCall[] retrofitCalls,
+                                                                int numberOfCalls) {
+
+        Assert.assertEquals("Check number of RetrofitCalls returned is " + numberOfCalls,
+                retrofitCalls.length,
+                numberOfCalls);
+    }
+}

--- a/core/src/test/java/in/testpress/ui/BaseFragmentTest.java
+++ b/core/src/test/java/in/testpress/ui/BaseFragmentTest.java
@@ -1,5 +1,6 @@
 package in.testpress.ui;
 
+import android.support.v4.app.Fragment;
 import android.support.v7.app.AppCompatActivity;
 
 import org.junit.Test;
@@ -23,25 +24,25 @@ import static org.powermock.api.support.membermodification.MemberMatcher.methods
 
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({ BaseToolBarActivity.class, CommonUtils.class })
-public class BaseToolBarActivityTest {
+@PrepareForTest({ BaseFragment.class, CommonUtils.class })
+public class BaseFragmentTest {
 
     @Mock
     private RetrofitCall retrofitCall;
 
     @Test
-    public void test_onStop_cancelAPIRequests_isCalled() {
-        PowerMockito.suppress(methodsDeclaredIn(AppCompatActivity.class));
-        BaseToolBarActivity activity = mock(BaseToolBarActivity.class);
+    public void testBaseFragment_onStop_cancelAPIRequests_isCalled() {
+        PowerMockito.suppress(methodsDeclaredIn(Fragment.class));
+        BaseFragment fragment = mock(BaseFragment.class);
 
         RetrofitCall[] retrofitCalls = new RetrofitCall[] { retrofitCall };
 
-        when(activity.getRetrofitCalls()).thenReturn(retrofitCalls);
+        when(fragment.getRetrofitCalls()).thenReturn(retrofitCalls);
 
-        doCallRealMethod().when(activity).onDestroy();
-        activity.onDestroy();
+        doCallRealMethod().when(fragment).onDestroyView();
+        fragment.onDestroyView();
 
-        verify(activity, times(1)).getRetrofitCalls();
+        verify(fragment, times(1)).getRetrofitCalls();
         verify(retrofitCall, times(1)).cancel();
 
         PowerMockito.mockStatic(CommonUtils.class);
@@ -52,7 +53,7 @@ public class BaseToolBarActivityTest {
             fail();
         }
 
-        activity.onDestroy();
+        fragment.onDestroyView();
 
         PowerMockito.verifyStatic(times(1));
         CommonUtils.cancelAPIRequests(retrofitCalls);

--- a/course/src/main/java/in/testpress/course/ui/ChapterDetailActivity.java
+++ b/course/src/main/java/in/testpress/course/ui/ChapterDetailActivity.java
@@ -26,6 +26,7 @@ import in.testpress.models.greendao.Chapter;
 import in.testpress.models.greendao.ChapterDao;
 import in.testpress.models.greendao.Course;
 import in.testpress.models.greendao.CourseDao;
+import in.testpress.network.RetrofitCall;
 import in.testpress.ui.BaseToolBarActivity;
 import in.testpress.util.UIUtils;
 
@@ -48,6 +49,8 @@ public class ChapterDetailActivity extends BaseToolBarActivity {
     private TextView emptyDescView;
     private ProgressBar progressBar;
     private Button retryButton;
+
+    private RetrofitCall<Chapter> chapterApiRequest;
 
     public static Intent createIntent(String title, String courseId, Context context) {
         Intent intent = new Intent(context, ChapterDetailActivity.class);
@@ -141,7 +144,7 @@ public class ChapterDetailActivity extends BaseToolBarActivity {
 
     void loadChapterFromServer(final String chapterUrl) {
         progressBar.setVisibility(View.VISIBLE);
-        new TestpressCourseApiClient(this).getChapter(chapterUrl)
+        chapterApiRequest = new TestpressCourseApiClient(this).getChapter(chapterUrl)
                 .enqueue(new TestpressCallback<Chapter>() {
                     @Override
                     public void onSuccess(Chapter chapter) {
@@ -238,4 +241,8 @@ public class ChapterDetailActivity extends BaseToolBarActivity {
         return data;
     }
 
+    @Override
+    public RetrofitCall[] getRetrofitCalls() {
+        return new RetrofitCall[] { chapterApiRequest };
+    }
 }

--- a/course/src/main/java/in/testpress/course/ui/LeaderboardFragment.java
+++ b/course/src/main/java/in/testpress/course/ui/LeaderboardFragment.java
@@ -3,7 +3,6 @@ package in.testpress.course.ui;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.design.widget.TabLayout;
-import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentActivity;
 import android.support.v4.view.ViewPager;
 import android.view.LayoutInflater;
@@ -23,11 +22,13 @@ import in.testpress.core.TestpressSdk;
 import in.testpress.course.R;
 import in.testpress.course.models.Reputation;
 import in.testpress.course.network.TestpressCourseApiClient;
+import in.testpress.network.RetrofitCall;
+import in.testpress.ui.BaseFragment;
 import in.testpress.util.UIUtils;
 
 import static in.testpress.course.ui.RankListFragment.PARAM_USER_REPUTATION;
 
-public class LeaderboardFragment extends Fragment {
+public class LeaderboardFragment extends BaseFragment {
 
     private LinearLayout carouselView;
     private ViewPager viewPager;
@@ -38,6 +39,8 @@ public class LeaderboardFragment extends Fragment {
     private TextView emptyDescView;
     private Button retryButton;
     private ProgressBar progressBar;
+
+    private RetrofitCall<Reputation> myReputationApiRequest;
 
     public static void show(FragmentActivity activity, int containerViewId) {
         activity.getSupportFragmentManager().beginTransaction()
@@ -81,7 +84,7 @@ public class LeaderboardFragment extends Fragment {
 
     void loadMyReputation() {
         progressBar.setVisibility(View.VISIBLE);
-        new TestpressCourseApiClient(getContext()).getMyRank()
+        myReputationApiRequest = new TestpressCourseApiClient(getContext()).getMyRank()
                 .enqueue(new TestpressCallback<Reputation>() {
                     @Override
                     public void onSuccess(Reputation reputation) {
@@ -128,4 +131,8 @@ public class LeaderboardFragment extends Fragment {
         emptyDescView.setText(description);
     }
 
+    @Override
+    public RetrofitCall[] getRetrofitCalls() {
+        return new RetrofitCall[] { myReputationApiRequest };
+    }
 }

--- a/course/src/main/java/in/testpress/course/ui/TargetThreadFragment.java
+++ b/course/src/main/java/in/testpress/course/ui/TargetThreadFragment.java
@@ -3,7 +3,6 @@ package in.testpress.course.ui;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.design.widget.Snackbar;
-import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentActivity;
 import android.support.v4.widget.SwipeRefreshLayout;
 import android.view.LayoutInflater;
@@ -25,11 +24,12 @@ import in.testpress.course.models.Reputation;
 import in.testpress.course.network.TestpressCourseApiClient;
 import in.testpress.models.TestpressApiResponse;
 import in.testpress.network.RetrofitCall;
+import in.testpress.ui.BaseFragment;
 import in.testpress.util.Assert;
 
 import static in.testpress.course.ui.RankListFragment.PARAM_USER_REPUTATION;
 
-public class TargetThreadFragment extends Fragment {
+public class TargetThreadFragment extends BaseFragment {
 
     private View emptyView;
     private TextView emptyTitleView;
@@ -202,13 +202,9 @@ public class TargetThreadFragment extends Fragment {
     }
 
     @Override
-    public void onDestroy() {
-        if (threadsLoader != null) {
-            threadsLoader.cancel();
-        }
-        if (targetsLoader != null) {
-            targetsLoader.cancel();
-        }
-        super.onDestroy();
+    public RetrofitCall[] getRetrofitCalls() {
+        return new RetrofitCall[] {
+                threadsLoader, targetsLoader
+        };
     }
 }

--- a/course/src/test/java/in/testpress/course/ui/ChapterDetailActivityTest.java
+++ b/course/src/test/java/in/testpress/course/ui/ChapterDetailActivityTest.java
@@ -1,0 +1,18 @@
+package in.testpress.course.ui;
+
+import org.junit.Test;
+
+import in.testpress.util.CommonTestUtils;
+
+public class ChapterDetailActivityTest {
+
+    private static final int NUMBER_OF_RETROFIT_CALLS = 1;
+
+    @Test
+    public void testChapterDetailActivity_getRetrofitCalls_returnCorrectValues() {
+        CommonTestUtils.testGetRetrofitCallsReturnCorrectValues(
+                new ChapterDetailActivity(),
+                NUMBER_OF_RETROFIT_CALLS
+        );
+    }
+}

--- a/course/src/test/java/in/testpress/course/ui/LeaderboardFragmentTest.java
+++ b/course/src/test/java/in/testpress/course/ui/LeaderboardFragmentTest.java
@@ -1,0 +1,19 @@
+package in.testpress.course.ui;
+
+import org.junit.Test;
+
+import in.testpress.exam.ui.BookmarksFragment;
+import in.testpress.util.CommonTestUtils;
+
+public class LeaderboardFragmentTest {
+
+    private static final int NUMBER_OF_RETROFIT_CALLS = 1;
+
+    @Test
+    public void testLeaderboardFragment_getRetrofitCalls_returnCorrectValues() {
+        CommonTestUtils.testGetRetrofitCallsReturnCorrectValues(
+                new LeaderboardFragment(),
+                NUMBER_OF_RETROFIT_CALLS
+        );
+    }
+}

--- a/course/src/test/java/in/testpress/course/ui/TargetThreadFragmentTest.java
+++ b/course/src/test/java/in/testpress/course/ui/TargetThreadFragmentTest.java
@@ -1,0 +1,18 @@
+package in.testpress.course.ui;
+
+import org.junit.Test;
+
+import in.testpress.util.CommonTestUtils;
+
+public class TargetThreadFragmentTest {
+
+    private static final int NUMBER_OF_RETROFIT_CALLS = 2;
+
+    @Test
+    public void testTargetThreadFragment_getRetrofitCalls_returnCorrectValues() {
+        CommonTestUtils.testGetRetrofitCallsReturnCorrectValues(
+                new TargetThreadFragment(),
+                NUMBER_OF_RETROFIT_CALLS
+        );
+    }
+}

--- a/exam/src/main/java/in/testpress/exam/ui/AccessCodeFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/AccessCodeFragment.java
@@ -3,7 +3,6 @@ package in.testpress.exam.ui;
 import android.app.ProgressDialog;
 import android.os.Bundle;
 import android.support.design.widget.Snackbar;
-import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentActivity;
 import android.view.KeyEvent;
 import android.view.LayoutInflater;
@@ -23,17 +22,20 @@ import in.testpress.exam.R;
 import in.testpress.exam.network.TestpressExamApiClient;
 import in.testpress.models.TestpressApiResponse;
 import in.testpress.models.greendao.Exam;
+import in.testpress.network.RetrofitCall;
+import in.testpress.ui.BaseFragment;
 import in.testpress.util.TextWatcherAdapter;
 import in.testpress.util.UIUtils;
 
 import static android.support.design.widget.Snackbar.LENGTH_SHORT;
 import static android.view.inputmethod.EditorInfo.IME_ACTION_DONE;
 
-public class AccessCodeFragment extends Fragment {
+public class AccessCodeFragment extends BaseFragment {
 
     private ProgressDialog progressDialog;
     private EditText accessCodeView;
     private View view;
+    private RetrofitCall<TestpressApiResponse<Exam>> examsApiRequest;
 
     public static void show(FragmentActivity activity, int containerViewId) {
         activity.getSupportFragmentManager().beginTransaction()
@@ -86,7 +88,7 @@ public class AccessCodeFragment extends Fragment {
         UIUtils.hideSoftKeyboard(getActivity());
         final String accessCode = accessCodeView.getText().toString().trim();
         Map<String, Object> queryParams = new HashMap<>();
-        new TestpressExamApiClient(getContext()).getExams(accessCode, queryParams)
+        examsApiRequest = new TestpressExamApiClient(getContext()).getExams(accessCode, queryParams)
                 .enqueue(new TestpressCallback<TestpressApiResponse<Exam>>() {
                     @Override
                     public void onSuccess(TestpressApiResponse<Exam> response) {
@@ -115,6 +117,11 @@ public class AccessCodeFragment extends Fragment {
                         }
                     }
                 });
+    }
+
+    @Override
+    public RetrofitCall[] getRetrofitCalls() {
+        return new RetrofitCall[] { examsApiRequest };
     }
 
 }

--- a/exam/src/main/java/in/testpress/exam/ui/AnalyticsFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/AnalyticsFragment.java
@@ -125,6 +125,7 @@ public class AnalyticsFragment extends Fragment
     public void onLoadFinished(final Loader<List<Subject>> loader, final List<Subject> items) {
         //noinspection ThrowableResultOfMethodCallIgnored
         TestpressException exception = ((ThrowableLoader<List<Subject>>) loader).clearException();
+        getLoaderManager().destroyLoader(loader.getId());
         if(exception != null) {
             if (exception.isNetworkError()) {
                 setEmptyText(R.string.testpress_network_error,

--- a/exam/src/main/java/in/testpress/exam/ui/AttemptsActivity.java
+++ b/exam/src/main/java/in/testpress/exam/ui/AttemptsActivity.java
@@ -36,6 +36,7 @@ import in.testpress.models.TestpressApiResponse;
 import in.testpress.models.greendao.Attempt;
 import in.testpress.models.greendao.Exam;
 import in.testpress.models.greendao.Language;
+import in.testpress.network.RetrofitCall;
 import in.testpress.ui.BaseToolBarActivity;
 import in.testpress.util.ThrowableLoader;
 import in.testpress.util.UIUtils;
@@ -66,6 +67,8 @@ public class AttemptsActivity extends BaseToolBarActivity
     private Exam exam;
     private List<Attempt> attempts = new ArrayList<>();
     private AttemptsPager pager;
+    private RetrofitCall<Exam> examApiRequest;
+    private RetrofitCall<TestpressApiResponse<Language>> languagesApiRequest;
 
     @SuppressWarnings({"ConstantConditions", "deprecation"})
     @SuppressLint({"SetJavaScriptEnabled", "AddJavascriptInterface", "DefaultLocale"})
@@ -214,7 +217,7 @@ public class AttemptsActivity extends BaseToolBarActivity
 
     void loadExam(final String examSlug) {
         progressBar.setVisibility(View.VISIBLE);
-        apiClient.getExam(examSlug)
+        examApiRequest = apiClient.getExam(examSlug)
                 .enqueue(new TestpressCallback<Exam>() {
                     @Override
                     public void onSuccess(Exam exam) {
@@ -239,7 +242,7 @@ public class AttemptsActivity extends BaseToolBarActivity
 
     void fetchLanguages() {
         progressBar.setVisibility(View.VISIBLE);
-        apiClient.getLanguages(exam.getSlug())
+        languagesApiRequest = apiClient.getLanguages(exam.getSlug())
                 .enqueue(new TestpressCallback<TestpressApiResponse<Language>>() {
                     @Override
                     public void onSuccess(TestpressApiResponse<Language> apiResponse) {
@@ -293,6 +296,7 @@ public class AttemptsActivity extends BaseToolBarActivity
     public void onLoadFinished(Loader<List<Attempt>> loader, List<Attempt> data) {
         //noinspection ThrowableResultOfMethodCallIgnored
         TestpressException exception = ((ThrowableLoader<List<Attempt>>) loader).clearException();
+        getSupportLoaderManager().destroyLoader(loader.getId());
         if(exception != null) {
             handleError(exception, R.string.testpress_error_loading_attempts);
             return;
@@ -405,6 +409,13 @@ public class AttemptsActivity extends BaseToolBarActivity
         } else {
             setEmptyText(errorMessage, R.string.testpress_some_thing_went_wrong_try_again);
         }
+    }
+
+    @Override
+    public RetrofitCall[] getRetrofitCalls() {
+        return new RetrofitCall[] {
+                examApiRequest, languagesApiRequest
+        };
     }
 
     @Override

--- a/exam/src/main/java/in/testpress/exam/ui/BookmarksActivity.java
+++ b/exam/src/main/java/in/testpress/exam/ui/BookmarksActivity.java
@@ -52,7 +52,6 @@ import in.testpress.network.RetrofitCall;
 import in.testpress.ui.BaseToolBarActivity;
 import in.testpress.ui.HeaderFooterListAdapter;
 import in.testpress.ui.view.ClosableSpinner;
-import in.testpress.util.CommonUtils;
 import in.testpress.util.SingleTypeAdapter;
 import in.testpress.util.ThrowableLoader;
 import in.testpress.util.UIUtils;
@@ -1007,12 +1006,11 @@ public class BookmarksActivity extends BaseToolBarActivity
     }
 
     @Override
-    protected void onStop() {
-        CommonUtils.cancelAPIRequests(new RetrofitCall[] {
+    public RetrofitCall[] getRetrofitCalls() {
+        return new RetrofitCall[] {
                 bookmarkFoldersLoader, updateFolderAPIRequest, deleteFolderAPIRequest,
                 undoBookmarkAPIRequest
-        });
-        super.onStop();
+        };
     }
 
     @Override

--- a/exam/src/main/java/in/testpress/exam/ui/BookmarksFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/BookmarksFragment.java
@@ -9,7 +9,6 @@ import android.support.annotation.DrawableRes;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.design.widget.Snackbar;
-import android.support.v4.app.Fragment;
 import android.support.v4.content.ContextCompat;
 import android.text.Html;
 import android.view.LayoutInflater;
@@ -51,8 +50,8 @@ import in.testpress.models.greendao.ReviewQuestion;
 import in.testpress.models.greendao.ReviewQuestionTranslation;
 import in.testpress.models.greendao.Video;
 import in.testpress.network.RetrofitCall;
+import in.testpress.ui.BaseFragment;
 import in.testpress.ui.view.ClosableSpinner;
-import in.testpress.util.CommonUtils;
 import in.testpress.util.FullScreenChromeClient;
 import in.testpress.util.UIUtils;
 import in.testpress.util.ViewUtils;
@@ -63,7 +62,7 @@ import in.testpress.v2_4.models.FolderListResponse;
 import static in.testpress.exam.network.TestpressExamApiClient.BOOKMARK_FOLDERS_PATH;
 import static in.testpress.models.greendao.BookmarkFolder.UNCATEGORIZED;
 
-public class BookmarksFragment extends Fragment {
+public class BookmarksFragment extends BaseFragment {
 
     static final String PARAM_BOOKMARK_ID = "position";
     static final String PARAM_SELECTED_LANGUAGE = "selectedLanguage";
@@ -721,13 +720,17 @@ public class BookmarksFragment extends Fragment {
     }
 
     @Override
+    public RetrofitCall[] getRetrofitCalls() {
+        return new RetrofitCall[] {
+                bookmarkFoldersLoader, updateBookmarkAPIRequest, deleteBookmarkAPIRequest
+        };
+    }
+
+    @Override
     public void onDestroyView() {
         if (commentsUtil != null) {
             commentsUtil.onDestroy();
         }
-        CommonUtils.cancelAPIRequests(new RetrofitCall[] {
-                bookmarkFoldersLoader, updateBookmarkAPIRequest, deleteBookmarkAPIRequest
-        });
         final ViewGroup viewGroup = (ViewGroup) webView.getParent();
         if (viewGroup != null) {
             // Remove webView from its parent before destroy to support below kitkat

--- a/exam/src/main/java/in/testpress/exam/ui/ReviewQuestionsActivity.java
+++ b/exam/src/main/java/in/testpress/exam/ui/ReviewQuestionsActivity.java
@@ -7,7 +7,6 @@ import android.database.Cursor;
 import android.os.Bundle;
 import android.support.annotation.StringRes;
 import android.support.v4.content.ContextCompat;
-import android.support.v4.view.MenuItemCompat;
 import android.support.v4.view.ViewPager;
 import android.support.v4.widget.SlidingPaneLayout;
 import android.view.Menu;
@@ -23,7 +22,6 @@ import android.widget.TextView;
 import junit.framework.Assert;
 
 import org.greenrobot.greendao.query.QueryBuilder;
-import org.greenrobot.greendao.query.WhereCondition;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -111,6 +109,7 @@ public class ReviewQuestionsActivity extends BaseToolBarActivity {
     protected Boolean spinnerDefaultCallback = true;
     protected int selectedItemPosition = -1;
     private RetrofitCall<TestpressApiResponse<ReviewItem>> reviewItemsLoader;
+    private RetrofitCall<TestpressApiResponse<Language>> languageApiRequest;
     private TestpressExamApiClient apiClient;
     private Menu optionsMenu;
 
@@ -454,7 +453,7 @@ public class ReviewQuestionsActivity extends BaseToolBarActivity {
 
     void fetchLanguages() {
         progressBar.setVisibility(View.VISIBLE);
-        apiClient.getLanguages(exam.getSlug())
+        languageApiRequest = apiClient.getLanguages(exam.getSlug())
                 .enqueue(new TestpressCallback<TestpressApiResponse<Language>>() {
                     @Override
                     public void onSuccess(TestpressApiResponse<Language> apiResponse) {
@@ -723,10 +722,10 @@ public class ReviewQuestionsActivity extends BaseToolBarActivity {
     }
 
     @Override
-    protected void onDestroy() {
-        if (reviewItemsLoader != null) {
-            reviewItemsLoader.cancel();
-        }
-        super.onDestroy();
+    public RetrofitCall[] getRetrofitCalls() {
+        return new RetrofitCall[] {
+                reviewItemsLoader, languageApiRequest
+        };
     }
+
 }

--- a/exam/src/main/java/in/testpress/exam/ui/ReviewStatsFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/ReviewStatsFragment.java
@@ -3,16 +3,9 @@ package in.testpress.exam.ui;
 import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.Intent;
-import android.graphics.PorterDuff;
-import android.graphics.drawable.Drawable;
 import android.os.Bundle;
-import android.support.annotation.ColorInt;
 import android.support.annotation.Nullable;
-import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentActivity;
-import android.support.v4.graphics.drawable.DrawableCompat;
-import android.support.v7.widget.Toolbar;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -37,6 +30,8 @@ import in.testpress.models.TestpressApiResponse;
 import in.testpress.models.greendao.Attempt;
 import in.testpress.models.greendao.CourseAttempt;
 import in.testpress.models.greendao.Exam;
+import in.testpress.network.RetrofitCall;
+import in.testpress.ui.BaseFragment;
 import in.testpress.util.UIUtils;
 import in.testpress.util.ViewUtils;
 
@@ -46,7 +41,7 @@ import static in.testpress.exam.ui.ReviewStatsActivity.PARAM_COURSE_ATTEMPT;
 import static in.testpress.exam.ui.ReviewStatsActivity.PARAM_EXAM;
 import static in.testpress.exam.ui.ReviewStatsActivity.PARAM_PREVIOUS_ACTIVITY;
 
-public class ReviewStatsFragment extends Fragment {
+public class ReviewStatsFragment extends BaseFragment {
 
     static final String PARAM_SHOW_RETAKE_BUTTON = "showRetakeButton";
 
@@ -86,6 +81,7 @@ public class ReviewStatsFragment extends Fragment {
     private Button timeAnalyticsButton;
     private Attempt attempt;
     private Exam exam;
+    private RetrofitCall<TestpressApiResponse<Attempt>> attemptsApiRequest;
 
     public static void showReviewStatsFragment(FragmentActivity activity, Exam exam, Attempt attempt,
                                                boolean showRetakeButton) {
@@ -306,8 +302,8 @@ public class ReviewStatsFragment extends Fragment {
     }
 
     private void loadAttempt() {
-        new TestpressExamApiClient(getActivity()).getAttempts(exam.getAttemptsUrl(),
-                new HashMap<String, Object>())
+        attemptsApiRequest = new TestpressExamApiClient(getActivity())
+                .getAttempts(exam.getAttemptsUrl(), new HashMap<String, Object>())
                 .enqueue(new TestpressCallback<TestpressApiResponse<Attempt>>() {
                     @Override
                     public void onSuccess(TestpressApiResponse<Attempt> response) {
@@ -367,6 +363,11 @@ public class ReviewStatsFragment extends Fragment {
             getActivity().setResult(resultCode);
             getActivity().finish();
         }
+    }
+
+    @Override
+    public RetrofitCall[] getRetrofitCalls() {
+        return new RetrofitCall[] { attemptsApiRequest };
     }
 
     protected void setEmptyText(final int title, final int description, int imageRes) {

--- a/exam/src/main/java/in/testpress/exam/ui/SearchFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/SearchFragment.java
@@ -236,6 +236,7 @@ public class SearchFragment extends Fragment implements AbsListView.OnScrollList
                 getListAdapter().removeFooter(loadingLayout);
             }
         }
+        getLoaderManager().destroyLoader(loader.getId());
         final TestpressException exception = getException(loader);
         if (exception != null) {
             if (!items.isEmpty()) {

--- a/exam/src/main/java/in/testpress/exam/ui/TimeAnalyticsActivity.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TimeAnalyticsActivity.java
@@ -52,6 +52,7 @@ import in.testpress.models.greendao.ReviewQuestionTranslation;
 import in.testpress.models.greendao.ReviewQuestionTranslationDao;
 import in.testpress.models.greendao.SelectedAnswer;
 import in.testpress.models.greendao.SelectedAnswerDao;
+import in.testpress.network.RetrofitCall;
 import in.testpress.ui.BaseToolBarActivity;
 import in.testpress.ui.ExploreSpinnerAdapter;
 import in.testpress.util.CommonUtils;
@@ -107,6 +108,7 @@ public class TimeAnalyticsActivity extends BaseToolBarActivity {
     private Button applyFilterButton;
     private Button clearFilterButton;
     private ImageView filterIcon;
+    private RetrofitCall<TestpressApiResponse<ReviewItem>> reviewItemsApiRequest;
 
     public static Intent createIntent(Activity activity, Exam exam, Attempt attempt) {
         Intent intent = new Intent(activity, TimeAnalyticsActivity.class);
@@ -470,7 +472,7 @@ public class TimeAnalyticsActivity extends BaseToolBarActivity {
     }
 
     private void loadReviewItemsFromServer(final ReviewAttempt reviewAttempt, final String url) {
-        new TestpressExamApiClient(this)
+        reviewItemsApiRequest = new TestpressExamApiClient(this)
                 .getReviewItems(url, new HashMap<String, Object>())
                 .enqueue(new TestpressCallback<TestpressApiResponse<ReviewItem>>() {
                     @Override
@@ -681,6 +683,11 @@ public class TimeAnalyticsActivity extends BaseToolBarActivity {
                 "</div>";
 
         return html;
+    }
+
+    @Override
+    public RetrofitCall[] getRetrofitCalls() {
+        return new RetrofitCall[] { reviewItemsApiRequest };
     }
 
     public class TimeAnalyticsListener {

--- a/exam/src/test/java/in/testpress/exam/ui/AccessCodeFragmentTest.java
+++ b/exam/src/test/java/in/testpress/exam/ui/AccessCodeFragmentTest.java
@@ -1,0 +1,18 @@
+package in.testpress.exam.ui;
+
+import org.junit.Test;
+
+import in.testpress.util.CommonTestUtils;
+
+public class AccessCodeFragmentTest {
+
+    private static final int NUMBER_OF_RETROFIT_CALLS = 1;
+
+    @Test
+    public void testAccessCodeFragment_getRetrofitCalls_returnCorrectValues() {
+        CommonTestUtils.testGetRetrofitCallsReturnCorrectValues(
+                new AccessCodeFragment(),
+                NUMBER_OF_RETROFIT_CALLS
+        );
+    }
+}

--- a/exam/src/test/java/in/testpress/exam/ui/AttemptActivityTest.java
+++ b/exam/src/test/java/in/testpress/exam/ui/AttemptActivityTest.java
@@ -1,0 +1,18 @@
+package in.testpress.exam.ui;
+
+import org.junit.Test;
+
+import in.testpress.util.CommonTestUtils;
+
+public class AttemptActivityTest {
+
+    private static final int NUMBER_OF_RETROFIT_CALLS = 2;
+
+    @Test
+    public void testAttemptActivity_getRetrofitCalls_returnCorrectValues() {
+        CommonTestUtils.testGetRetrofitCallsReturnCorrectValues(
+                new AttemptsActivity(),
+                NUMBER_OF_RETROFIT_CALLS
+        );
+    }
+}

--- a/exam/src/test/java/in/testpress/exam/ui/BookmarksActivityTest.java
+++ b/exam/src/test/java/in/testpress/exam/ui/BookmarksActivityTest.java
@@ -1,0 +1,18 @@
+package in.testpress.exam.ui;
+
+import org.junit.Test;
+
+import in.testpress.util.CommonTestUtils;
+
+public class BookmarksActivityTest {
+
+    private static final int NUMBER_OF_RETROFIT_CALLS = 4;
+
+    @Test
+    public void testBookmarksActivity_getRetrofitCalls_returnCorrectValues() {
+        CommonTestUtils.testGetRetrofitCallsReturnCorrectValues(
+                new BookmarksActivity(),
+                NUMBER_OF_RETROFIT_CALLS
+        );
+    }
+}

--- a/exam/src/test/java/in/testpress/exam/ui/BookmarksFragmentTest.java
+++ b/exam/src/test/java/in/testpress/exam/ui/BookmarksFragmentTest.java
@@ -1,0 +1,18 @@
+package in.testpress.exam.ui;
+
+import org.junit.Test;
+
+import in.testpress.util.CommonTestUtils;
+
+public class BookmarksFragmentTest {
+
+    private static final int NUMBER_OF_RETROFIT_CALLS = 3;
+
+    @Test
+    public void testBookmarksFragment_getRetrofitCalls_returnCorrectValues() {
+        CommonTestUtils.testGetRetrofitCallsReturnCorrectValues(
+                new BookmarksFragment(),
+                NUMBER_OF_RETROFIT_CALLS
+        );
+    }
+}

--- a/exam/src/test/java/in/testpress/exam/ui/ReviewQuestionsActivityTest.java
+++ b/exam/src/test/java/in/testpress/exam/ui/ReviewQuestionsActivityTest.java
@@ -1,0 +1,18 @@
+package in.testpress.exam.ui;
+
+import org.junit.Test;
+
+import in.testpress.util.CommonTestUtils;
+
+public class ReviewQuestionsActivityTest {
+
+    private static final int NUMBER_OF_RETROFIT_CALLS = 2;
+
+    @Test
+    public void testReviewQuestionsActivity_getRetrofitCalls_returnCorrectValues() {
+        CommonTestUtils.testGetRetrofitCallsReturnCorrectValues(
+                new ReviewQuestionsActivity(),
+                NUMBER_OF_RETROFIT_CALLS
+        );
+    }
+}

--- a/exam/src/test/java/in/testpress/exam/ui/ReviewStatsFragmentTest.java
+++ b/exam/src/test/java/in/testpress/exam/ui/ReviewStatsFragmentTest.java
@@ -1,0 +1,19 @@
+package in.testpress.exam.ui;
+
+import org.junit.Test;
+
+import in.testpress.util.CommonTestUtils;
+
+public class ReviewStatsFragmentTest {
+
+    private static final int NUMBER_OF_RETROFIT_CALLS = 1;
+
+    @Test
+    public void testReviewStatsFragment_getRetrofitCalls_returnCorrectValues() {
+        CommonTestUtils.testGetRetrofitCallsReturnCorrectValues(
+                new ReviewStatsFragment(),
+                NUMBER_OF_RETROFIT_CALLS
+        );
+    }
+
+}

--- a/exam/src/test/java/in/testpress/exam/ui/TimeAnalyticsActivityTest.java
+++ b/exam/src/test/java/in/testpress/exam/ui/TimeAnalyticsActivityTest.java
@@ -1,0 +1,18 @@
+package in.testpress.exam.ui;
+
+import org.junit.Test;
+
+import in.testpress.util.CommonTestUtils;
+
+public class TimeAnalyticsActivityTest {
+
+    private static final int NUMBER_OF_RETROFIT_CALLS = 1;
+
+    @Test
+    public void testTimeAnalyticsActivity_getRetrofitCalls_returnCorrectValues() {
+        CommonTestUtils.testGetRetrofitCallsReturnCorrectValues(
+                new TimeAnalyticsActivity(),
+                NUMBER_OF_RETROFIT_CALLS
+        );
+    }
+}


### PR DESCRIPTION
### Changes done
- Canceled network loads on activity/fragment destroy

### Reason for the changes
- There is no meaning on performing network load after activity/fragment destroy.
