### PR TITLE
Preload logo for share in review questions activity

### DIFF
--- a/core/src/main/assets/TestpressReview.js
+++ b/core/src/main/assets/TestpressReview.js
@@ -30,11 +30,14 @@ function getElement(className) {
     return document.getElementsByClassName(className)[0];
 }
 
-function showLogo(logoUrl) {
+function addLogo(logoUrl) {
     var imageContainer = `<div class='logo' id='logo' style='max-width:150px;padding: 20px;display:none;'>
             <img src='${logoUrl}'>
             </div>`;
     document.body.innerHTML =  imageContainer + document.body.innerHTML
+}
+
+function showLogo() {
     var logo = getElement("logo");
     logo.style.display = "block";
 }

--- a/core/src/main/java/in/testpress/util/WebViewUtils.java
+++ b/core/src/main/java/in/testpress/util/WebViewUtils.java
@@ -179,12 +179,16 @@ public class WebViewUtils {
         evaluateJavascript("displayBookmarkButton();");
     }
 
-    public void showLogo(String logoUrl) {
-        evaluateJavascript("showLogo('"+logoUrl+"');");
+    public void addLogo(String logoUrl) {
+        evaluateJavascript("addLogo('"+logoUrl+"');");
     }
 
     public void hideLogo() {
         evaluateJavascript("hideLogo();");
+    }
+
+    public void showLogo() {
+        evaluateJavascript("showLogo();");
     }
 
     protected static String getTestEngineHeader() {

--- a/exam/src/main/java/in/testpress/exam/ui/ReviewQuestionsFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/ReviewQuestionsFragment.java
@@ -207,6 +207,7 @@ public class ReviewQuestionsFragment extends Fragment {
                     commentsUtil.displayComments();
                 }
                 animationView.bringToFront();
+                webViewUtils.addLogo(instituteSettings.getAppToolbarLogo());
                 setHasOptionsMenu(true);
             }
 
@@ -294,6 +295,7 @@ public class ReviewQuestionsFragment extends Fragment {
             htmlContent = getHtml(reviewQuestion.getDirection(), reviewQuestion.getQuestionHtml(),
                     reviewQuestion.getAnswers(), reviewQuestion.getExplanationHtml(), reviewQuestion.getSubject());
         }
+
         return htmlContent;
     }
 
@@ -611,7 +613,7 @@ public class ReviewQuestionsFragment extends Fragment {
 
     private void shareQuestionAsImage(final String package_name) {
         webViewUtils.hideBookmarkButton();
-        webViewUtils.showLogo(instituteSettings.getAppToolbarLogo());
+        webViewUtils.showLogo();
         new Handler().postDelayed(new Runnable() {
             @Override
             public void run() {


### PR DESCRIPTION
- Once webview is loaded, img tag with logo URL will be added to it and it is hidden by default.
- Now once the user clicks the share button already loaded hidden image will be displayed while taking a screenshot and then hidden again.
