### PR TITLE
Display info if parallel login restriction is enabled

### DIFF
--- a/core/src/main/java/in/testpress/network/TestpressApiClient.java
+++ b/core/src/main/java/in/testpress/network/TestpressApiClient.java
@@ -67,6 +67,7 @@ public class TestpressApiClient {
     public static final String MODIFIED_SINCE = "modified_since";
     public static final String CREATED_SINCE = "created_since";
     public static final String CREATED_UNTIL = "created_until";
+    public static final String PARAM_SHOW_PARALLEL_LOGIN_INFO = "show_parallel_login_restriction_info";
 
     protected final Retrofit retrofit;
 
@@ -158,6 +159,7 @@ public class TestpressApiClient {
                                 @Override
                                 public void run() {
                                     Intent intent = new Intent(context, UserDevicesActivity.class);
+                                    intent.putExtra(PARAM_SHOW_PARALLEL_LOGIN_INFO, true);
                                     context.startActivity(intent);
                                 }
                             });

--- a/core/src/main/java/in/testpress/ui/UserDevicesActivity.java
+++ b/core/src/main/java/in/testpress/ui/UserDevicesActivity.java
@@ -1,5 +1,6 @@
 package in.testpress.ui;
 
+import android.content.Intent;
 import android.os.Bundle;
 import android.view.View;
 import android.widget.Button;
@@ -12,6 +13,8 @@ import in.testpress.core.TestpressException;
 import in.testpress.core.TestpressSdk;
 import in.testpress.core.TestpressSession;
 import in.testpress.network.TestpressApiClient;
+
+import static in.testpress.network.TestpressApiClient.PARAM_SHOW_PARALLEL_LOGIN_INFO;
 
 public class UserDevicesActivity extends BaseToolBarActivity {
 
@@ -72,6 +75,21 @@ public class UserDevicesActivity extends BaseToolBarActivity {
         parallelLoginRestrictionInfo = (TextView) findViewById(R.id.parallel_login_restriction_note);
         TestpressSession session = TestpressSdk.getTestpressSession(this);
         String info = getString(R.string.lockout_limit_info);
+
+        Intent intent = getIntent();
+
+        Bundle extras = intent.getExtras();
+        if (extras != null) {
+            if (extras.containsKey(PARAM_SHOW_PARALLEL_LOGIN_INFO)) {
+                boolean showParallelLoginRestrictionInfo = extras.getBoolean("isNewItem", false);
+                if (showParallelLoginRestrictionInfo) {
+                    info = getString(R.string.parallel_login_restriction_message);
+                    parallelLoginRestrictionInfo.setVisibility(View.VISIBLE);
+                    parallelLoginRestrictionInfo.setText(info);
+                }
+            }
+        }
+
 
         if (session.getInstituteSettings().getLockoutLimit() != null) {
             parallelLoginRestrictionInfo.setVisibility(View.VISIBLE);

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -42,5 +42,6 @@
     <string name="no_devices_found">No devices found</string>
     <string name="session_cleared_message">Your session has been cleared. Please log out and login again.</string>
     <string name="lockout_limit_info">Note : Admin has restricted login attempts to %d</string>
+    <string name="parallel_login_restriction_message">Multiple devices cannot be logged in simultaneously, please logout other devices to continue.</string>
 
 </resources>


### PR DESCRIPTION
### Changes done
- Display appropriate info if parallel login restriction is turned on.

### Reason for the changes
- This way user can know that they have to log out other devices if they exceed maximum parallel logins.