### PR TITLE
Add method to store content and its relations in repository

### DIFF
--- a/course/src/main/java/in/testpress/course/di/InjectorUtils.kt
+++ b/course/src/main/java/in/testpress/course/di/InjectorUtils.kt
@@ -9,8 +9,9 @@ import android.content.Context
 object InjectorUtils {
     fun getContentRepository(context: Context): ContentRepository {
         val contentDao = TestpressSDKDatabase.getContentDao(context)
+        val attachmentDao = TestpressSDKDatabase.getAttachmentDao(context)
         val roomContentDao = TestpressDatabase(context).contentDao()
-        return ContentRepository(roomContentDao, contentDao, getCourseNetwork(context))
+        return ContentRepository(roomContentDao, contentDao, attachmentDao, getCourseNetwork(context))
     }
 
     private fun getCourseNetwork(context: Context): CourseNetwork {

--- a/course/src/main/java/in/testpress/course/repository/ContentRepository.kt
+++ b/course/src/main/java/in/testpress/course/repository/ContentRepository.kt
@@ -35,7 +35,7 @@ class ContentRepository(
         return object : NetworkBoundResource<DomainContent, NetworkContent>() {
             override fun saveNetworkResponseToDB(item: NetworkContent) {
                 roomContentDao.insert(item.asDatabaseModel())
-                contentDao.insertOrReplace(item.asGreenDaoModel())
+                storeContentAndItsRelationsToDB(item)
             }
 
             override fun shouldFetch(data: DomainContent?): Boolean {

--- a/course/src/main/java/in/testpress/course/repository/ContentRepository.kt
+++ b/course/src/main/java/in/testpress/course/repository/ContentRepository.kt
@@ -23,6 +23,7 @@ import androidx.lifecycle.MutableLiveData
 class ContentRepository(
     val roomContentDao: `in`.testpress.database.ContentDao,
     val contentDao: ContentDao,
+    val attachmentDao: AttachmentDao,
     val courseNetwork: CourseNetwork
 ) {
     private var contentAttempt: MutableLiveData<Resource<NetworkContentAttempt>> = MutableLiveData()
@@ -99,6 +100,16 @@ class ContentRepository(
                 }
             })
         return contentAttempt
+    }
+
+    fun storeContentAndItsRelationsToDB(content: NetworkContent) {
+        val greenDaoContent = content.asGreenDaoModel()
+        content.attachment?.let {
+            val attachment = it.asGreenDaoModel()
+            greenDaoContent.attachmentId = attachment.id
+            attachmentDao.insertOrReplace(it.asGreenDaoModel())
+        }
+        contentDao.insertOrReplace(greenDaoContent)
     }
 
     fun storeBookmarkIdToContent(bookmarkId: Long?, contentId: Long) {

--- a/course/src/test/java/in/testpress/course/repository/ContentRepositoryTest.kt
+++ b/course/src/test/java/in/testpress/course/repository/ContentRepositoryTest.kt
@@ -37,8 +37,9 @@ import org.mockito.junit.MockitoJUnitRunner
 class ContentRepositoryTest {
     private val contentDao = mock(ContentDao::class.java)
     private val roomContentDao = mock(`in`.testpress.database.ContentDao::class.java)
+    private val attachmentDao = mock(AttachmentDao::class.java)
     private val courseNetwork = mock(CourseNetwork::class.java)
-    private val repo = ContentRepository(roomContentDao, contentDao, courseNetwork)
+    private val repo = ContentRepository(roomContentDao, contentDao, attachmentDao, courseNetwork)
 
     @Mock
     lateinit var queryBuilder: QueryBuilder<Content>


### PR DESCRIPTION
### Changes done
- After fetching content, content and its related items should be stored in DB

No of test case - 1
