### PR TITLE
Add fragment to display exception

### DIFF
--- a/core/src/main/java/in/testpress/core/TestpressException.java
+++ b/core/src/main/java/in/testpress/core/TestpressException.java
@@ -96,6 +96,10 @@ public class TestpressException extends RuntimeException {
         return kind == Kind.NETWORK;
     }
 
+    public boolean isPageNotFound() {
+        return statusCode == 404;
+    }
+
     public boolean isForbidden() {
         return statusCode == 403;
     }

--- a/course/build.gradle
+++ b/course/build.gradle
@@ -44,6 +44,7 @@ dependencies {
     testImplementation rootProject.roboelectric
     testImplementation rootProject.androidxCore
     testImplementation rootProject.mockServer
+    testImplementation "org.robolectric:shadows-supportv4:3.8"
     testImplementation (rootProject.powermockMockio) {
         exclude group: 'org.mockito'
     }

--- a/course/src/main/java/in/testpress/course/ui/fragments/EmptyViewFragment.kt
+++ b/course/src/main/java/in/testpress/course/ui/fragments/EmptyViewFragment.kt
@@ -54,32 +54,40 @@ class EmptyViewFragment : Fragment() {
 
     fun displayError(exception: TestpressException) {
         when {
-            exception.isForbidden -> {
-                setEmptyText(R.string.permission_denied,
-                        R.string.testpress_no_permission,
-                        R.drawable.ic_error_outline_black_18dp)
-                retryButton.visibility = View.GONE
-            }
-            exception.isNetworkError -> {
-                setEmptyText(R.string.testpress_network_error,
-                        R.string.testpress_no_internet_try_again,
-                        R.drawable.ic_error_outline_black_18dp)
-                retryButton.setOnClickListener {
-                    emptyContainer.visibility = View.GONE
-                    emptyViewListener?.onRetryClick()
-                }
-            }
-            exception.isPageNotFound -> {
-                setEmptyText(R.string.testpress_content_not_available,
-                        R.string.testpress_content_not_available_description,
-                        R.drawable.ic_error_outline_black_18dp)
-            }
-            else -> {
-                setEmptyText(R.string.testpress_error_loading_contents,
-                        R.string.testpress_some_thing_went_wrong_try_again,
-                        R.drawable.ic_error_outline_black_18dp)
-            }
+            exception.isForbidden -> handleForbidden()
+            exception.isNetworkError -> handleNetworkError()
+            exception.isPageNotFound -> handleIsPageNotFound()
+            else -> handleUnknownError()
         }
+    }
+
+    private fun handleForbidden() {
+        setEmptyText(R.string.permission_denied,
+                R.string.testpress_no_permission,
+                R.drawable.ic_error_outline_black_18dp)
+        retryButton.visibility = View.GONE
+    }
+
+    private fun handleNetworkError() {
+        setEmptyText(R.string.testpress_network_error,
+                R.string.testpress_no_internet_try_again,
+                R.drawable.ic_error_outline_black_18dp)
+        retryButton.setOnClickListener {
+            emptyContainer.visibility = View.GONE
+            emptyViewListener?.onRetryClick()
+        }
+    }
+
+    private fun handleIsPageNotFound() {
+        setEmptyText(R.string.testpress_content_not_available,
+                R.string.testpress_content_not_available_description,
+                R.drawable.ic_error_outline_black_18dp)
+    }
+
+    private fun handleUnknownError() {
+        setEmptyText(R.string.testpress_error_loading_contents,
+                R.string.testpress_some_thing_went_wrong_try_again,
+                R.drawable.ic_error_outline_black_18dp)
     }
 
     private fun setEmptyText(title: Int, description: Int, left: Int) {

--- a/course/src/main/java/in/testpress/course/ui/fragments/EmptyViewFragment.kt
+++ b/course/src/main/java/in/testpress/course/ui/fragments/EmptyViewFragment.kt
@@ -32,17 +32,17 @@ class EmptyViewFragment : Fragment() {
 
     override fun onAttach(context: Context?) {
         super.onAttach(context)
+        initializeListeners()
+    }
 
-        if (parentFragment != null) {
-            onAttachToParentFragment(parentFragment)
+    private fun initializeListeners() {
+        emptyViewListener = if (parentFragment != null) {
+            parentFragment as? EmptyViewListener
         } else {
-            emptyViewListener = context as? EmptyViewListener
+            context as? EmptyViewListener
         }
     }
 
-    private fun onAttachToParentFragment(fragment: Fragment?) {
-        emptyViewListener = fragment as? EmptyViewListener
-    }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)

--- a/course/src/main/java/in/testpress/course/ui/fragments/EmptyViewFragment.kt
+++ b/course/src/main/java/in/testpress/course/ui/fragments/EmptyViewFragment.kt
@@ -1,0 +1,96 @@
+package `in`.testpress.course.ui.fragments
+
+import `in`.testpress.core.TestpressException
+import `in`.testpress.course.R
+import android.content.Context
+import android.os.Bundle
+import android.support.annotation.VisibleForTesting
+import android.support.v4.app.Fragment
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Button
+import android.widget.LinearLayout
+import android.widget.TextView
+
+
+class EmptyViewFragment : Fragment() {
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    lateinit var emptyTitleView: TextView
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    lateinit var emptyDescView: TextView
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    lateinit var emptyContainer: LinearLayout
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    lateinit var retryButton: Button
+
+    private var emptyViewListener: EmptyViewListener? = null
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        return inflater.inflate(R.layout.testpress_empty_view, container, false);
+    }
+
+    override fun onAttach(context: Context?) {
+        super.onAttach(context)
+
+        if (parentFragment != null) {
+            onAttachToParentFragment(parentFragment)
+        } else {
+            emptyViewListener = context as? EmptyViewListener
+        }
+    }
+
+    private fun onAttachToParentFragment(fragment: Fragment?) {
+        emptyViewListener = fragment as? EmptyViewListener
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        emptyContainer = view.findViewById(R.id.empty_container)
+        emptyTitleView = view.findViewById(R.id.empty_title)
+        emptyDescView = view.findViewById(R.id.empty_description)
+        retryButton = view.findViewById(R.id.retry_button)
+    }
+
+    fun displayError(exception: TestpressException) {
+        when {
+            exception.isForbidden -> {
+                setEmptyText(R.string.permission_denied,
+                        R.string.testpress_no_permission,
+                        R.drawable.ic_error_outline_black_18dp)
+                retryButton.visibility = View.GONE
+            }
+            exception.isNetworkError -> {
+                setEmptyText(R.string.testpress_network_error,
+                        R.string.testpress_no_internet_try_again,
+                        R.drawable.ic_error_outline_black_18dp)
+                retryButton.setOnClickListener {
+                    emptyContainer.visibility = View.GONE
+                    emptyViewListener?.onRetryClick()
+                }
+            }
+            exception.isPageNotFound -> {
+                setEmptyText(R.string.testpress_content_not_available,
+                        R.string.testpress_content_not_available_description,
+                        R.drawable.ic_error_outline_black_18dp)
+            }
+            else -> {
+                setEmptyText(R.string.testpress_error_loading_contents,
+                        R.string.testpress_some_thing_went_wrong_try_again,
+                        R.drawable.ic_error_outline_black_18dp)
+            }
+        }
+    }
+
+    private fun setEmptyText(title: Int, description: Int, left: Int) {
+        emptyContainer.visibility = View.VISIBLE
+        emptyTitleView.setText(title)
+        emptyTitleView.setCompoundDrawablesWithIntrinsicBounds(left, 0, 0, 0)
+        emptyDescView.setText(description)
+        retryButton.visibility = View.VISIBLE
+    }
+}
+
+interface EmptyViewListener {
+    fun onRetryClick()
+}

--- a/course/src/test/java/in/testpress/course/fragments/EmptyViewFragmentTest.kt
+++ b/course/src/test/java/in/testpress/course/fragments/EmptyViewFragmentTest.kt
@@ -1,0 +1,98 @@
+package `in`.testpress.course.fragments
+
+import `in`.testpress.core.TestpressException
+import `in`.testpress.course.R
+import `in`.testpress.course.ui.fragments.EmptyViewFragment
+import `in`.testpress.models.TestpressApiResponse
+import `in`.testpress.models.greendao.Content
+import android.content.Context
+import android.view.View
+import androidx.test.core.app.ApplicationProvider
+import junit.framework.Assert
+import okhttp3.MediaType
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.ResponseBody
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.shadows.support.v4.SupportFragmentTestUtil
+import retrofit2.Response
+import java.io.IOException
+
+
+@RunWith(RobolectricTestRunner::class)
+class EmptyViewFragmentTest {
+    lateinit var fragment: EmptyViewFragment
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+
+    @Before
+    fun setUp() {
+        fragment = EmptyViewFragment()
+        SupportFragmentTestUtil.startFragment(fragment)
+    }
+
+    private fun buildErrorResponse(errorCode: Int): Response<TestpressApiResponse<Content>> {
+        val responseBody = ResponseBody.create(MediaType.parse("application/json"), """{"detail":"Error"}""")
+        return Response.error<TestpressApiResponse<Content>>(responseBody, okhttp3.Response.Builder()
+                .code(errorCode)
+                .message("Error")
+                .protocol(Protocol.HTTP_1_1)
+                .request(Request.Builder().url("http://localhost/").build())
+                .build())
+    }
+
+    @Test
+    fun testNetworkError() {
+        val ioException = IOException()
+        val exception = TestpressException.networkError(ioException)
+        fragment.displayError(exception)
+
+        Assert.assertEquals(View.VISIBLE, fragment.emptyContainer.visibility)
+        Assert.assertEquals(context.getString(R.string.testpress_network_error), fragment.emptyTitleView.text)
+        Assert.assertEquals(context.getString(R.string.testpress_no_internet_try_again), fragment.emptyDescView.text)
+    }
+
+    @Test
+    fun testForbiddenError() {
+        val exception = TestpressException.httpError(buildErrorResponse(403))
+        fragment.displayError(exception)
+
+        Assert.assertEquals(View.VISIBLE, fragment.emptyContainer.visibility)
+        Assert.assertEquals(context.getString(R.string.permission_denied), fragment.emptyTitleView.text)
+        Assert.assertEquals(context.getString(R.string.testpress_no_permission), fragment.emptyDescView.text)
+    }
+
+    @Test
+    fun testIsPageNotFound() {
+        val exception = TestpressException.httpError(buildErrorResponse(404))
+        fragment.displayError(exception)
+
+        Assert.assertEquals(View.VISIBLE, fragment.emptyContainer.visibility)
+        Assert.assertEquals(context.getString(R.string.testpress_content_not_available), fragment.emptyTitleView.text)
+        Assert.assertEquals(context.getString(R.string.testpress_content_not_available_description), fragment.emptyDescView.text)
+    }
+
+    @Test
+    fun testOtherErrorCode() {
+        val exception = TestpressException.httpError(buildErrorResponse(405))
+        fragment.displayError(exception)
+
+        Assert.assertEquals(View.VISIBLE, fragment.emptyContainer.visibility)
+        Assert.assertEquals(context.getString(R.string.testpress_error_loading_contents), fragment.emptyTitleView.text)
+        Assert.assertEquals(context.getString(R.string.testpress_some_thing_went_wrong_try_again), fragment.emptyDescView.text)
+    }
+
+    @Test
+    fun testRetryButtonClick() {
+        val ioException = IOException()
+        val exception = TestpressException.networkError(ioException)
+        fragment.displayError(exception)
+        Assert.assertEquals(View.VISIBLE, fragment.emptyContainer.visibility)
+
+        fragment.retryButton.performClick()
+
+        Assert.assertEquals(View.GONE, fragment.emptyContainer.visibility)
+    }
+}


### PR DESCRIPTION
### Changes done
- Added fragment to display error/exception
- This can be reused in any activity/fragment to handle the exception.
- This will reduce redundant code.

No of test cases - 5
