### PR TITLE
Move account activity to core activity in samples

### DIFF
--- a/samples/src/main/AndroidManifest.xml
+++ b/samples/src/main/AndroidManifest.xml
@@ -22,10 +22,14 @@
             </intent-filter>
         </activity>
 
-        <activity android:name=".core.TestpressCoreSampleActivity"
+        <activity android:name=".core.LoginActivity"
             android:windowSoftInputMode="stateHidden"
             android:configChanges="orientation|keyboard|screenSize"
-            android:label="Testpress Core Example" />
+            android:label="Login Activity" />
+
+        <activity android:name=".core.CoreSampleActivity"
+            android:configChanges="orientation|keyboard|screenSize"
+            android:label="Core Sample Activity" />
 
         <activity android:name=".exam.ExamSampleActivity"
             android:configChanges="orientation|keyboard|screenSize"

--- a/samples/src/main/java/in/testpress/samples/MainActivity.java
+++ b/samples/src/main/java/in/testpress/samples/MainActivity.java
@@ -4,19 +4,17 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.view.View;
-import android.view.WindowManager;
-
-import com.facebook.FacebookSdk;
 
 import in.testpress.core.TestpressSdk;
 import in.testpress.exam.TestpressExam;
 import in.testpress.exam.network.TestpressExamApiClient;
-import in.testpress.samples.core.TestpressCoreSampleActivity;
+import in.testpress.samples.core.CoreSampleActivity;
+import in.testpress.samples.core.LoginActivity;
 import in.testpress.samples.exam.ExamSampleActivity;
 import in.testpress.samples.course.CourseSampleActivity;
 import in.testpress.samples.store.StoreSampleActivity;
 
-import static in.testpress.samples.core.TestpressCoreSampleActivity.AUTHENTICATE_REQUEST_CODE;
+import static in.testpress.samples.core.LoginActivity.AUTHENTICATE_REQUEST_CODE;
 
 public class MainActivity extends BaseToolBarActivity {
 
@@ -27,7 +25,7 @@ public class MainActivity extends BaseToolBarActivity {
         findViewById(R.id.core).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                Intent intent = new Intent(MainActivity.this, TestpressCoreSampleActivity.class);
+                Intent intent = new Intent(MainActivity.this, CoreSampleActivity.class);
                 startActivity(intent);
             }
         });
@@ -69,7 +67,7 @@ public class MainActivity extends BaseToolBarActivity {
                     TestpressSdk.getTestpressSession(MainActivity.this)
             );
         } else {
-            Intent intent = new Intent(MainActivity.this, TestpressCoreSampleActivity.class);
+            Intent intent = new Intent(MainActivity.this, LoginActivity.class);
             startActivityForResult(intent, AUTHENTICATE_REQUEST_CODE);
         }
     }

--- a/samples/src/main/java/in/testpress/samples/core/CoreSampleActivity.java
+++ b/samples/src/main/java/in/testpress/samples/core/CoreSampleActivity.java
@@ -1,0 +1,59 @@
+package in.testpress.samples.core;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.view.View;
+
+import in.testpress.core.TestpressSdk;
+import in.testpress.core.TestpressSession;
+import in.testpress.samples.BaseToolBarActivity;
+import in.testpress.samples.R;
+import in.testpress.ui.UserDevicesActivity;
+
+public class CoreSampleActivity extends BaseToolBarActivity {
+    private int selectedItem;
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_core);
+
+        //noinspection ConstantConditions
+        getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+        findViewById(R.id.login).setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                Intent intent = new Intent(CoreSampleActivity.this, LoginActivity.class);
+                startActivity(intent);
+            }
+        });
+        findViewById(R.id.login_activity_button).setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                showSDK(view.getId());
+            }
+        });
+    }
+
+    private void showSDK(int clickedButtonId) {
+        selectedItem = clickedButtonId;
+        if (TestpressSdk.hasActiveSession(this)) {
+            TestpressSession session = TestpressSdk.getTestpressSession(this);
+            //noinspection ConstantConditions
+            session.getInstituteSettings()
+                    .setBookmarksEnabled(true)
+                    .setCommentsVotingEnabled(false)
+                    .setCoursesFrontend(false)
+                    .setCoursesGamificationEnabled(false);
+            TestpressSdk.setTestpressSession(this, session);
+            switch (clickedButtonId) {
+                case R.id.login_activity_button:
+                    Intent intent = new Intent(this, UserDevicesActivity.class);
+                    this.startActivity(intent);
+                default:
+                    break;
+            }
+        }
+    }
+}

