### PR TITLE
Fix NullPointerException in email marquee in exoplayer

### DIFF
--- a/course/src/main/java/in/testpress/course/util/ExoPlayerUtil.java
+++ b/course/src/main/java/in/testpress/course/util/ExoPlayerUtil.java
@@ -474,6 +474,7 @@ public class ExoPlayerUtil {
     }
 
     private void startOverlayMarquee() {
+        if (emailIdLayout == null) return;
         Animation marquee = AnimationUtils.loadAnimation(activity, R.anim.testpress_marquee);
         emailIdLayout.startAnimation(marquee);
     }

--- a/course/src/main/java/in/testpress/course/util/ExoPlayerUtil.java
+++ b/course/src/main/java/in/testpress/course/util/ExoPlayerUtil.java
@@ -145,6 +145,8 @@ public class ExoPlayerUtil {
         this.exoPlayerMainFrame = exoPlayerMainFrame;
         this.url = url;
         this.startPosition = startPosition;
+
+        initializeViews();
         exoPlayerLayout = exoPlayerMainFrame.findViewById(R.id.exo_player_layout);
         playerView = exoPlayerMainFrame.findViewById(R.id.exo_player_view);
         fullscreenIcon = exoPlayerMainFrame.findViewById(R.id.exo_fullscreen_icon);
@@ -206,6 +208,12 @@ public class ExoPlayerUtil {
         this(activity, exoPlayerMainFrame, url, startPosition);
         this.playWhenReady = playWhenReady;
         setSpeedRate(speedRate);
+    }
+
+
+    private void initializeViews() {
+        emailIdTextView = exoPlayerMainFrame.findViewById(R.id.email_id);
+        emailIdLayout = exoPlayerMainFrame.findViewById(R.id.email_id_layout);
     }
 
     private void initFullscreenDialog() {
@@ -466,15 +474,12 @@ public class ExoPlayerUtil {
         } else {
             overlayText = profileDetails.getUsername();
         }
-        emailIdTextView = exoPlayerMainFrame.findViewById(R.id.email_id);
         emailIdTextView.setText(overlayText);
-        emailIdLayout = exoPlayerMainFrame.findViewById(R.id.email_id_layout);
         overlayPositionHandler = new Handler();
         startOverlayMarquee();
     }
 
     private void startOverlayMarquee() {
-        if (emailIdLayout == null) return;
         Animation marquee = AnimationUtils.loadAnimation(activity, R.anim.testpress_marquee);
         emailIdLayout.startAnimation(marquee);
     }


### PR DESCRIPTION
### Changes done
- User's email address will be shown in marquee animation in exoplayer
- During first time, the user's email address will not be available so we will fetch it and then initialize view and then start marquee animation.
- When orientation is changed, we will again start marquee animation as it will be stopped. But if orientation is changed before fetching user details, then view won't be initialized so trying to start marquee animation will result in error


