### PR TITLE
Add support to show sectional instruction for exam

### DIFF
--- a/exam/src/main/java/in/testpress/exam/ui/PlainSpinnerItemAdapter.java
+++ b/exam/src/main/java/in/testpress/exam/ui/PlainSpinnerItemAdapter.java
@@ -5,6 +5,7 @@ import androidx.core.content.ContextCompat;
 import android.view.Gravity;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.Button;
 import android.widget.TextView;
 
 import in.testpress.exam.R;
@@ -14,6 +15,8 @@ import in.testpress.util.ViewUtils;
 public class PlainSpinnerItemAdapter extends ExploreSpinnerAdapter {
 
     protected Activity activity;
+    private boolean showSectionInfo = false;
+    private SectionInfoClickListener sectionInfoClickListener;
 
     public PlainSpinnerItemAdapter(Activity activity) {
         super(activity.getLayoutInflater(), activity.getResources(), false);
@@ -28,8 +31,26 @@ public class PlainSpinnerItemAdapter extends ExploreSpinnerAdapter {
         }
         TextView textView = view.findViewById(android.R.id.text1);
         textView.setText(getTitle(position));
+        Button info = view.findViewById(R.id.info_button);
+        if (showSectionInfo) {
+            info.setVisibility(View.VISIBLE);
+        }
+        info.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                sectionInfoClickListener.showInfo();
+            }
+        });
         ViewUtils.setDrawableColor(textView, R.color.testpress_black);
         return view;
+    }
+
+    public void showSectionInfoButton(boolean showSectionInfo) {
+        this.showSectionInfo = showSectionInfo;
+    }
+
+    public void setSectionInfoClickListener(SectionInfoClickListener listener) {
+        this.sectionInfoClickListener = listener;
     }
 
     @Override
@@ -45,5 +66,9 @@ public class PlainSpinnerItemAdapter extends ExploreSpinnerAdapter {
         dividerView.setBackgroundColor(ContextCompat.getColor(activity, R.color.testpress_gray_light));
         dividerView.setVisibility(View.VISIBLE);
         return view;
+    }
+
+    public interface SectionInfoClickListener {
+        void showInfo();
     }
 }

--- a/exam/src/main/res/layout/testpress_plain_spinner_item.xml
+++ b/exam/src/main/res/layout/testpress_plain_spinner_item.xml
@@ -25,6 +25,7 @@
         android:textColor="@color/testpress_color_primary"
         android:textSize="12sp"
         android:visibility="gone"
+        android:layout_marginTop="4dp"
         android:paddingLeft="0dp"
         android:id="@+id/info_button"
         android:layout_alignParentRight="true"

--- a/exam/src/main/res/layout/testpress_plain_spinner_item.xml
+++ b/exam/src/main/res/layout/testpress_plain_spinner_item.xml
@@ -1,23 +1,33 @@
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:orientation="vertical"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content" >
+    android:layout_height="wrap_content">
 
     <TextView
         android:id="@android:id/text1"
         android:paddingTop="15dp"
         android:paddingBottom="15dp"
-        android:paddingRight="10dp"
+        android:paddingRight="0dp"
         android:paddingLeft="28dp"
         android:layout_height="wrap_content"
-        android:layout_width="match_parent"
+        android:layout_width="wrap_content"
         android:textColor="@color/testpress_black"
         android:background="@color/testpress_white"
         android:maxLines="1"
+        android:layout_centerInParent="true"
         android:ellipsize="end"
-        android:gravity="center"
         android:textSize="16sp"
         android:drawableRight="@drawable/ic_expand_more_18dp"
         android:drawableEnd="@drawable/ic_expand_more_18dp" />
 
-</LinearLayout>
+    <Button
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textColor="@color/testpress_color_primary"
+        android:textSize="12sp"
+        android:visibility="gone"
+        android:paddingLeft="0dp"
+        android:id="@+id/info_button"
+        android:layout_alignParentRight="true"
+        style="?attr/buttonBarButtonStyle"
+        android:text="Instructions"/>
+</RelativeLayout>

--- a/exam/src/main/res/layout/testpress_plain_spinner_item.xml
+++ b/exam/src/main/res/layout/testpress_plain_spinner_item.xml
@@ -25,7 +25,7 @@
         android:textColor="@color/testpress_color_primary"
         android:textSize="12sp"
         android:visibility="gone"
-        android:layout_marginTop="4dp"
+        android:layout_marginTop="3dp"
         android:paddingLeft="0dp"
         android:id="@+id/info_button"
         android:layout_alignParentRight="true"


### PR DESCRIPTION
### Changes done
- If exam sections have instructions then near the section title, the button will be displayed.
- On clicking, that button will display section's instructions

