### PR TITLE
Change custom field HTML_TYPE value to 'Notes'

### DIFF
--- a/core/src/main/java/in/testpress/models/greendao/Content.java
+++ b/core/src/main/java/in/testpress/models/greendao/Content.java
@@ -92,7 +92,7 @@ public class Content implements android.os.Parcelable {
     public static final String EXAM_TYPE = "Exam";
     public static final String VIDEO_TYPE = "Video";
     public static final String ATTACHMENT_TYPE = "Attachment";
-    public static final String HTML_TYPE = "Html";
+    public static final String HTML_TYPE = "Notes";
     // KEEP FIELDS END
 
     @Generated


### PR DESCRIPTION
### Changes done
- Changed custom field HTML_TYPE value to 'Notes' from 'Html'

### Reason for the changes
- There was a mismatch in content type due to which notes were not getting loaded.
