### PR TITLE
Display alert http status code 401

### DIFF
--- a/core/src/main/java/in/testpress/core/TestpressSdk.java
+++ b/core/src/main/java/in/testpress/core/TestpressSdk.java
@@ -77,13 +77,16 @@ public final class TestpressSdk {
     }
 
     public static void clearActiveSession(@NonNull Context context) {
-        new TestpressApiClient(context, TestpressSdk.getTestpressSession(context)).logout().enqueue(new TestpressCallback<Void>() {
-            @Override
-            public void onSuccess(Void result) {}
+        if (TestpressSdk.getTestpressSession(context) != null) {
+            new TestpressApiClient(context, TestpressSdk.getTestpressSession(context)).logout().enqueue(new TestpressCallback<Void>() {
+                @Override
+                public void onSuccess(Void result) {}
 
-            @Override
-            public void onException(TestpressException exception) {}
-        });
+                @Override
+                public void onException(TestpressException exception) {}
+            });
+        }
+
         SharedPreferences.Editor editor = getPreferenceEditor(context);
         editor.clear().commit();
     }

--- a/core/src/main/java/in/testpress/network/TestpressApiClient.java
+++ b/core/src/main/java/in/testpress/network/TestpressApiClient.java
@@ -137,10 +137,19 @@ public class TestpressApiClient {
                 final String rawJson = response.body().string();
 
                 if (response.code() >= 400 && response.code() <= 500) {
+                    Handler handler = new Handler(Looper.getMainLooper());
+                    if (response.code() == 401) {
+                        handler.post(new Runnable() {
+                            @Override
+                            public void run() {
+                                UIUtils.showAlert(context, "Session Cleared", context.getString(R.string.session_cleared_message));
+                            }
+                        });
+                    }
+
                     try {
                         JSONObject json = new JSONObject(rawJson);
                         String error_code = json.getString("error_code");
-                        Handler handler = new Handler(Looper.getMainLooper());
 
                         if (error_code.equals("parallel_login_restriction")) {
                             handler.post(new Runnable() {

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -40,5 +40,6 @@
     <string name="max_login_limit_exceeded_error">Your account has been locked as it has exceeded maximum devices it can be used.</string>
     <string name="account_unlock_info">Your account will automatically get unlocked within </string>
     <string name="no_devices_found">No devices found</string>
+    <string name="session_cleared_message">Your session has been cleared. Please log out and login again.</string>
 
 </resources>


### PR DESCRIPTION
- Displayed alert message that user should logout on HTTP status code 401.
- Since all API's will fail for HTTP code 401, it makes sense to inform user that he should logout.