### PR TITLE
Fix width of product price string

### DIFF
--- a/store/src/main/res/layout/testpress_products_list_item.xml
+++ b/store/src/main/res/layout/testpress_products_list_item.xml
@@ -42,13 +42,13 @@
             android:textSize="16sp"
             android:textStyle="bold"
             android:gravity="top"
-            android:layout_width="match_parent"
+            android:layout_width="wrap_content"
             android:layout_marginBottom="5dp"
             android:layout_height="wrap_content"
             />
 
         <LinearLayout
-            android:layout_width="match_parent"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:orientation="horizontal"
             android:layout_marginBottom="5dp"
@@ -83,7 +83,7 @@
             android:drawablePadding="5dp"
             android:text="AIIMS, AIPGMEE, NBE, PGI"
             android:textSize="12sp"
-            android:layout_width="match_parent"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:maxLines="1"
             android:ellipsize="end"


### PR DESCRIPTION
### Changes done
- Fixed width of product price string
- Used wrap_content for product_price, categories, counts so that their width depends on the content instead of product title like it was earlier.
