### PR TITLE
Add buy now button in product preview

### DIFF
--- a/core/src/main/res/layout/course_preview_layout.xml
+++ b/core/src/main/res/layout/course_preview_layout.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    >
+
+
+    <com.facebook.shimmer.ShimmerFrameLayout
+        android:id="@+id/shimmer_view_container"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:visibility="gone"
+        app:shimmer_duration="1000">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:orientation="vertical"
+            >
+
+            <include
+                layout="@layout/testpress_list_placholder">
+            </include>
+            <include
+                layout="@layout/testpress_list_placholder">
+            </include>
+            <include
+                layout="@layout/testpress_list_placholder">
+            </include>
+            <include
+                layout="@layout/testpress_list_placholder">
+            </include>
+            <include
+                layout="@layout/testpress_list_placholder">
+            </include>
+            <include
+                layout="@layout/testpress_list_placholder">
+            </include>
+            <include
+                layout="@layout/testpress_list_placholder">
+            </include>
+            <include
+                layout="@layout/testpress_list_placholder">
+            </include>
+            <include
+                layout="@layout/testpress_list_placholder">
+            </include>
+
+        </LinearLayout>
+    </com.facebook.shimmer.ShimmerFrameLayout>
+
+
+
+    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        android:id="@+id/swipe_container"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_marginBottom="40dp">
+
+        <ListView
+            android:id="@android:id/list"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"/>
+
+        <com.google.android.material.floatingactionbutton.FloatingActionButton
+            android:id="@+id/fab"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="end|bottom"
+            android:src="@drawable/crown"
+            android:contentDescription="hello"
+            android:layout_alignParentBottom="true"
+            android:layout_margin="16dp" />
+    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+
+
+    <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/buy_button"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/testpress_orange"
+        android:layout_marginTop="20dp"
+        android:text="Buy Now"
+        android:gravity="center"
+        android:textAllCaps="true"
+        android:visibility="gone"
+        android:layout_centerHorizontal="true"
+        android:layout_alignParentBottom="true"
+        android:textColor="@color/testpress_white"
+        android:textSize="@dimen/testpress_text_size_xxlarge" />
+    <include
+        layout="@layout/testpress_empty_view">
+    </include>
+
+</RelativeLayout>

--- a/course/src/main/java/in/testpress/course/ui/ChaptersListFragment.java
+++ b/course/src/main/java/in/testpress/course/ui/ChaptersListFragment.java
@@ -1,6 +1,5 @@
 package in.testpress.course.ui;
 
-import android.content.Intent;
 import android.os.Bundle;
 import androidx.loader.content.Loader;
 
@@ -18,13 +17,12 @@ import in.testpress.core.TestpressSDKDatabase;
 import in.testpress.course.R;
 import in.testpress.course.pagers.ChapterPager;
 import in.testpress.course.api.TestpressCourseApiClient;
-import in.testpress.course.util.ProductUtils;
+import in.testpress.course.util.UIUtils;
 import in.testpress.models.greendao.Chapter;
 import in.testpress.models.greendao.ChapterDao;
 import in.testpress.models.greendao.Course;
 import in.testpress.models.greendao.CourseDao;
 import in.testpress.network.BaseResourcePager;
-import in.testpress.store.ui.ProductDetailsActivity;
 import in.testpress.ui.BaseDataBaseFragment;
 import in.testpress.util.SingleTypeAdapter;
 
@@ -86,21 +84,7 @@ public class ChaptersListFragment extends BaseDataBaseFragment<Chapter, Long> {
 
     private void displayBuyNowButton() {
         Button buyButton = requireView().findViewById(R.id.buy_button);
-        buyButton.setVisibility(View.VISIBLE);
-        if (ProductUtils.getPriceForProduct(productSlug, requireContext()) > 0.0) {
-            buyButton.setText(R.string.buy_now);
-        } else {
-            buyButton.setText(R.string.get_it_for_free);
-        }
-
-        buyButton.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View view) {
-                Intent intent = new Intent(requireContext(), ProductDetailsActivity.class);
-                intent.putExtra(ProductDetailsActivity.PRODUCT_SLUG, productSlug);
-                requireActivity().startActivity(intent);
-            }
-        });
+        UIUtils.displayBuyNowButton(buyButton, productSlug, requireContext());
     }
 
     @Override

