### PR TITLE
Turn watermark upside down in review and attempt

### DIFF
--- a/core/src/main/assets/TestpressReview.js
+++ b/core/src/main/assets/TestpressReview.js
@@ -49,5 +49,5 @@ function hideLogo() {
 
 function addWatermark(logoUrl) {
     document.body.pseudoStyle("before", "background-image", `url(${logoUrl})`);
-    document.body.classList.add("review-watermark");
+    document.body.classList.add("watermark");
 }

--- a/core/src/main/assets/testpress_questions_typebase.css
+++ b/core/src/main/assets/testpress_questions_typebase.css
@@ -401,26 +401,12 @@ body.watermark::before {
     width: 100%;
     height: 100%;
     opacity: 0.1;
-    top: -50%;
-    left: -50%;
+    height: 200px;
     z-index: 999;
-    transform: translateY(60%) rotate(45deg);
+    transform: translateY(30%) rotate(-45deg);
     background-repeat: no-repeat;
-    background-size: contain;
+    transform-origin: bottom right;
+    background-size: 95%;
+    background-position: center;
     overflow: hidden;
-}
-
-body.review-watermark::before {
-    content: "";
-    position: absolute;
-    width: 100%;
-    height: 400px;
-    opacity: 0.1;
-    left: -30%;
-    z-index: 999;
-    transform: translateY(30%) rotate(45deg);
-    background-repeat: no-repeat;
-    background-size: contain;
-    overflow: hidden;
-    display: block;
 }


### PR DESCRIPTION
### Changes done
- Rotated watermark such that logo's start will come at bottom left and will end at top right
- Since the above changes can be done for both review and attempt questions with single CSS class itself, `review-watermark` class is removed
