### PR TITLE
Change info text in UserDevicesActivity

### DIFF
--- a/core/src/main/java/in/testpress/ui/UserDevicesActivity.java
+++ b/core/src/main/java/in/testpress/ui/UserDevicesActivity.java
@@ -71,11 +71,11 @@ public class UserDevicesActivity extends BaseToolBarActivity {
     public void setInfoText() {
         parallelLoginRestrictionInfo = (TextView) findViewById(R.id.parallel_login_restriction_note);
         TestpressSession session = TestpressSdk.getTestpressSession(this);
-        String info = "Note : Admin has restricted parallel logged in devices to %s";
+        String info = getString(R.string.lockout_limit_info);
 
-        if (session.getInstituteSettings().isParallelLoginRestrictionEnabled()) {
+        if (session.getInstituteSettings().getLockoutLimit() != null) {
             parallelLoginRestrictionInfo.setVisibility(View.VISIBLE);
-            parallelLoginRestrictionInfo.setText(String.format(info, session.getInstituteSettings().getMaxParallelLogins()));
+            parallelLoginRestrictionInfo.setText(String.format(info, session.getInstituteSettings().getLockoutLimit()));
         }
     }
 

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -41,5 +41,6 @@
     <string name="account_unlock_info">Your account will automatically get unlocked within </string>
     <string name="no_devices_found">No devices found</string>
     <string name="session_cleared_message">Your session has been cleared. Please log out and login again.</string>
+    <string name="lockout_limit_info">Note : Admin has restricted login attempts to %d</string>
 
 </resources>

--- a/core/src/test/java/in/testpress/ui/UserDevicesActivityTest.java
+++ b/core/src/test/java/in/testpress/ui/UserDevicesActivityTest.java
@@ -1,6 +1,7 @@
 package in.testpress.ui;
 
 import android.support.v4.app.Fragment;
+import android.widget.TextView;
 
 import androidx.test.core.app.ApplicationProvider;
 
@@ -11,6 +12,7 @@ import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 
+import in.testpress.R;
 import in.testpress.core.TestpressSdk;
 import in.testpress.core.TestpressSession;
 import in.testpress.models.AccountActivity;
@@ -38,6 +40,7 @@ public class UserDevicesActivityTest {
     private static final String USER_TOKEN = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6NDYsInVzZXJfaWQiOjQ2LCJlbWFpbCI6IiIsImV4cCI6MTUxOTAzNjUzM30.FUuyJfYNSAw_VcypZsN8_ZHvZra6gHU3njcXmr-TGVU";
     private AccountActivity accountActivity;
     private MockWebServer mockWebServer;
+    private InstituteSettings instituteSettings;
 
 
     public String randomDataString() {
@@ -64,8 +67,9 @@ public class UserDevicesActivityTest {
     public void setUp() throws IOException{
         mockWebServer = new MockWebServer();
         accountActivity = createAccountActivity();
-        InstituteSettings instituteSettings =
+        instituteSettings =
                 new InstituteSettings("http://localhost:9200");
+        instituteSettings.setLockoutLimit(1);
         TestpressSdk.setTestpressSession(ApplicationProvider.getApplicationContext(),
                 new TestpressSession(instituteSettings, USER_TOKEN));
         activity = Robolectric.buildActivity(UserDevicesActivity.class)
@@ -113,6 +117,15 @@ public class UserDevicesActivityTest {
         mockWebServer.takeRequest();
 
         Assert.assertTrue(response.isSuccessful());
+    }
+
+    @Test
+    public void testLoginAttemptRestrictionInfo() {
+        activity.setInfoText();
+        String lockout_limit_info = "Note : Admin has restricted login attempts to %s";
+        TextView info = activity.findViewById(R.id.parallel_login_restriction_note);
+
+        Assert.assertEquals(info.getText(), String.format(lockout_limit_info, instituteSettings.getLockoutLimit()));
     }
 
     @After


### PR DESCRIPTION
### Changes done
- Changed info text in UserDevicesActivity to display lockout limit

### Reason for the changes
- Earlier it used to display parallel login limit which wasn't useful.

TestCases - 1