### PR TITLE
Fix image click not working in review questions

### DIFF
--- a/core/src/main/assets/TestpressImageTagHandler.js
+++ b/core/src/main/assets/TestpressImageTagHandler.js
@@ -1,12 +1,6 @@
 // Set click listeners to the images in the html content to display the images as zoomable
 var images = document.getElementsByTagName("img");
 for (i = 0; i < images.length; i++) {
-   images[i].onclick = (
-       function() {
-           var src = images[i].src;
-           return function() {
-               ImageHandler.onClickImage(src);
-           }
-       }
-   )();
+    var src = images[i].src;
+    images[i].setAttribute('onclick','ImageHandler.onClickImage(src)');
 }


### PR DESCRIPTION
### Changes done
- In review questions, clicking image is not opening it.

