### PR TITLE
Handle exception in network bound resource

### DIFF
--- a/course/src/main/java/in/testpress/course/repository/NetworkBoundResource.kt
+++ b/course/src/main/java/in/testpress/course/repository/NetworkBoundResource.kt
@@ -72,9 +72,7 @@ abstract class NetworkBoundResource<ResultDataType, NetworkDataType> {
                     }
                 }
             } catch (e: Exception) {
-                println("I am here 2")
                 withContext(Dispatchers.Main) {
-                    println("I am here 3")
                     val exception = TestpressException.unexpectedError(e)
                     setValue(Resource.error(exception, null))
                 }

--- a/course/src/test/java/in/testpress/course/repository/NetworkBoundResourceTest.kt
+++ b/course/src/test/java/in/testpress/course/repository/NetworkBoundResourceTest.kt
@@ -148,7 +148,7 @@ class NetworkBoundResourceTest {
     }
 
     @Test
-    fun exceptionsShouldBeHandled() = runBlocking {
+    fun exceptionShouldBeSetOnLiveDataInCase() = runBlocking {
         val exception = Exception()
         shouldFetchHandler = { true }
         createCallHandler = {

--- a/course/src/test/java/in/testpress/course/repository/NetworkBoundResourceTest.kt
+++ b/course/src/test/java/in/testpress/course/repository/NetworkBoundResourceTest.kt
@@ -148,7 +148,7 @@ class NetworkBoundResourceTest {
     }
 
     @Test
-    fun exceptionShouldBeSetOnLiveDataInCase() = runBlocking {
+    fun onNetworkErrorExceptionIsSetOnResource() = runBlocking {
         val exception = Exception()
         shouldFetchHandler = { true }
         createCallHandler = {


### PR DESCRIPTION
### Changes done
- While making requests if any exception occurs, it should be set to live data in Network bound resource.
- Previously it used to crash the app since the exception wasn't handled


No of test case - 1