### PR TITLE
Fix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,6 @@ before_script:
   - adb shell input keyevent 82 &
 
 
-before_install:
-  - yes | sdkmanager "platforms;android-27"
+#before_install:
+#  - yes | sdkmanager "platforms;android-27"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,8 +43,8 @@ android:
     # White list all the licenses.
     - '.+'
 
-#install:
-#  - echo yes | ${ANDROID_HOME}/tools/bin/sdkmanager "platforms;android-27"
+install:
+  - echo yes | ${ANDROID_HOME}/tools/bin/sdkmanager "platforms;android-27"
 
 
 # Emulator Management: Create, Start and Wait
@@ -55,6 +55,7 @@ before_script:
   - adb shell input keyevent 82 &
 
 #before_install:
-#  - echo yes | sdkmanager "build-tools;28.0.3"
+#  - echo yes | sdkmanager "build-tools;28.0.3"  # Fails , no such script
+#  - yes | sdkmanager "build-tools;28.0.3"   # Fails , no such script
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
     - ADB_INSTALL_TIMEOUT=20 # minutes (2 minutes by default)
 
 android:
- components:
+  components:
 #    # latest version of the tools
 #    - tools
 #    - platform-tools
@@ -37,14 +37,14 @@ android:
     # Emulator
     - sys-img-armeabi-v7a-google_apis-$EMULATOR_API_LEVEL
 
-licenses:
-  # White list all android-sdk-license revisions.
-  - 'android-sdk-license-.+'
-  # White list all the licenses.
-  - '.+'
+  licenses:
+    # White list all android-sdk-license revisions.
+    - 'android-sdk-license-.+'
+    # White list all the licenses.
+    - '.+'
 
-install:
-  - echo yes | ${ANDROID_HOME}/tools/bin/sdkmanager "platforms;android-27"
+#install:
+#  - echo yes | ${ANDROID_HOME}/tools/bin/sdkmanager "platforms;android-27"
 
 
 # Emulator Management: Create, Start and Wait
@@ -54,7 +54,7 @@ before_script:
   - android-wait-for-emulator
   - adb shell input keyevent 82 &
 
-before_install:
-  - echo yes | sdkmanager "build-tools;28.0.3"
+#before_install:
+#  - echo yes | sdkmanager "build-tools;28.0.3"
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,4 @@ before_script:
   - emulator -avd test -no-audio -no-window &
   - android-wait-for-emulator
   - adb shell input keyevent 82 &
-
-
-script:
-  - ./gradlew clean build connectedCheck -PdisablePreDex --stacktrace
+  - ./gradlew build connectedCheck

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: android
+install: travis_wait 30 mvn install
 jdk: oraclejdk8
 
 sudo: required
@@ -11,7 +12,7 @@ env:
     - ANDROID_BUILD_TOOLS_VERSION=28.0.3
     - ANDROID_ABI=armeabi-v7a
     - ANDROID_TAG=google_apis
-    - ADB_INSTALL_TIMEOUT=20 # minutes (2 minutes by default)
+    - ADB_INSTALL_TIMEOUT=30 # minutes (2 minutes by default)
 
 android:
  components:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ dist: precise
 env:
   global:
     - ANDROID_API_LEVEL=27  # Compile SDK version
-    - EMULATOR_API_LEVEL=24
+    - EMULATOR_API_LEVEL=21
     - ANDROID_BUILD_TOOLS_VERSION=28.0.3
     - ANDROID_ABI=armeabi-v7a
     - ANDROID_TAG=google_apis

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,5 +55,6 @@ before_script:
   - adb shell input keyevent 82 &
 
 before_install:
-  - yes | sdkmanager "platforms;android-28"
+  - echo yes | sdkmanager "build-tools;28.0.3"
+
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,8 +43,8 @@ android:
     # White list all the licenses.
     - '.+'
 
-install:
-  - echo yes | ${ANDROID_HOME}/tools/bin/sdkmanager "platforms;android-27"
+#install:
+#  - echo yes | ${ANDROID_HOME}/tools/bin/sdkmanager "platforms;android-27"
 
 
 # Emulator Management: Create, Start and Wait
@@ -55,7 +55,9 @@ before_script:
   - adb shell input keyevent 82 &
 
 #before_install:
+#  - yes | sdkmanager "platforms;android-28" # Fails , no such script
 #  - echo yes | sdkmanager "build-tools;28.0.3"  # Fails , no such script
 #  - yes | sdkmanager "build-tools;28.0.3"   # Fails , no such script
+  - yes | sdkmanager build-tools;28.0.3
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ dist: precise
 env:
   global:
     - ANDROID_API_LEVEL=27  # Compile SDK version
-    - EMULATOR_API_LEVEL=19
+    - EMULATOR_API_LEVEL=24
     - ANDROID_BUILD_TOOLS_VERSION=28.0.3
     - ANDROID_ABI=armeabi-v7a
     - ANDROID_TAG=google_apis
