### PR TITLE
Show analytics button only if show analytics is enabled

### DIFF
--- a/exam/src/main/java/in/testpress/exam/ui/ReviewStatsFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/ReviewStatsFragment.java
@@ -273,7 +273,9 @@ public class ReviewStatsFragment extends BaseFragment {
             timeAnalyticsButtonLayout.setVisibility(View.GONE);
         }
 
-        if (instituteSettings.getDisableStudentAnalytics()) {
+        if (exam.showAnalytics()) {
+            analyticsButton.setVisibility(View.VISIBLE);
+        } else {
             analyticsButton.setVisibility(View.GONE);
         }
 

--- a/exam/src/main/res/layout/testpress_fragment_review_stats.xml
+++ b/exam/src/main/res/layout/testpress_fragment_review_stats.xml
@@ -624,7 +624,6 @@
         android:orientation="horizontal"
         android:layout_marginLeft="10dp"
         android:layout_marginRight="10dp"
-        android:weightSum="2"
         android:baselineAligned="false"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"


### PR DESCRIPTION
### Changes done
- If show score is disabled for an exam then the student cannot view analytics, so it is appropriate to hide it
