### PR TITLE
Cancel network loads on TestActivity destroy & Support activity recreate

### DIFF
--- a/core/src/main/java/in/testpress/models/greendao/Attempt.java
+++ b/core/src/main/java/in/testpress/models/greendao/Attempt.java
@@ -62,7 +62,9 @@ public class Attempt implements android.os.Parcelable {
     private List<AttemptSection> sections;
 
     // KEEP FIELDS - put your custom fields here
+    public static final String NOT_STARTED = "Not Started";
     public static final String RUNNING = "Running";
+    public static final String COMPLETED = "Completed";
     // KEEP FIELDS END
 
     @Generated
@@ -438,6 +440,10 @@ public class Attempt implements android.os.Parcelable {
             return sections;
         }
         return getSections();
+    }
+
+    public void setSections(List<AttemptSection> sections) {
+        this.sections = sections;
     }
 
     public ReviewAttempt getReviewAttempt() {

--- a/core/src/main/java/in/testpress/ui/BaseFragment.java
+++ b/core/src/main/java/in/testpress/ui/BaseFragment.java
@@ -1,5 +1,6 @@
 package in.testpress.ui;
 
+import android.app.Dialog;
 import android.support.v4.app.Fragment;
 
 import in.testpress.network.RetrofitCall;
@@ -11,9 +12,14 @@ public abstract class BaseFragment extends Fragment {
         return new RetrofitCall[] {};
     }
 
+    public Dialog[] getDialogs() {
+        return new Dialog[] {};
+    }
+
     @Override
     public void onDestroyView() {
         CommonUtils.cancelAPIRequests(getRetrofitCalls());
+        CommonUtils.dismissDialogs(getDialogs());
         super.onDestroyView();
     }
 

--- a/core/src/main/java/in/testpress/util/CommonTestUtils.java
+++ b/core/src/main/java/in/testpress/util/CommonTestUtils.java
@@ -20,6 +20,14 @@ public class CommonTestUtils {
         testGetRetrofitCallsReturnCorrectValues(fragment.getRetrofitCalls(), numberOfCalls);
     }
 
+    public static void testGetDialogsReturnCorrectValues(BaseFragment fragment,
+                                                         int numberOfDialogs) {
+
+        Assert.assertEquals("Check number of Dialogs returned is " + numberOfDialogs,
+                fragment.getDialogs().length,
+                numberOfDialogs);
+    }
+
     private static void testGetRetrofitCallsReturnCorrectValues(RetrofitCall[] retrofitCalls,
                                                                 int numberOfCalls) {
 

--- a/core/src/main/java/in/testpress/util/CommonUtils.java
+++ b/core/src/main/java/in/testpress/util/CommonUtils.java
@@ -1,8 +1,11 @@
 package in.testpress.util;
 
+import android.app.AlertDialog;
+import android.app.Dialog;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.support.annotation.NonNull;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -64,6 +67,14 @@ public class CommonUtils {
         for (RetrofitCall retrofitCall : retrofitCalls) {
             if (retrofitCall != null) {
                 retrofitCall.cancel();
+            }
+        }
+    }
+
+    public static void dismissDialogs(@NonNull Dialog[] dialogs) {
+        for (Dialog dialog : dialogs) {
+            if (dialog != null && dialog.isShowing()) {
+                dialog.dismiss();
             }
         }
     }

--- a/core/src/test/java/in/testpress/ui/BaseFragmentTest.java
+++ b/core/src/test/java/in/testpress/ui/BaseFragmentTest.java
@@ -1,8 +1,9 @@
 package in.testpress.ui;
 
+import android.app.Dialog;
 import android.support.v4.app.Fragment;
-import android.support.v7.app.AppCompatActivity;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -13,49 +14,48 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import in.testpress.network.RetrofitCall;
 import in.testpress.util.CommonUtils;
 
-import static org.junit.Assert.fail;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.powermock.api.mockito.PowerMockito.doCallRealMethod;
-import static org.powermock.api.mockito.PowerMockito.doNothing;
 import static org.powermock.api.mockito.PowerMockito.when;
 import static org.powermock.api.support.membermodification.MemberMatcher.methodsDeclaredIn;
 
-
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({ BaseFragment.class, CommonUtils.class })
+@PrepareForTest({ CommonUtils.class })
 public class BaseFragmentTest {
 
-    @Mock
-    private RetrofitCall retrofitCall;
+    @Mock private BaseFragment fragment;
+
+    @Before
+    public void setUp() {
+        PowerMockito.suppress(methodsDeclaredIn(Fragment.class));
+        PowerMockito.mockStatic(CommonUtils.class);
+    }
 
     @Test
-    public void testBaseFragment_onStop_cancelAPIRequests_isCalled() {
-        PowerMockito.suppress(methodsDeclaredIn(Fragment.class));
-        BaseFragment fragment = mock(BaseFragment.class);
-
-        RetrofitCall[] retrofitCalls = new RetrofitCall[] { retrofitCall };
-
+    public void testBaseFragment_onDestroyView_cancelAPIRequests_isCalled() {
+        RetrofitCall[] retrofitCalls = new RetrofitCall[] {};
         when(fragment.getRetrofitCalls()).thenReturn(retrofitCalls);
 
         doCallRealMethod().when(fragment).onDestroyView();
         fragment.onDestroyView();
 
         verify(fragment, times(1)).getRetrofitCalls();
-        verify(retrofitCall, times(1)).cancel();
-
-        PowerMockito.mockStatic(CommonUtils.class);
-        try {
-            doNothing().when(CommonUtils.class, "cancelAPIRequests", (Object) retrofitCalls);
-        } catch (Exception e) {
-            e.printStackTrace();
-            fail();
-        }
-
-        fragment.onDestroyView();
-
         PowerMockito.verifyStatic(times(1));
         CommonUtils.cancelAPIRequests(retrofitCalls);
     }
+
+    @Test
+    public void testBaseFragment_onDestroyView_dismissDialogs_isCalled() {
+        Dialog[] dialogs = new Dialog[] {};
+        when(fragment.getDialogs()).thenReturn(dialogs);
+
+        doCallRealMethod().when(fragment).onDestroyView();
+        fragment.onDestroyView();
+
+        verify(fragment, times(1)).getDialogs();
+        PowerMockito.verifyStatic(times(1));
+        CommonUtils.dismissDialogs(dialogs);
+    }
+
 }

--- a/core/src/test/java/in/testpress/ui/BaseToolBarActivityTest.java
+++ b/core/src/test/java/in/testpress/ui/BaseToolBarActivityTest.java
@@ -23,7 +23,7 @@ import static org.powermock.api.support.membermodification.MemberMatcher.methods
 
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({ BaseToolBarActivity.class, CommonUtils.class })
+@PrepareForTest({ AppCompatActivity.class, CommonUtils.class })
 public class BaseToolBarActivityTest {
 
     @Mock

--- a/core/src/test/java/in/testpress/util/CommonUtilsTest.java
+++ b/core/src/test/java/in/testpress/util/CommonUtilsTest.java
@@ -1,0 +1,31 @@
+package in.testpress.util;
+
+import android.app.Dialog;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CommonUtilsTest {
+
+    @Mock
+    private Dialog dialog;
+
+    @Test
+    public void test_dismissDialogs_callingDialogDismiss() {
+        Dialog[] dialogs = new Dialog[] { dialog };
+
+        when(dialog.isShowing()).thenReturn(true);
+
+        CommonUtils.dismissDialogs(dialogs);
+
+        verify(dialog, times(1)).isShowing();
+        verify(dialog, times(1)).dismiss();
+    }
+}

--- a/exam/build.gradle
+++ b/exam/build.gradle
@@ -36,6 +36,11 @@ dependencies {
     api rootProject.lottie
     testImplementation rootProject.junit
     testImplementation rootProject.mockito
+    testImplementation rootProject.powermockJunit
+    testImplementation (rootProject.powermockMockio) {
+        exclude group: 'org.mockito'
+    }
+
     androidTestImplementation rootProject.junit
     androidTestImplementation rootProject.testRunner
     androidTestImplementation rootProject.espressoCore

--- a/exam/src/main/AndroidManifest.xml
+++ b/exam/src/main/AndroidManifest.xml
@@ -14,7 +14,7 @@
 
         <activity android:name=".ui.TestActivity"
             android:label="@string/testpress_start_exam"
-            android:theme="@style/TestpressTheme.NoToolBar"
+            android:theme="@style/TestpressTheme"
             android:configChanges="orientation|keyboard|screenSize" />
 
         <activity android:name=".ui.AccessCodeActivity"

--- a/exam/src/main/java/in/testpress/exam/models/AttemptItem.java
+++ b/exam/src/main/java/in/testpress/exam/models/AttemptItem.java
@@ -45,6 +45,8 @@ public class AttemptItem implements Parcelable {
         shortText = in.readString();
         currentShortText = in.readString();
         attemptSection = in.readParcelable(AttemptSection.class.getClassLoader());
+        in.readList(selectedAnswers, Integer.class.getClassLoader());
+        in.readList(savedAnswers, Integer.class.getClassLoader());
     }
 
     @Override
@@ -62,6 +64,8 @@ public class AttemptItem implements Parcelable {
         dest.writeString(shortText);
         dest.writeString(currentShortText);
         dest.writeParcelable(attemptSection, flags);
+        dest.writeList(selectedAnswers);
+        dest.writeList(savedAnswers);
     }
 
     @Override

--- a/exam/src/main/java/in/testpress/exam/models/Permission.java
+++ b/exam/src/main/java/in/testpress/exam/models/Permission.java
@@ -1,9 +1,40 @@
 package in.testpress.exam.models;
 
-public class Permission {
+import android.os.Parcel;
+import android.os.Parcelable;
+
+public class Permission implements Parcelable {
 
     private boolean hasPermission;
     private String nextRetakeTime;
+
+    protected Permission(Parcel in) {
+        hasPermission = in.readByte() != 0;
+        nextRetakeTime = in.readString();
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        dest.writeByte((byte) (hasPermission ? 1 : 0));
+        dest.writeString(nextRetakeTime);
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    public static final Creator<Permission> CREATOR = new Creator<Permission>() {
+        @Override
+        public Permission createFromParcel(Parcel in) {
+            return new Permission(in);
+        }
+
+        @Override
+        public Permission[] newArray(int size) {
+            return new Permission[size];
+        }
+    };
 
     public Boolean getHasPermission() {
         return hasPermission;

--- a/exam/src/main/res/values/strings.xml
+++ b/exam/src/main/res/values/strings.xml
@@ -39,6 +39,8 @@
     <string name="testpress_error_loading_categories">Loading categories failed</string>
     <string name="testpress_exam_not_available">Exam not available</string>
     <string name="testpress_exam_not_available_description">This is no longer available or not published yet.</string>
+    <string name="testpress_exam_paused">Exam is paused, click resume to continue</string>
+
 
     <string name="testpress_analytics">Analytics</string>
     <string name="testpress_error_loading_analytics">Loading analytics failed</string>

--- a/exam/src/main/res/values/styles.xml
+++ b/exam/src/main/res/values/styles.xml
@@ -86,10 +86,6 @@
         <item name="android:textSize">@dimen/testpress_text_size_xlarge</item>
     </style>
 
-    <style name="TestpressTheme.NoToolBar">
-        <item name="colorControlNormal">#808080</item>
-    </style>
-
     <style name="TestpressText">
         <item name="android:textSize">16sp</item>
         <item name="android:lineSpacingMultiplier">1.4</item>

--- a/exam/src/test/java/in/testpress/exam/ui/TestActivityTest.java
+++ b/exam/src/test/java/in/testpress/exam/ui/TestActivityTest.java
@@ -1,0 +1,124 @@
+package in.testpress.exam.ui;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import in.testpress.exam.models.Permission;
+import in.testpress.models.greendao.Attempt;
+import in.testpress.models.greendao.Content;
+import in.testpress.models.greendao.CourseAttempt;
+import in.testpress.models.greendao.Exam;
+import in.testpress.util.CommonTestUtils;
+
+import static in.testpress.exam.ui.TestActivity.PARAM_EXAM_SLUG;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class TestActivityTest {
+
+    private static final int NUMBER_OF_RETROFIT_CALLS = 4;
+
+    @Mock private TestActivity activity;
+    @Mock private Content content;
+    @Mock private CourseAttempt courseAttempt;
+
+    @Test
+    public void test_onDataInitialized_checkPermission_ifPermissionAndCourseAttemptIsNull() {
+        activity.courseContent = content;
+
+        doCallRealMethod().when(activity).onDataInitialized();
+        activity.onDataInitialized();
+
+        verify(activity, times(1)).checkPermission();
+    }
+
+    @Test
+    public void test_onDataInitialized_checkStartExamScreenState_ifPermissionIsNonNull() {
+        activity.courseContent = content;
+        activity.permission = mock(Permission.class);
+
+        doCallRealMethod().when(activity).onDataInitialized();
+        activity.onDataInitialized();
+
+        verify(content, times(1)).getRawExam();
+        verify(activity, times(1)).checkStartExamScreenState();
+    }
+
+    @Test
+    public void test_onDataInitialized_checkStartExamScreenState_ifCourseAttemptIsNonNull() {
+        activity.courseContent = content;
+        activity.courseAttempt = courseAttempt;
+
+        doCallRealMethod().when(activity).onDataInitialized();
+        activity.onDataInitialized();
+
+        verify(content, times(1)).getRawExam();
+        verify(activity, times(1)).checkStartExamScreenState();
+    }
+
+    @Test
+    public void test_onDataInitialized_courseAttemptUpdated_ifAttemptIsNonNull() {
+        activity.courseContent = content;
+        activity.courseAttempt = courseAttempt;
+        activity.attempt = mock(Attempt.class);
+
+        doCallRealMethod().when(activity).onDataInitialized();
+        activity.onDataInitialized();
+
+        verify(courseAttempt, times(1)).setAssessment(activity.attempt);
+    }
+
+    @Test
+    public void test_onDataInitialized_checkStartExamScreenState_ifContentIsNullAndExamIsNonNull() {
+        activity.exam = mock(Exam.class);
+
+        doCallRealMethod().when(activity).onDataInitialized();
+        activity.onDataInitialized();
+
+        verify(activity, times(1)).checkStartExamScreenState();
+    }
+
+    @Test
+    public void test_onDataInitialized_loadExam_ifContentAndExamIsNullAndSlugIsNonNull() {
+        TestActivity activity = mock(TestActivity.class, RETURNS_DEEP_STUBS);
+        String testUrl = "DummyUrl";
+        when(activity.getIntent().getStringExtra(PARAM_EXAM_SLUG)).thenReturn(testUrl);
+
+        doCallRealMethod().when(activity).onDataInitialized();
+        activity.onDataInitialized();
+
+        verify(activity, times(1)).loadExam(testUrl);
+    }
+
+    @Test
+    public void test_onDataInitialized_throwException_ifContentAndExamAndSlugIsNull() {
+        TestActivity activity = mock(TestActivity.class, RETURNS_DEEP_STUBS);
+        when(activity.getIntent().getStringExtra(PARAM_EXAM_SLUG)).thenReturn(null);
+
+        doCallRealMethod().when(activity).onDataInitialized();
+
+        try {
+            activity.onDataInitialized();
+            fail("PARAM_EXAM_SLUG must not be null or empty.");
+        } catch (IllegalArgumentException e) {
+            assertEquals("PARAM_EXAM_SLUG must not be null or empty.", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testTestActivity_getRetrofitCalls_returnCorrectValues() {
+        CommonTestUtils.testGetRetrofitCallsReturnCorrectValues(
+                new TestActivity(),
+                NUMBER_OF_RETROFIT_CALLS
+        );
+    }
+}

--- a/exam/src/test/java/in/testpress/exam/ui/TestFragmentTest.java
+++ b/exam/src/test/java/in/testpress/exam/ui/TestFragmentTest.java
@@ -1,0 +1,218 @@
+package in.testpress.exam.ui;
+
+import android.os.CountDownTimer;
+import android.support.v4.app.Fragment;
+import android.widget.Spinner;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.List;
+
+import in.testpress.exam.models.AttemptItem;
+import in.testpress.models.greendao.Attempt;
+import in.testpress.models.greendao.AttemptSection;
+import in.testpress.util.CommonTestUtils;
+
+import static in.testpress.models.greendao.Attempt.NOT_STARTED;
+import static in.testpress.models.greendao.Attempt.RUNNING;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.powermock.api.support.membermodification.MemberMatcher.methodsDeclaredIn;
+
+@RunWith(PowerMockRunner.class)
+public class TestFragmentTest {
+
+    private static final int NUMBER_OF_RETROFIT_CALLS = 6;
+    private static final int NUMBER_OF_DIALOGS = 5;
+
+    @Mock private Attempt attempt;
+    @Mock private TestFragment fragment;
+    @Mock private AttemptSection section;
+    @Mock private List<AttemptItem> attemptItemList;
+    @Mock private List<AttemptSection> sections;
+
+    private String attemptRemainingTime = "0:00:20";
+    private long attemptMillisRemaining = Long.parseLong(attemptRemainingTime.split(":")[2]);
+
+    @Before
+    public void setUp() {
+        fragment.millisRemaining = -1;
+        fragment.attempt = attempt;
+        fragment.sections = sections;
+        fragment.attemptItemList = attemptItemList;
+        when(attempt.getRemainingTime()).thenReturn(attemptRemainingTime);
+        when(fragment.formatMillisecond(attemptRemainingTime)).thenReturn(attemptMillisRemaining);
+        when(sections.get(0)).thenReturn(section);
+    }
+
+    @Test
+    public void test_startCountDownTimer_startsNewSection_ifSectionNotStarted() {
+        fragment.lockedSectionExam = true;
+        when(section.getState()).thenReturn(NOT_STARTED);
+
+        doCallRealMethod().when(fragment).startCountDownTimer();
+        fragment.startCountDownTimer();
+
+        verify(fragment, times(1)).startSection();
+    }
+
+    @Test
+    public void test_startCountDownTimer_startingTimer() {
+        when(fragment.attemptItemList.isEmpty()).thenReturn(false);
+
+        doCallRealMethod().when(fragment).startCountDownTimer();
+        fragment.startCountDownTimer();
+
+        assertThat("millisRemaining value needs to same as attempt remaining time",
+                fragment.millisRemaining,
+                is(attemptMillisRemaining));
+
+        verify(fragment, times(1)).startCountDownTimer(attemptMillisRemaining);
+    }
+
+    @Test
+    public void test_startCountDownTimer_callsTimeOver_ifRemainingTimeZero() {
+        String attemptRemainingTime = "0:00:00";
+        attemptMillisRemaining = 0;
+        when(attempt.getRemainingTime()).thenReturn(attemptRemainingTime);
+        when(fragment.formatMillisecond(attemptRemainingTime)).thenReturn(attemptMillisRemaining);
+
+        doCallRealMethod().when(fragment).startCountDownTimer();
+        fragment.startCountDownTimer();
+
+        assertThat("millisRemaining value needs to same as attempt remaining time",
+                fragment.millisRemaining,
+                is(attemptMillisRemaining));
+
+        verify(fragment, times(1)).onRemainingTimeOver();
+    }
+
+    @Test
+    public void test_startCountDownTimer_usesSectionRemainingTime_forLockedSectionExam() {
+        fragment.lockedSectionExam = true;
+        String sectionRemainingTime = "0:00:10";
+        long sectionMillisRemaining = Long.parseLong(sectionRemainingTime.split(":")[2]);
+        when(section.getRemainingTime()).thenReturn(sectionRemainingTime);
+        when(fragment.formatMillisecond(sectionRemainingTime)).thenReturn(sectionMillisRemaining);
+        when(section.getState()).thenReturn(RUNNING);
+
+        when(fragment.attemptItemList.isEmpty()).thenReturn(false);
+
+        doCallRealMethod().when(fragment).startCountDownTimer();
+        fragment.startCountDownTimer();
+
+        assertThat("millisRemaining value needs to same as section remaining time",
+                fragment.millisRemaining,
+                is(sectionMillisRemaining));
+
+        verify(fragment, times(1)).startCountDownTimer(sectionMillisRemaining);
+    }
+
+    @Test
+    public void test_onSectionEnded_endExam_ifReachedLastSection() {
+        int currentSectionPosition = 2;
+        fragment.currentSection = currentSectionPosition;
+        when(sections.size()).thenReturn(currentSectionPosition + 1);
+
+        doCallRealMethod().when(fragment).onSectionEnded();
+        fragment.onSectionEnded();
+
+        verify(fragment, times(1)).endExam();
+    }
+
+    @Test
+    public void test_onSectionEnded_startSection_ifNextSectionAvailable() {
+        int currentSectionPosition = 2;
+        fragment.currentSection = currentSectionPosition;
+        when(sections.size()).thenReturn(currentSectionPosition + 2);
+
+        fragment.primaryQuestionsFilter = mock(Spinner.class);
+        fragment.sectionSpinnerAdapter = mock(LockableSpinnerItemAdapter.class);
+
+        doCallRealMethod().when(fragment).onSectionEnded();
+        fragment.onSectionEnded();
+
+        verify(fragment, times(1)).startSection();
+    }
+
+    @Test
+    public void test_formatMillisecond_returnZero_ifRemainingTimeNull() {
+        doCallRealMethod().when(fragment).formatMillisecond(null);
+
+        long millisRemaining = fragment.formatMillisecond(null);
+
+        assertThat("millisRemaining value needs to be 0",
+                millisRemaining,
+                is((long) 0));
+    }
+
+    @Test
+    public void test_onRemainingTimeOver_endSection_ifLockedSectionExam() {
+        fragment.lockedSectionExam = true;
+
+        doCallRealMethod().when(fragment).onRemainingTimeOver();
+        fragment.onRemainingTimeOver();
+
+        verify(fragment, times(1)).endSection();
+    }
+
+    @Test
+    public void test_onRemainingTimeOver_endExam() {
+        doCallRealMethod().when(fragment).onRemainingTimeOver();
+        fragment.onRemainingTimeOver();
+
+        verify(fragment, times(1)).endExam();
+    }
+
+    @Test
+    public void test_stopTimer_cancel_countDownTimer() {
+        CountDownTimer countDownTimer = mock(CountDownTimer.class);
+        fragment.countDownTimer = countDownTimer;
+
+        doCallRealMethod().when(fragment).stopTimer();
+        fragment.stopTimer();
+
+        verify(countDownTimer, times(1)).cancel();
+        assertThat("countDownTimer must needs to be null.",
+                fragment.countDownTimer,
+                is(nullValue()));
+    }
+
+    @Test
+    public void testTestFragment_getRetrofitCalls_returnCorrectValues() {
+        CommonTestUtils.testGetRetrofitCallsReturnCorrectValues(
+                new TestFragment(),
+                NUMBER_OF_RETROFIT_CALLS
+        );
+    }
+
+    @Test
+    public void testTestFragment_getDialogs_returnCorrectValues() {
+        CommonTestUtils.testGetDialogsReturnCorrectValues(
+                new TestFragment(),
+                NUMBER_OF_DIALOGS
+        );
+    }
+
+    @Test
+    public void test_onDestroy_stopTasks() {
+        PowerMockito.suppress(methodsDeclaredIn(Fragment.class));
+
+        doCallRealMethod().when(fragment).onDestroy();
+        fragment.onDestroy();
+
+        verify(fragment, times(1)).stopTimer();
+        verify(fragment, times(1)).removeAppBackgroundHandler();
+    }
+}


### PR DESCRIPTION
### Changes done
- Canceled network loads on `TestActivity` & `TestFragment` destroy.
- If an app was moved to background during attempting a test, returning to the app was not resuming. It was taking it to start exam screen. This is now fixed.
- Paused timer after 1 minute of the app went background(To handle user expected behaviour) and Shown "Exam paused click resume to continue" dialog to call start attempt API to update heartbeat on the server.

### Reason for the changes
- Performing network load after destroy is unnecessary.