@@ -41,6 +41,6 @@ android:
 # Emulator Management: Create, Start and Wait
 before_script:
   - echo no | android create avd --force -n test -t "android-"$EMULATOR_API_LEVEL --abi $ANDROID_ABI --tag $ANDROID_TAG
-  - QEMU_AUDIO_DRV=none emulator -avd test -no-audio -no-window &
+  - emulator -avd test -no-audio -no-window &
   - android-wait-for-emulator
   - adb shell input keyevent 82 &

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ android:
   components:
 #    # latest version of the tools
     - tools
-#    - platform-tools
+    - platform-tools
 
     # build tools version
     - build-tools-$ANDROID_BUILD_TOOLS_VERSION

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,7 @@ before_script:
   - android-wait-for-emulator
   - adb shell input keyevent 82 &
 
+
 before_install:
   - yes | sdkmanager "platforms;android-27"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,10 @@ android:
     - sys-img-armeabi-v7a-google_apis-$EMULATOR_API_LEVEL
 
 licenses:
+  # White list all android-sdk-license revisions.
   - 'android-sdk-license-.+'
+  # White list all the licenses.
+  - '.+'
 
 # Emulator Management: Create, Start and Wait
 before_script:
@@ -48,6 +51,6 @@ before_script:
   - adb shell input keyevent 82 &
 
 
-before_install:
-  - yes | sdkmanager --licenses
+#before_install:
+#  - yes | sdkmanager --licenses
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,8 +37,8 @@ android:
     # Emulator
     - sys-img-armeabi-v7a-google_apis-$EMULATOR_API_LEVEL
 
-  licenses:
-      - 'android-sdk-license-.+'
+licenses:
+     - 'android-sdk-license-.+'
 
 # Emulator Management: Create, Start and Wait
 before_script:
@@ -48,6 +48,6 @@ before_script:
   - adb shell input keyevent 82 &
 
 
-#before_install:
-#  - yes | sdkmanager "platforms;android-27"
+before_install:
+  - yes | sdkmanager "platforms;android-27"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,6 @@ before_script:
 #  - yes | sdkmanager "platforms;android-28" # Fails , no such script
 #  - echo yes | sdkmanager "build-tools;28.0.3"  # Fails , no such script
 #  - yes | sdkmanager "build-tools;28.0.3"   # Fails , no such script
-  - yes | sdkmanager build-tools;28.0.3
+
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,6 @@ before_script:
   - adb shell input keyevent 82 &
 
 
-#before_install:
-#  - yes | sdkmanager "platforms;android-27"
+before_install:
+  - yes | sdkmanager "build-tools;28.0.3"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,6 @@ android:
   licenses:
       - 'android-sdk-license-.+'
 
-
 # Emulator Management: Create, Start and Wait
 before_script:
   - echo no | android create avd --force -n test -t "android-"$EMULATOR_API_LEVEL --abi $ANDROID_ABI --tag $ANDROID_TAG

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ dist: precise
 env:
   global:
     - ANDROID_API_LEVEL=27  # Compile SDK version
-    - EMULATOR_API_LEVEL=21
+    - EMULATOR_API_LEVEL=19
     - ANDROID_BUILD_TOOLS_VERSION=28.0.3
     - ANDROID_ABI=armeabi-v7a
     - ANDROID_TAG=google_apis
@@ -44,3 +44,7 @@ before_script:
   - emulator -avd test -no-audio -no-window &
   - android-wait-for-emulator
   - adb shell input keyevent 82 &
+
+
+script:
+  - ./gradlew clean build connectedCheck -PdisablePreDex --stacktrace

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,10 @@ licenses:
   # White list all the licenses.
   - '.+'
 
+install:
+  - echo yes | ${ANDROID_HOME}/tools/bin/sdkmanager "platforms;android-27"
+
+
 # Emulator Management: Create, Start and Wait
 before_script:
   - echo no | android create avd --force -n test -t "android-"$EMULATOR_API_LEVEL --abi $ANDROID_ABI --tag $ANDROID_TAG
@@ -50,7 +54,6 @@ before_script:
   - android-wait-for-emulator
   - adb shell input keyevent 82 &
 
-
-#before_install:
-#  - yes | sdkmanager --licenses
+before_install:
+  - yes | sdkmanager "platforms;android-28"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ android:
     - sys-img-armeabi-v7a-google_apis-$EMULATOR_API_LEVEL
 
 licenses:
-     - 'android-sdk-license-.+'
+  - 'android-sdk-license-.+'
 
 # Emulator Management: Create, Start and Wait
 before_script:
@@ -49,5 +49,5 @@ before_script:
 
 
 before_install:
-  - yes | sdkmanager "build-tools;28.0.3"
+  - yes | sdkmanager --licenses
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: android
-install: travis_wait 30 mvn install
 jdk: oraclejdk8
 
 sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
 android:
   components:
 #    # latest version of the tools