--- a/samples/src/main/java/in/testpress/samples/core/LoginActivity.java
+++ b/samples/src/main/java/in/testpress/samples/core/LoginActivity.java
@@ -30,7 +30,7 @@ import in.testpress.models.InstituteSettings;
 import in.testpress.samples.BaseToolBarActivity;
 import in.testpress.samples.R;
 
-public class TestpressCoreSampleActivity extends BaseToolBarActivity {
+public class LoginActivity extends BaseToolBarActivity {
 
     public static final int AUTHENTICATE_REQUEST_CODE = 1111;
     public static final int REQUEST_CODE_GOOGLE_SIGN_IN = 2222;

--- a/samples/src/main/java/in/testpress/samples/course/CourseSampleActivity.java
+++ b/samples/src/main/java/in/testpress/samples/course/CourseSampleActivity.java
@@ -10,7 +10,7 @@ import in.testpress.core.TestpressSession;
 import in.testpress.course.TestpressCourse;
 import in.testpress.samples.BaseToolBarActivity;
 import in.testpress.samples.R;
-import in.testpress.samples.core.TestpressCoreSampleActivity;
+import in.testpress.samples.core.LoginActivity;
 import in.testpress.util.ViewUtils;
 
 import static in.testpress.core.TestpressSdk.COURSE_CHAPTER_REQUEST_CODE;
@@ -18,7 +18,7 @@ import static in.testpress.core.TestpressSdk.COURSE_CONTENT_DETAIL_REQUEST_CODE;
 import static in.testpress.core.TestpressSdk.COURSE_CONTENT_LIST_REQUEST_CODE;
 import static in.testpress.course.TestpressCourse.CHAPTER_URL;
 import static in.testpress.course.TestpressCourse.COURSE_ID;
-import static in.testpress.samples.core.TestpressCoreSampleActivity.AUTHENTICATE_REQUEST_CODE;
+import static in.testpress.samples.core.LoginActivity.AUTHENTICATE_REQUEST_CODE;
 
 public class CourseSampleActivity extends BaseToolBarActivity {
 
@@ -133,7 +133,7 @@ public class CourseSampleActivity extends BaseToolBarActivity {
                     break;
             }
         } else {
-            Intent intent = new Intent(this, TestpressCoreSampleActivity.class);
+            Intent intent = new Intent(this, LoginActivity.class);
             startActivityForResult(intent, AUTHENTICATE_REQUEST_CODE);
         }
     }

--- a/samples/src/main/java/in/testpress/samples/course/NavigationDrawerActivity.java
+++ b/samples/src/main/java/in/testpress/samples/course/NavigationDrawerActivity.java
@@ -8,9 +8,9 @@ import in.testpress.core.TestpressSession;
 import in.testpress.course.TestpressCourse;
 import in.testpress.samples.BaseNavigationDrawerActivity;
 import in.testpress.samples.R;
-import in.testpress.samples.core.TestpressCoreSampleActivity;
+import in.testpress.samples.core.LoginActivity;
 
-import static in.testpress.samples.core.TestpressCoreSampleActivity.AUTHENTICATE_REQUEST_CODE;
+import static in.testpress.samples.core.LoginActivity.AUTHENTICATE_REQUEST_CODE;
 
 public class NavigationDrawerActivity extends BaseNavigationDrawerActivity {
 
@@ -51,7 +51,7 @@ public class NavigationDrawerActivity extends BaseNavigationDrawerActivity {
                 TestpressCourse.showLeaderboard(this, R.id.fragment_container, session);
             }
         } else {
-            Intent intent = new Intent(this, TestpressCoreSampleActivity.class);
+            Intent intent = new Intent(this, LoginActivity.class);
             startActivityForResult(intent, AUTHENTICATE_REQUEST_CODE);
         }
     }

