### PR TITLE
Add support to clear cookies for webview

### DIFF
--- a/course/build.gradle
+++ b/course/build.gradle
@@ -38,6 +38,8 @@ dependencies {
     testImplementation rootProject.junit
     testImplementation rootProject.mockito
     testImplementation rootProject.powermockJunit
+    testImplementation rootProject.roboelectric
+    testImplementation rootProject.androidxCore
     testImplementation (rootProject.powermockMockio) {
         exclude group: 'org.mockito'
     }

--- a/course/src/main/java/in/testpress/course/ui/WebViewActivity.java
+++ b/course/src/main/java/in/testpress/course/ui/WebViewActivity.java
@@ -3,6 +3,7 @@ package in.testpress.course.ui;
 import android.Manifest;
 import android.annotation.SuppressLint;
 import android.app.Activity;
+import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.content.res.Configuration;
@@ -18,6 +19,8 @@ import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
 import android.view.KeyEvent;
 import android.view.View;
+import android.webkit.CookieManager;
+import android.webkit.CookieSyncManager;
 import android.webkit.ValueCallback;
 import android.webkit.WebChromeClient;
 import android.webkit.WebSettings;
@@ -97,6 +100,7 @@ public class WebViewActivity extends BaseToolBarActivity {
         } else {
             finish();
         }
+        clearCookies(getApplicationContext());
 
         if (intent.hasExtra(ACTIVITY_TITLE) && intent.getExtras().getString(ACTIVITY_TITLE) != "") {
             getSupportActionBar().setTitle(intent.getExtras().getString(ACTIVITY_TITLE));
@@ -219,6 +223,23 @@ public class WebViewActivity extends BaseToolBarActivity {
 
     public void setUrl(String url) {
         this.url = url;
+    }
+
+    public static void clearCookies(Context context)
+    {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1) {
+            CookieManager.getInstance().removeAllCookies(null);
+            CookieManager.getInstance().flush();
+        } else
+        {
+            CookieSyncManager cookieSyncManager=CookieSyncManager.createInstance(context);
+            cookieSyncManager.startSync();
+            CookieManager cookieManager=CookieManager.getInstance();
+            cookieManager.removeAllCookie();
+            cookieManager.removeSessionCookie();
+            cookieSyncManager.stopSync();
+            cookieSyncManager.sync();
+        }
     }
 
     // Create an image file

--- a/course/src/test/java/in/testpress/course/ui/WebViewActivityTest.java
+++ b/course/src/test/java/in/testpress/course/ui/WebViewActivityTest.java
@@ -1,0 +1,26 @@
+package in.testpress.course.ui;
+
+import androidx.test.core.app.ApplicationProvider;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import android.webkit.CookieManager;
+
+import junit.framework.Assert;
+
+
+@RunWith(RobolectricTestRunner.class)
+public class WebViewActivityTest {
+
+    @Test
+    public void testClearCookies() {
+        CookieManager.getInstance().setCookie("http://example.com/", "key=value");
+        Assert.assertTrue(CookieManager.getInstance().hasCookies());
+        WebViewActivity.clearCookies(ApplicationProvider.getApplicationContext());
+
+        Assert.assertFalse(CookieManager.getInstance().hasCookies());
+    }
+
+}


### PR DESCRIPTION
### Changes done
- Add support to clear cookies for webview

### Reason for the changes
- Sometimes previous SSO session's cookies will be persisted

Fixes #98 

Testcases - 1