### PR TITLE
Rename course list fragment to my courses fragment

### DIFF
--- a/course/src/main/java/in/testpress/course/TestpressCourse.java
+++ b/course/src/main/java/in/testpress/course/TestpressCourse.java
@@ -12,7 +12,7 @@ import in.testpress.core.TestpressSession;
 import in.testpress.course.ui.ChapterDetailActivity;
 import in.testpress.course.ui.ContentActivity;
 import in.testpress.course.ui.CourseListActivity;
-import in.testpress.course.ui.CourseListFragment;
+import in.testpress.course.ui.MyCoursesFragment;
 import in.testpress.course.ui.LeaderboardActivity;
 import in.testpress.course.ui.LeaderboardFragment;
 import in.testpress.util.Assert;
@@ -52,7 +52,7 @@ public class TestpressCourse {
         Assert.assertNotNull("Activity must not be null.", activity);
 
         init(activity.getApplicationContext(), testpressSession);
-        CourseListFragment.show(activity, containerViewId);
+        MyCoursesFragment.show(activity, containerViewId);
     }
 
     /**
@@ -85,13 +85,13 @@ public class TestpressCourse {
      * @param context Context
      * @param testpressSession TestpressSession got from the core module
      */
-    public static CourseListFragment getCoursesListFragment(@NonNull Context context,
-                                                            @NonNull TestpressSession testpressSession) {
+    public static MyCoursesFragment getCoursesListFragment(@NonNull Context context,
+                                                           @NonNull TestpressSession testpressSession) {
 
         Assert.assertNotNull("Context must not be null.", context);
 
         init(context.getApplicationContext(), testpressSession);
-        return new CourseListFragment();
+        return new MyCoursesFragment();
     }
 
     /**

--- a/course/src/main/java/in/testpress/course/ui/CourseListActivity.java
+++ b/course/src/main/java/in/testpress/course/ui/CourseListActivity.java
@@ -12,7 +12,7 @@ public class CourseListActivity extends BaseToolBarActivity {
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.testpress_container_layout);
-        CourseListFragment fragment = new CourseListFragment();
+        MyCoursesFragment fragment = new MyCoursesFragment();
         fragment.setArguments(getIntent().getExtras());
         getSupportFragmentManager().beginTransaction().replace(R.id.fragment_container, fragment)
                 .commitAllowingStateLoss();

--- a/course/src/main/java/in/testpress/course/ui/MyCoursesFragment.java
+++ b/course/src/main/java/in/testpress/course/ui/MyCoursesFragment.java
@@ -20,14 +20,14 @@ import in.testpress.network.BaseResourcePager;
 import in.testpress.ui.BaseDataBaseFragment;
 import in.testpress.util.SingleTypeAdapter;
 
-public class CourseListFragment extends BaseDataBaseFragment<Course, Long> {
+public class MyCoursesFragment extends BaseDataBaseFragment<Course, Long> {
 
     private TestpressCourseApiClient mApiClient;
     private CourseDao courseDao;
 
     public static void show(FragmentActivity activity, int containerViewId) {
         activity.getSupportFragmentManager().beginTransaction()
-                .replace(containerViewId, new CourseListFragment())
+                .replace(containerViewId, new MyCoursesFragment())
                 .commitAllowingStateLoss();
     }
 


### PR DESCRIPTION
### Changes done
- Renamed `CourseListFragment` to `MyCoursesFragment`
- Since only user's courses are displayed in CourseListFragment and for course payment feature we need a top-level fragment that shows user's courses and available courses.We can name that top-level fragment as `CourseListFragment` so appropriate name for current `CourseListFragment` is `MyCoursesFragment`