-#    - tools
+    - tools
 #    - platform-tools
 
     # build tools version

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,8 @@ env:
 
 android:
   components:
-#    # latest version of the tools
+    # latest version of the tools
     - tools
-    - platform-tools
 
     # build tools version
     - build-tools-$ANDROID_BUILD_TOOLS_VERSION
@@ -43,8 +42,6 @@ android:
     # White list all the licenses.
     - '.+'
 
-#install:
-#  - echo yes | ${ANDROID_HOME}/tools/bin/sdkmanager "platforms;android-27"
 
 
 # Emulator Management: Create, Start and Wait
@@ -53,11 +50,6 @@ before_script:
   - emulator -avd test -no-audio -no-window &
   - android-wait-for-emulator
   - adb shell input keyevent 82 &
-
-#before_install:
-#  - yes | sdkmanager "platforms;android-28" # Fails , no such script
-#  - echo yes | sdkmanager "build-tools;28.0.3"  # Fails , no such script
-#  - yes | sdkmanager "build-tools;28.0.3"   # Fails , no such script
 
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ android:
   components:
     # latest version of the tools
     - tools
+#    - platform-tools
 
     # build tools version
     - build-tools-$ANDROID_BUILD_TOOLS_VERSION
@@ -42,14 +43,9 @@ android:
     # White list all the licenses.
     - '.+'
 
-
-
 # Emulator Management: Create, Start and Wait
 before_script:
   - echo no | android create avd --force -n test -t "android-"$EMULATOR_API_LEVEL --abi $ANDROID_ABI --tag $ANDROID_TAG
   - emulator -avd test -no-audio -no-window &
   - android-wait-for-emulator
   - adb shell input keyevent 82 &
-
-
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,4 +44,3 @@ before_script:
   - emulator -avd test -no-audio -no-window &
   - android-wait-for-emulator
   - adb shell input keyevent 82 &
-  - ./gradlew build connectedCheck

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,3 +44,7 @@ before_script:
   - emulator -avd test -no-audio -no-window &
   - android-wait-for-emulator
   - adb shell input keyevent 82 &
+
+
+script:
+  - ./gradlew clean build connectedCheck -PdisablePreDex --stacktrace

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,6 @@ android:
 # Emulator Management: Create, Start and Wait
 before_script:
   - echo no | android create avd --force -n test -t "android-"$EMULATOR_API_LEVEL --abi $ANDROID_ABI --tag $ANDROID_TAG
-  - emulator -avd test -no-window &
+  - QEMU_AUDIO_DRV=none emulator -avd test -no-audio -no-window &
   - android-wait-for-emulator
   - adb shell input keyevent 82 &

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,9 @@ android:
     # Emulator
     - sys-img-armeabi-v7a-google_apis-$EMULATOR_API_LEVEL
 
+  licenses:
+      - 'android-sdk-license-.+'
+
 
 # Emulator Management: Create, Start and Wait
 before_script:
@@ -44,4 +47,7 @@ before_script:
   - emulator -avd test -no-audio -no-window &
   - android-wait-for-emulator
   - adb shell input keyevent 82 &
+
+before_install:
+  - yes | sdkmanager "platforms;android-27"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,9 @@ env:
 
 android:
  components:
-    # latest version of the tools
-    - tools
-    - platform-tools
+#    # latest version of the tools
+#    - tools
+#    - platform-tools
 
     # build tools version
     - build-tools-$ANDROID_BUILD_TOOLS_VERSION
@@ -45,6 +45,3 @@ before_script:
   - android-wait-for-emulator
   - adb shell input keyevent 82 &
 
-
-script:
-  - ./gradlew clean build connectedCheck -PdisablePreDex --stacktrace

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
     - ANDROID_BUILD_TOOLS_VERSION=28.0.3
     - ANDROID_ABI=armeabi-v7a
     - ANDROID_TAG=google_apis
-    - ADB_INSTALL_TIMEOUT=30 # minutes (2 minutes by default)
+    - ADB_INSTALL_TIMEOUT=20 # minutes (2 minutes by default)
 
 android:
  components:
@@ -41,6 +41,6 @@ android:
 # Emulator Management: Create, Start and Wait
 before_script:
   - echo no | android create avd --force -n test -t "android-"$EMULATOR_API_LEVEL --abi $ANDROID_ABI --tag $ANDROID_TAG
-  - emulator -avd test -no-audio -no-window &
+  - emulator -avd test -no-window &
   - android-wait-for-emulator
   - adb shell input keyevent 82 &


### PR DESCRIPTION
### Changes done
- Removed platform-tools from Travis file's components section. [Reference](https://stackoverflow.com/questions/35438941/travis-emulator-stop-after-android-wait-for-emulator/35485723#35485723)

### Reason for the changes
- Travis emulator is not starting and there some issue related to accepting the license.
