### PR TITLE
Make exam analytics to appear on the basis of institute settings.

### DIFF
--- a/core/src/main/java/in/testpress/models/InstituteSettings.java
+++ b/core/src/main/java/in/testpress/models/InstituteSettings.java
@@ -13,6 +13,7 @@ public class InstituteSettings {
     private boolean bookmarksEnabled;
     private boolean displayUserEmailOnVideo;
     private Boolean questionShareDisabled;
+    private Boolean disableStudentAnalytics;
 
     public InstituteSettings(String baseUrl) {
         setBaseUrl(baseUrl);
@@ -84,6 +85,14 @@ public class InstituteSettings {
 
     public boolean isDisplayUserEmailOnVideo() {
         return displayUserEmailOnVideo;
+    }
+
+    public boolean getDisableStudentAnalytics() {
+        return disableStudentAnalytics;
+    }
+
+    public void setDisableStudentAnalytics(boolean disableStudentAnalytics) {
+        this.disableStudentAnalytics = disableStudentAnalytics;
     }
 
     public boolean isQuestionShareDisabled() {

--- a/exam/src/androidTest/java/in/testpress/exam/ui/ReviewStatsActivityTest.java
+++ b/exam/src/androidTest/java/in/testpress/exam/ui/ReviewStatsActivityTest.java
@@ -46,6 +46,7 @@ public class ReviewStatsActivityTest extends ActivityTestRule<ReviewStatsActivit
                     super.beforeActivityLaunched();
                     InstituteSettings instituteSettings =
                             new InstituteSettings("http://sandbox.testpress.in");
+                    instituteSettings.setDisableStudentAnalytics(false);
 
                     TestpressSdk.setTestpressSession(InstrumentationRegistry.getTargetContext(),
                             new TestpressSession(instituteSettings, USER_TOKEN));

--- a/exam/src/main/java/in/testpress/exam/ui/ReviewStatsFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/ReviewStatsFragment.java
@@ -81,6 +81,7 @@ public class ReviewStatsFragment extends BaseFragment {
     private Button timeAnalyticsButton;
     private Attempt attempt;
     private Exam exam;
+    private InstituteSettings instituteSettings;
     private RetrofitCall<TestpressApiResponse<Attempt>> attemptsApiRequest;
 
     public static void showReviewStatsFragment(FragmentActivity activity, Exam exam, Attempt attempt,
@@ -102,6 +103,7 @@ public class ReviewStatsFragment extends BaseFragment {
         super.onCreate(savedInstanceState);
         exam = getArguments().getParcelable(PARAM_EXAM);
         Assert.assertNotNull("PARAM_EXAM must not be null.", exam);
+        instituteSettings = getInstituteSettings();
         attempt = getArguments().getParcelable(PARAM_ATTEMPT);
         CourseAttempt courseAttempt = getArguments().getParcelable(PARAM_COURSE_ATTEMPT);
         if (courseAttempt != null) {
@@ -266,6 +268,11 @@ public class ReviewStatsFragment extends BaseFragment {
             analyticsButton.setVisibility(View.GONE);
             timeAnalyticsButtonLayout.setVisibility(View.GONE);
         }
+
+        if (instituteSettings.getDisableStudentAnalytics()) {
+            analyticsButton.setVisibility(View.GONE);
+        }
+
         if (exam.getAllowPdf()) {
             emailPdfButton.setOnClickListener(new View.OnClickListener() {
                 @Override
@@ -277,9 +284,6 @@ public class ReviewStatsFragment extends BaseFragment {
         } else {
             emailPdfButtonLayout.setVisibility(View.GONE);
         }
-        //noinspection ConstantConditions
-        InstituteSettings settings =
-                TestpressSdk.getTestpressSession(getContext()).getInstituteSettings();
 
         if (canAttemptExam() && getArguments().getBoolean(PARAM_SHOW_RETAKE_BUTTON, true)) {
             retakeButton.setOnClickListener(new View.OnClickListener() {
@@ -375,5 +379,12 @@ public class ReviewStatsFragment extends BaseFragment {
         emptyTitleView.setText(title);
         emptyDescView.setText(description);
         emptyViewImage.setImageResource(imageRes);
+    }
+
+    public InstituteSettings getInstituteSettings() {
+        //noinspection ConstantConditions
+        InstituteSettings settings =
+                TestpressSdk.getTestpressSession(getContext()).getInstituteSettings();
+        return settings;
     }
 }

--- a/exam/src/main/java/in/testpress/exam/ui/ReviewStatsFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/ReviewStatsFragment.java
@@ -265,7 +265,6 @@ public class ReviewStatsFragment extends BaseFragment {
             timeAnalyticsButtonLayout.setVisibility(View.GONE);
         } else {
             reviewQuestionsButton.setVisibility(View.GONE);
-            analyticsButton.setVisibility(View.GONE);
             timeAnalyticsButtonLayout.setVisibility(View.GONE);
         }
 

--- a/samples/src/main/java/in/testpress/samples/course/CourseSampleActivity.java
+++ b/samples/src/main/java/in/testpress/samples/course/CourseSampleActivity.java
@@ -111,6 +111,8 @@ public class CourseSampleActivity extends BaseToolBarActivity {
             }
             session.getInstituteSettings().setDisplayUserEmailOnVideo(true);
             session.getInstituteSettings().setScreenshotDisabled(false);
+            session.getInstituteSettings().setDisableStudentAnalytics(false);
+
             TestpressSdk.setTestpressSession(this, session);
             switch (clickedButtonId) {
                 case R.id.simple_course:


### PR DESCRIPTION
### Changes done
- Added isanalytics disabled field in institute settings.
- Made exam analytics visible on the basis of institute settings. 

### Reason for the changes
- Earlier on making analytics disabled from the server side, was not affecting the app side analytics visibility.