--- a/course/src/main/java/in/testpress/course/ui/ChaptersListFragment.java
+++ b/course/src/main/java/in/testpress/course/ui/ChaptersListFragment.java
@@ -18,12 +18,11 @@ import in.testpress.core.TestpressSDKDatabase;
 import in.testpress.course.R;
 import in.testpress.course.pagers.ChapterPager;
 import in.testpress.course.api.TestpressCourseApiClient;
+import in.testpress.course.util.ProductUtils;
 import in.testpress.models.greendao.Chapter;
 import in.testpress.models.greendao.ChapterDao;
 import in.testpress.models.greendao.Course;
 import in.testpress.models.greendao.CourseDao;
-import in.testpress.models.greendao.Product;
-import in.testpress.models.greendao.ProductDao;
 import in.testpress.network.BaseResourcePager;
 import in.testpress.store.ui.ProductDetailsActivity;
 import in.testpress.ui.BaseDataBaseFragment;
@@ -32,7 +31,6 @@ import in.testpress.util.SingleTypeAdapter;
 import static in.testpress.course.TestpressCourse.COURSE_ID;
 import static in.testpress.course.TestpressCourse.PARENT_ID;
 import static in.testpress.course.TestpressCourse.PRODUCT_SLUG;
-import static in.testpress.store.TestpressStore.STORE_REQUEST_CODE;
 
 public class ChaptersListFragment extends BaseDataBaseFragment<Chapter, Long> {
 
@@ -87,19 +85,12 @@ public class ChaptersListFragment extends BaseDataBaseFragment<Chapter, Long> {
     }
 
     private void displayBuyNowButton() {
-        ProductDao productDao = TestpressSDKDatabase.getProductDao(getContext());
         Button buyButton = requireView().findViewById(R.id.buy_button);
         buyButton.setVisibility(View.VISIBLE);
-        List<Product> products = productDao.queryBuilder().where(ProductDao.Properties.Slug.eq(productSlug)).list();
-        if (!products.isEmpty()) {
-            Product product = products.get(0);
-            float price = Float.parseFloat(product.getCurrentPrice());
-
-            if (price > 0.0) {
-                buyButton.setText(R.string.buy_now);
-            } else {
-                buyButton.setText(R.string.get_it_for_free);
-            }
+        if (ProductUtils.getPriceForProduct(productSlug, requireContext()) > 0.0) {
+            buyButton.setText(R.string.buy_now);
+        } else {
+            buyButton.setText(R.string.get_it_for_free);
         }
 
         buyButton.setOnClickListener(new View.OnClickListener() {

--- a/course/src/main/java/in/testpress/course/ui/CoursePreviewFragment.java
+++ b/course/src/main/java/in/testpress/course/ui/CoursePreviewFragment.java
@@ -1,7 +1,6 @@
 package in.testpress.course.ui;
 
 import android.content.Context;
-import android.content.Intent;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -18,11 +17,9 @@ import java.util.List;
 import in.testpress.core.TestpressException;
 import in.testpress.core.TestpressSDKDatabase;
 import in.testpress.course.R;
-import in.testpress.course.util.ProductUtils;
+import in.testpress.course.util.UIUtils;
 import in.testpress.models.greendao.Course;
 import in.testpress.models.greendao.CourseDao;
-import in.testpress.models.greendao.ProductDao;
-import in.testpress.store.ui.ProductDetailsActivity;
 import in.testpress.ui.BaseListViewFragment;
 import in.testpress.util.SingleTypeAdapter;
 import in.testpress.util.ThrowableLoader;
@@ -63,22 +60,7 @@ public class CoursePreviewFragment extends BaseListViewFragment<Course> {
 
     private void displayBuyNowButton() {
         Button buyButton = requireView().findViewById(R.id.buy_button);
-        buyButton.setVisibility(View.VISIBLE);
-
-        if (ProductUtils.getPriceForProduct(productSlug, requireContext()) > 0.0) {
-            buyButton.setText(R.string.buy_now);
-        } else {
-            buyButton.setText(R.string.get_it_for_free);
-        }
-
-        buyButton.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View view) {
-                Intent intent = new Intent(requireContext(), ProductDetailsActivity.class);
-                intent.putExtra(ProductDetailsActivity.PRODUCT_SLUG, productSlug);
-                requireActivity().startActivity(intent);
-            }
-        });
+        UIUtils.displayBuyNowButton(buyButton, productSlug, requireContext());
     }
 
     @Override

--- a/course/src/main/java/in/testpress/course/ui/CoursePreviewFragment.java
+++ b/course/src/main/java/in/testpress/course/ui/CoursePreviewFragment.java
@@ -18,9 +18,9 @@ import java.util.List;
 import in.testpress.core.TestpressException;
 import in.testpress.core.TestpressSDKDatabase;
 import in.testpress.course.R;
+import in.testpress.course.util.ProductUtils;
 import in.testpress.models.greendao.Course;
 import in.testpress.models.greendao.CourseDao;
-import in.testpress.models.greendao.Product;
 import in.testpress.models.greendao.ProductDao;
 import in.testpress.store.ui.ProductDetailsActivity;
 import in.testpress.ui.BaseListViewFragment;
@@ -32,7 +32,6 @@ import static in.testpress.course.TestpressCourse.PRODUCT_SLUG;
 
 public class CoursePreviewFragment extends BaseListViewFragment<Course> {
     private CourseDao courseDao;
-    private ProductDao productDao;
     private List<Course> courses = new ArrayList<Course>();
     private ArrayList<Integer> courseIds;
     private String productSlug;
@@ -42,7 +41,6 @@ public class CoursePreviewFragment extends BaseListViewFragment<Course> {
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         courseDao = TestpressSDKDatabase.getCourseDao(getActivity());
-        productDao = TestpressSDKDatabase.getProductDao(getContext());
         Bundle bundle = this.getArguments();
         if (bundle != null) {
             courseIds = bundle.getIntegerArrayList(COURSE_IDS);
@@ -66,16 +64,11 @@ public class CoursePreviewFragment extends BaseListViewFragment<Course> {
     private void displayBuyNowButton() {
         Button buyButton = requireView().findViewById(R.id.buy_button);
         buyButton.setVisibility(View.VISIBLE);
-        List<Product> products = productDao.queryBuilder().where(ProductDao.Properties.Slug.eq(productSlug)).list();
-        if (!products.isEmpty()) {
-            Product product = products.get(0);
-            float price = Float.parseFloat(product.getCurrentPrice());
 
-            if (price > 0.0) {
-                buyButton.setText(R.string.buy_now);
-            } else {
-                buyButton.setText(R.string.get_it_for_free);
-            }
+        if (ProductUtils.getPriceForProduct(productSlug, requireContext()) > 0.0) {
+            buyButton.setText(R.string.buy_now);
+        } else {
+            buyButton.setText(R.string.get_it_for_free);
         }
 
         buyButton.setOnClickListener(new View.OnClickListener() {

--- a/course/src/main/java/in/testpress/course/util/ProductUtils.kt
+++ b/course/src/main/java/in/testpress/course/util/ProductUtils.kt
@@ -1,0 +1,20 @@
+package `in`.testpress.course.util
+
+import `in`.testpress.core.TestpressSDKDatabase
+import `in`.testpress.models.greendao.ProductDao
+import android.content.Context
+
+object ProductUtils {
+    @JvmStatic
+    fun getPriceForProduct(slug: String, context: Context): Float {
+        val productDao = TestpressSDKDatabase.getProductDao(context)
+        val products = productDao.queryBuilder()
+            .where(ProductDao.Properties.Slug.eq(slug)).list()
+
+        if (products.isNotEmpty()) {
+            return products[0].currentPrice.toFloat()
+        }
+
+        return 0.0F
+    }
+}

--- a/course/src/main/java/in/testpress/course/util/UIUtils.kt
+++ b/course/src/main/java/in/testpress/course/util/UIUtils.kt
@@ -1,0 +1,28 @@
+package `in`.testpress.course.util
+
+import `in`.testpress.course.R
+import `in`.testpress.course.util.ProductUtils.getPriceForProduct
+import `in`.testpress.store.ui.ProductDetailsActivity
+import android.content.Context
+import android.content.Intent
+import android.view.View
+import android.widget.Button
+
+object UIUtils {
+    @JvmStatic
+    fun displayBuyNowButton(button: Button, productSlug: String, context: Context) {
+        button.visibility = View.VISIBLE
+
+        if (getPriceForProduct(productSlug, context) > 0.0) {
+            button.setText(R.string.buy_now)
+        } else {
+            button.setText(R.string.get_it_for_free)
+        }
+
+        button.setOnClickListener {
+            val intent = Intent(context, ProductDetailsActivity::class.java)
+            intent.putExtra(ProductDetailsActivity.PRODUCT_SLUG, productSlug)
+            context.startActivity(intent)
+        }
+    }
+}

--- a/course/src/main/res/values/strings.xml
+++ b/course/src/main/res/values/strings.xml
@@ -47,6 +47,8 @@
     <string name="available_courses_title">Available Courses</string>
     <string name="no_products_available">No Products Available</string>
     <string name="check_again_later">Please check again later</string>
+    <string name="buy_now">Buy Now</string>
+    <string name="get_it_for_free">Get it for free</string>
 
     <string-array name="exo_speed_values">
         <item>0.5</item>

--- a/course/src/test/java/in/testpress/course/util/ProductUtilsTest.kt
+++ b/course/src/test/java/in/testpress/course/util/ProductUtilsTest.kt
@@ -1,0 +1,53 @@
+package `in`.testpress.course.util
+
+import `in`.testpress.core.TestpressSDKDatabase
+import `in`.testpress.models.greendao.Product
+import `in`.testpress.models.greendao.ProductDao
+import android.content.Context
+import org.greenrobot.greendao.query.QueryBuilder
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mock
+import org.mockito.Mockito
+import org.powermock.api.mockito.PowerMockito.`when`
+import org.powermock.api.mockito.PowerMockito.mockStatic
+import org.powermock.core.classloader.annotations.PrepareForTest
+import org.powermock.modules.junit4.PowerMockRunner
+
+@RunWith(PowerMockRunner::class)
+@PrepareForTest(TestpressSDKDatabase::class)
+class ProductUtilsTest {
+    @Mock
+    lateinit var context: Context
+    private val productDao = Mockito.mock(ProductDao::class.java)
+    @Mock
+    lateinit var queryBuilder: QueryBuilder<Product>
+
+    @Before
+    fun setUp() {
+        mockStatic(TestpressSDKDatabase::class.java)
+        `when`(TestpressSDKDatabase.getProductDao(any())).thenReturn(productDao)
+        `when`(productDao.queryBuilder()).thenReturn(queryBuilder)
+        `when`(
+            productDao.queryBuilder().where(ArgumentMatchers.any())
+        ).thenReturn(queryBuilder)
+    }
+
+    @Test
+    fun getPriceForProductShouldReturnPriceInFloatForMatchingProduct() {
+        val product = Product(1)
+        product.currentPrice = "4.1"
+        `when`(productDao.queryBuilder().list()).thenReturn(listOf(product))
+
+        assert(ProductUtils.getPriceForProduct("a", context) == product.currentPrice.toFloat())
+    }
+
+    @Test
+    fun getPriceForProductShouldReturnZeroIfProductIsNotFound() {
+        `when`(productDao.queryBuilder().list()).thenReturn(listOf())
+        assert(ProductUtils.getPriceForProduct("a", context) == 0.0f)
+    }
+}


### PR DESCRIPTION
### Changes done
- In course products/store to buy a product, a user has to click course and navigate to premium content and then click it.
- The above process is time-consuming, so buy now button is added to the bottom of the course/chapter/contents list in product preview.
