### PR TITLE
Expose method in base activity to display logo in toolbar

### DIFF
--- a/core/src/main/java/in/testpress/models/InstituteSettings.java
+++ b/core/src/main/java/in/testpress/models/InstituteSettings.java
@@ -19,6 +19,7 @@ public class InstituteSettings {
     private Integer lockoutLimit;
     private String cooloffTime;
     private String storeLabel;
+    private String appToolbarLogo;
 
     public InstituteSettings(String baseUrl) {
         setBaseUrl(baseUrl);
@@ -156,6 +157,15 @@ public class InstituteSettings {
 
     public InstituteSettings setStoreLabel(String storeLabel) {
         this.storeLabel = storeLabel;
+        return this;
+    }
+
+    public String getAppToolbarLogo() {
+        return appToolbarLogo;
+    }
+
+    public InstituteSettings setAppToolbarLogo(String appToolbarLogo) {
+        this.appToolbarLogo = appToolbarLogo;
         return this;
     }
 }

--- a/core/src/main/java/in/testpress/ui/BaseToolBarActivity.java
+++ b/core/src/main/java/in/testpress/ui/BaseToolBarActivity.java
@@ -6,6 +6,7 @@ import androidx.annotation.StringRes;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
 import android.view.MenuItem;
+import android.widget.ImageView;
 
 import in.testpress.R;
 import in.testpress.core.TestpressSdk;
@@ -24,6 +25,7 @@ import static in.testpress.core.TestpressSdk.ACTION_PRESSED_HOME;
 public abstract class BaseToolBarActivity extends AppCompatActivity {
 
     public static final String ACTIONBAR_TITLE = "title";
+    protected ImageView logo;
 
     @Override
     public void setContentView(final int layoutResId) {
@@ -33,6 +35,7 @@ public abstract class BaseToolBarActivity extends AppCompatActivity {
         }
         super.setContentView(layoutResId);
         Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
+        logo = findViewById(R.id.toolbar_logo);
         setSupportActionBar(toolbar);
         //noinspection ConstantConditions
         getSupportActionBar().setHomeButtonEnabled(true);

--- a/core/src/main/java/in/testpress/ui/BaseToolBarActivity.java
+++ b/core/src/main/java/in/testpress/ui/BaseToolBarActivity.java
@@ -57,7 +57,7 @@ public abstract class BaseToolBarActivity extends AppCompatActivity {
         getSupportActionBar().setTitle(title);
     }
 
-    public void setLogo() {
+    public void showLogoInToolbar() {
         getSupportActionBar().setTitle("");
         if (session == null || session.getInstituteSettings() == null) {
             return;

--- a/core/src/main/java/in/testpress/ui/BaseToolBarActivity.java
+++ b/core/src/main/java/in/testpress/ui/BaseToolBarActivity.java
@@ -8,11 +8,15 @@ import androidx.appcompat.widget.Toolbar;
 import android.view.MenuItem;
 import android.widget.ImageView;
 
+import com.nostra13.universalimageloader.core.DisplayImageOptions;
+import com.nostra13.universalimageloader.core.ImageLoader;
+
 import in.testpress.R;
 import in.testpress.core.TestpressSdk;
 import in.testpress.core.TestpressSession;
 import in.testpress.network.RetrofitCall;
 import in.testpress.util.CommonUtils;
+import in.testpress.util.ImageUtils;
 
 import static android.view.WindowManager.LayoutParams.FLAG_SECURE;
 import static in.testpress.core.TestpressSdk.ACTION_PRESSED_HOME;
@@ -26,10 +30,11 @@ public abstract class BaseToolBarActivity extends AppCompatActivity {
 
     public static final String ACTIONBAR_TITLE = "title";
     protected ImageView logo;
+    private TestpressSession session;
 
     @Override
     public void setContentView(final int layoutResId) {
-        TestpressSession session = TestpressSdk.getTestpressSession(this);
+        session = TestpressSdk.getTestpressSession(this);
         if (session != null && session.getInstituteSettings().isScreenshotDisabled()) {
             getWindow().setFlags(FLAG_SECURE, FLAG_SECURE);
         }
@@ -50,6 +55,20 @@ public abstract class BaseToolBarActivity extends AppCompatActivity {
     public void setActionBarTitle(String title) {
         //noinspection ConstantConditions
         getSupportActionBar().setTitle(title);
+    }
+
+    public void setLogo() {
+        getSupportActionBar().setTitle("");
+        if (session == null || session.getInstituteSettings() == null) {
+            return;
+        }
+        String url = session.getInstituteSettings().getAppToolbarLogo();
+        ImageLoader imageLoader = ImageUtils.initImageLoader(this);
+        DisplayImageOptions options = new DisplayImageOptions.Builder()
+                .cacheInMemory(true)
+                .cacheOnDisk(true)
+                .build();
+        imageLoader.displayImage(url, logo, options);
     }
 
     @SuppressWarnings("DanglingJavadoc")

--- a/core/src/main/res/layout/testpress_toolbar.xml
+++ b/core/src/main/res/layout/testpress_toolbar.xml
@@ -15,7 +15,15 @@
         android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize"
         android:background="?attr/colorPrimary"
+        app:contentInsetStartWithNavigation="0dp"
         app:popupTheme="@style/TestpressTheme.PopupOverlay"
-        app:layout_scrollFlags="scroll|enterAlways" />
+        app:layout_scrollFlags="scroll|enterAlways" >
+
+        <ImageView
+            android:id="@+id/toolbar_logo"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="left|start"/>
+    </androidx.appcompat.widget.Toolbar>
 
 </com.google.android.material.appbar.AppBarLayout>


### PR DESCRIPTION
### Changes done
- Added a helper in the base activity to display a logo in the toolbar
- This can be used by the derived activities for displaying an image in toolbar which is usually logo
- This will be a prerequisite for the ReviewQuestionsActivity where we will be using to display the logo in the toolbar
- Helps in marketing when users share screenshots of the app screen