--- a/samples/src/main/java/in/testpress/samples/exam/ExamSampleActivity.java
+++ b/samples/src/main/java/in/testpress/samples/exam/ExamSampleActivity.java
@@ -11,12 +11,11 @@ import in.testpress.core.TestpressSession;
 import in.testpress.exam.TestpressExam;
 import in.testpress.samples.BaseToolBarActivity;
 import in.testpress.samples.R;
-import in.testpress.samples.core.TestpressCoreSampleActivity;
-import in.testpress.ui.UserDevicesActivity;
+import in.testpress.samples.core.LoginActivity;
 import in.testpress.util.ViewUtils;
 
 import static in.testpress.exam.ui.CarouselFragment.TEST_TAKEN_REQUEST_CODE;
-import static in.testpress.samples.core.TestpressCoreSampleActivity.AUTHENTICATE_REQUEST_CODE;
+import static in.testpress.samples.core.LoginActivity.AUTHENTICATE_REQUEST_CODE;
 
 public class ExamSampleActivity extends BaseToolBarActivity {
 
@@ -65,12 +64,6 @@ public class ExamSampleActivity extends BaseToolBarActivity {
                 showSDK(view.getId());
             }
         });
-        findViewById(R.id.login_activity_button).setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View view) {
-                showSDK(view.getId());
-            }
-        });
         findViewById(R.id.fragment_button).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
@@ -107,16 +100,12 @@ public class ExamSampleActivity extends BaseToolBarActivity {
                 case R.id.bookmarks:
                     TestpressExam.showBookmarks(this, session);
                     break;
-                case R.id.login_activity_button:
-                    Intent intent = new Intent(this, UserDevicesActivity.class);
-                    this.startActivity(intent);
-                    break;
                 default:
                     TestpressExam.showCategories(this, false, session);
                     break;
             }
         } else {
-            Intent intent = new Intent(this, TestpressCoreSampleActivity.class);
+            Intent intent = new Intent(this, LoginActivity.class);
             startActivityForResult(intent, AUTHENTICATE_REQUEST_CODE);
         }
     }

--- a/samples/src/main/java/in/testpress/samples/exam/NavigationDrawerActivity.java
+++ b/samples/src/main/java/in/testpress/samples/exam/NavigationDrawerActivity.java
@@ -8,9 +8,9 @@ import in.testpress.core.TestpressSession;
 import in.testpress.exam.TestpressExam;
 import in.testpress.samples.BaseNavigationDrawerActivity;
 import in.testpress.samples.R;
-import in.testpress.samples.core.TestpressCoreSampleActivity;
+import in.testpress.samples.core.LoginActivity;
 
-import static in.testpress.samples.core.TestpressCoreSampleActivity.AUTHENTICATE_REQUEST_CODE;
+import static in.testpress.samples.core.LoginActivity.AUTHENTICATE_REQUEST_CODE;
 
 public class NavigationDrawerActivity extends BaseNavigationDrawerActivity {
 
@@ -50,7 +50,7 @@ public class NavigationDrawerActivity extends BaseNavigationDrawerActivity {
             }
         } else {
             Intent intent = new Intent(NavigationDrawerActivity.this,
-                    TestpressCoreSampleActivity.class);
+                    LoginActivity.class);
             startActivityForResult(intent, AUTHENTICATE_REQUEST_CODE);
         }
     }

--- a/samples/src/main/java/in/testpress/samples/store/NavigationDrawerActivity.java
+++ b/samples/src/main/java/in/testpress/samples/store/NavigationDrawerActivity.java
@@ -7,10 +7,10 @@ import in.testpress.core.TestpressSdk;
 import in.testpress.core.TestpressSession;
 import in.testpress.samples.BaseNavigationDrawerActivity;
 import in.testpress.samples.R;
