### PR TITLE
Remove fetching chapter detail API from chapters list screen

### DIFF
--- a/course/src/main/java/in/testpress/course/ui/ChapterDetailActivity.java
+++ b/course/src/main/java/in/testpress/course/ui/ChapterDetailActivity.java
@@ -141,13 +141,7 @@ public class ChapterDetailActivity extends BaseToolBarActivity {
         List<Chapter> chapters = TestpressSDKDatabase.getChapterDao(this).queryBuilder()
                 .where(ChapterDao.Properties.Url.eq(chapterUrl)).list();
 
-        if (chapters.isEmpty() ||
-                (!chapters.get(0).hasChildren() && !chapters.get(0).hasContents())) {
-
-            if (!chapters.isEmpty()) {
-                //noinspection ConstantConditions
-                getSupportActionBar().setTitle(chapters.get(0).getName());
-            }
+        if (chapters.isEmpty()) {
             loadChapterFromServer(chapterUrl);
         } else {
             onChapterLoaded(chapters.get(0));
@@ -256,14 +250,11 @@ public class ChapterDetailActivity extends BaseToolBarActivity {
             getIntent().putExtra(PARENT_ID, chapter.getId().toString());
             getIntent().putExtra(PRODUCT_SLUG, productSlug);
             loadChildChapters();
-        } else if (chapter.hasContents()) {
+        } else  {
             getIntent().putExtra(CONTENTS_URL_FRAG, chapter.getChapterContentsUrl());
             getIntent().putExtra(CHAPTER_ID, chapter.getId());
             getIntent().putExtra(PRODUCT_SLUG, productSlug);
             loadContents();
-        } else {
-            setEmptyText(R.string.testpress_no_content,
-                    R.string.testpress_no_content_description);
         }
     }
 

--- a/course/src/main/java/in/testpress/course/ui/ContentsListFragment.java
+++ b/course/src/main/java/in/testpress/course/ui/ContentsListFragment.java
@@ -148,6 +148,10 @@ public class ContentsListFragment extends BaseListViewFragment<Content> {
         deleteContents(chapterId);
         contentDao.insertOrReplaceInTx(contents);
         getListAdapter().notifyDataSetChanged();
+
+        if (isItemsEmpty()) {
+            setEmptyText();
+        }
         showList();
     }
 


### PR DESCRIPTION
### Changes done
- Earlier on clicking the chapter, we will fetch chapter detail to know if that chapter has children or content.
- But now as we get all chapters of those courses including children in chapters list itself we don't need to fetch chapter detail page. We can simply conclude that if the chapter has children then we should show sub-chapters or else we should show contents list.

