### PR TITLE
Hide marks in exam if it has variable marks

### DIFF
--- a/exam/src/main/java/in/testpress/exam/ui/TestActivity.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestActivity.java
@@ -375,6 +375,8 @@ public class TestActivity extends BaseToolBarActivity implements LoaderManager.L
         TextView date = findViewById(R.id.date);
         LinearLayout dateLayout = findViewById(R.id.date_layout);
         LinearLayout description = findViewById(R.id.description);
+        LinearLayout marksPerQuestionLayout = findViewById(R.id.mark_per_question_layout);
+        LinearLayout negativeMarksLayout = findViewById(R.id.negative_marks_layout);
         TextView descriptionContent = findViewById(R.id.descriptionContent);
         TextView questionsLabel = findViewById(R.id.questions_label);
         TextView durationLabel = findViewById(R.id.duration_label);
@@ -427,6 +429,11 @@ public class TestActivity extends BaseToolBarActivity implements LoaderManager.L
         }
         progressBar.setVisibility(View.GONE);
         examDetailsContainer.setVisibility(View.VISIBLE);
+
+        if (exam.getVariableMarkPerQuestion()) {
+            marksPerQuestionLayout.setVisibility(View.GONE);
+            negativeMarksLayout.setVisibility(View.GONE);
+        }
     }
 
     private void endExam() {

--- a/exam/src/main/res/layout/testpress_exam_details_layout.xml
+++ b/exam/src/main/res/layout/testpress_exam_details_layout.xml
@@ -63,6 +63,7 @@
         <LinearLayout
             style="@style/TestpressExamInfoRow"
             android:layout_marginBottom="5dp"
+            android:id="@+id/mark_per_question_layout"
             android:layout_gravity="center">
             <ImageView
                 android:layout_height="match_parent"
@@ -86,6 +87,7 @@
         <LinearLayout
             style="@style/TestpressExamInfoRow"
             android:layout_marginBottom="5dp"
+            android:id="@+id/negative_marks_layout"
             android:layout_gravity="center">
             <ImageView
                 android:layout_height="match_parent"


### PR DESCRIPTION
### Changes done
- If the exam has variable marks then the exam's total marks should not be displayed in the exam start screen.