-import in.testpress.samples.core.TestpressCoreSampleActivity;
+import in.testpress.samples.core.LoginActivity;
 import in.testpress.store.TestpressStore;
 
-import static in.testpress.samples.core.TestpressCoreSampleActivity.AUTHENTICATE_REQUEST_CODE;
+import static in.testpress.samples.core.LoginActivity.AUTHENTICATE_REQUEST_CODE;
 
 public class NavigationDrawerActivity extends BaseNavigationDrawerActivity {
 
@@ -40,7 +40,7 @@ public class NavigationDrawerActivity extends BaseNavigationDrawerActivity {
                 TestpressStore.show(this, R.id.fragment_container, session);
             }
         } else {
-            Intent intent = new Intent(this, TestpressCoreSampleActivity.class);
+            Intent intent = new Intent(this, LoginActivity.class);
             startActivityForResult(intent, AUTHENTICATE_REQUEST_CODE);
         }
     }

--- a/samples/src/main/java/in/testpress/samples/store/StoreSampleActivity.java
+++ b/samples/src/main/java/in/testpress/samples/store/StoreSampleActivity.java
@@ -9,12 +9,12 @@ import in.testpress.core.TestpressSdk;
 import in.testpress.core.TestpressSession;
 import in.testpress.samples.BaseToolBarActivity;
 import in.testpress.samples.R;
-import in.testpress.samples.core.TestpressCoreSampleActivity;
+import in.testpress.samples.core.LoginActivity;
 import in.testpress.store.TestpressStore;
 import in.testpress.util.Assert;
 import in.testpress.util.ViewUtils;
 
-import static in.testpress.samples.core.TestpressCoreSampleActivity.AUTHENTICATE_REQUEST_CODE;
+import static in.testpress.samples.core.LoginActivity.AUTHENTICATE_REQUEST_CODE;
 import static in.testpress.store.TestpressStore.CONTINUE_PURCHASE;
 import static in.testpress.store.TestpressStore.STORE_REQUEST_CODE;
 
@@ -69,7 +69,7 @@ public class StoreSampleActivity extends BaseToolBarActivity {
                     break;
             }
         } else {
-            Intent intent = new Intent(this, TestpressCoreSampleActivity.class);
+            Intent intent = new Intent(this, LoginActivity.class);
             startActivityForResult(intent, AUTHENTICATE_REQUEST_CODE);
         }
     }

--- a/samples/src/main/res/layout/activity_core.xml
+++ b/samples/src/main/res/layout/activity_core.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <include layout="@layout/toolbar" />
+
+    <ScrollView
+        android:fillViewport="true"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <LinearLayout
+            android:orientation="vertical"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
+            android:gravity="center">
+
+            <android.support.v7.widget.AppCompatButton
+                style="@style/Button"
+                android:layout_marginTop="10dp"
+                android:text="Login"
+                android:id="@+id/login" />
+
+            <android.support.v7.widget.AppCompatButton
+                style="@style/Button"
+                android:text="Account Activity"
+                android:id="@+id/login_activity_button" />
+
+        </LinearLayout>
+
+    </ScrollView>
+
+</LinearLayout>

--- a/samples/src/main/res/layout/activity_open_exams_as.xml
+++ b/samples/src/main/res/layout/activity_open_exams_as.xml
@@ -55,11 +55,6 @@
                 android:text="Fragment"
                 android:id="@+id/fragment_button" />
 
-            <android.support.v7.widget.AppCompatButton
-                style="@style/Button"
-                android:text="Login Activity"
-                android:id="@+id/login_activity_button" />
-
         </LinearLayout>
 
     </ScrollView>


### PR DESCRIPTION
### Changes done
- Moved account activity to core activity in samples

### Reason for the changes
- Earlier it was in exam activity because it was easier to add a new button in exam activity and also core activity directly showed the login screen. So now core activity will show buttons such as login, account activity. This is more appropriate.