### PR TITLE
Fix start button not working after pausing exam

### DIFF
--- a/course/src/main/java/in/testpress/course/fragments/ExamContentFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/ExamContentFragment.kt
@@ -3,6 +3,13 @@ package `in`.testpress.course.fragments
 import `in`.testpress.course.R
 import `in`.testpress.course.domain.DomainContent
 import `in`.testpress.course.network.NetworkContentAttempt
+import `in`.testpress.course.ui.ContentActivity.FORCE_REFRESH
+import `in`.testpress.course.ui.ContentActivity.TESTPRESS_CONTENT_SHARED_PREFS
+import `in`.testpress.exam.ui.CarouselFragment.TEST_TAKEN_REQUEST_CODE
+import android.app.Activity.RESULT_OK
+import android.content.Context
+import android.content.Intent
+import android.content.SharedPreferences
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -39,12 +46,6 @@ class ExamContentFragment: BaseContentDetailFragment(), ExamRefreshListener {
         initExamWidget(content)
     }
 
-    override fun onResume() {
-        super.onResume()
-        if (isContentInitialized()) {
-            display()
-        }
-    }
 
     private fun initExamWidget(content: DomainContent) {
         val examWidgetFragment = ExamWidgetFactory.getWidget(content)
@@ -52,6 +53,20 @@ class ExamContentFragment: BaseContentDetailFragment(), ExamRefreshListener {
         val transaction = childFragmentManager.beginTransaction()
         transaction.replace(R.id.exam_widget_fragment, examWidgetFragment)
         transaction.commit()
+    }
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        super.onActivityResult(requestCode, resultCode, data)
+        if (requestCode == TEST_TAKEN_REQUEST_CODE && resultCode == RESULT_OK) {
+            if (requireActivity().callingActivity == null) {
+                val prefs: SharedPreferences = requireActivity().getSharedPreferences(
+                    TESTPRESS_CONTENT_SHARED_PREFS,
+                    Context.MODE_PRIVATE
+                )
+                prefs.edit().putBoolean(FORCE_REFRESH, true).apply()
+            }
+            forceReloadContent()
+        }
     }
 
     override fun showOrHideRefresh(isRefreshing: Boolean) {

--- a/course/src/main/java/in/testpress/course/ui/ContentActivity.java
+++ b/course/src/main/java/in/testpress/course/ui/ContentActivity.java
@@ -3,8 +3,10 @@ package in.testpress.course.ui;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
+import android.util.Log;
 import android.view.MenuItem;
 
+import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.fragment.app.Fragment;
 
@@ -70,5 +72,13 @@ public class ContentActivity extends BaseToolBarActivity implements ContentFragm
         fragment.setArguments(bundle);
         getSupportFragmentManager().beginTransaction()
                 .replace(R.id.fragment_container, fragment).commitAllowingStateLoss();
+    }
+
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, @Nullable Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+        for (Fragment fragment : getSupportFragmentManager().getFragments()) {
+            fragment.onActivityResult(requestCode, resultCode, data);
+        }
     }
 }


### PR DESCRIPTION
- If exam is paused, exam content should be refreshed(as its pausedattemptcount will be incremented).
- Previously exam content was not refreshed so paused attempt count will be 0 which caused it to display the start button instead of a resume button
