### PR TITLE
Fix Video is not playing with transcoded URL

### DIFF
--- a/course/src/main/java/in/testpress/course/network/NetworkStreams.kt
+++ b/course/src/main/java/in/testpress/course/network/NetworkStreams.kt
@@ -12,3 +12,9 @@ data class NetworkStream(
 fun NetworkStream.asGreenDaoModel(): Stream {
     return Stream(this.id, this.format, this.url, this.videoId)
 }
+
+fun List<NetworkStream>.asGreenDaoModel(): List<Stream> {
+    return this.map {
+        it.asGreenDaoModel()
+    }
+}

--- a/course/src/main/java/in/testpress/course/repository/ContentRepository.kt
+++ b/course/src/main/java/in/testpress/course/repository/ContentRepository.kt
@@ -132,6 +132,9 @@ open class ContentRepository(
             val video = it.asGreenDaoModel()
             greenDaoContent.videoId = video.id
             videoDao.insertOrReplace(it.asGreenDaoModel())
+            val streamDao = TestpressSDKDatabase.getStreamDao(context)
+            val streams = it.streams.asGreenDaoModel()
+            streamDao.insertOrReplaceInTx(streams)
         }
         content.attachment?.let {
             val attachmentDao = TestpressSDKDatabase.getAttachmentDao(context)


### PR DESCRIPTION
### Changes done
- If content detail fragment is accessed directly, then it will fetch that content detail and store that content and its relations in DB. But streams are not being stored.
- So the video is playing in the original resolution
- This is fixed by storing streams

