### PR TITLE
Refactor quiz attempts list

### DIFF
--- a/course/src/main/java/in/testpress/course/fragments/QuizAttemptsList.kt
+++ b/course/src/main/java/in/testpress/course/fragments/QuizAttemptsList.kt
@@ -1,13 +1,45 @@
 package `in`.testpress.course.fragments
 
 import `in`.testpress.course.R
+import `in`.testpress.course.domain.DomainContent
 import `in`.testpress.course.domain.DomainContentAttempt
+import `in`.testpress.course.domain.getGreenDaoContent
+import `in`.testpress.course.domain.getGreenDaoContentAttempts
+import `in`.testpress.course.enums.Status
+import `in`.testpress.course.repository.ExamContentRepository
+import `in`.testpress.course.ui.ContentActivity
+import `in`.testpress.course.ui.ContentAttemptListAdapter
+import `in`.testpress.course.viewmodels.ExamContentViewModel
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.Observer
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
 
-class QuizAttemptsList : AttemptsListFragment() {
+
+class QuizAttemptsList : Fragment() {
+    private lateinit var viewModel: ExamContentViewModel
+    private lateinit var content: DomainContent
+    private var contentId: Long = -1
+    lateinit var contentAttempts: ArrayList<DomainContentAttempt>
+    private lateinit var attemptList: RecyclerView
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        viewModel = ViewModelProvider(this, object : ViewModelProvider.Factory {
+            override fun <T : ViewModel> create(modelClass: Class<T>): T {
+                return ExamContentViewModel(
+                    ExamContentRepository(context!!)
+                ) as T
+            }
+        }).get(ExamContentViewModel::class.java)
+    }
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -16,8 +48,43 @@ class QuizAttemptsList : AttemptsListFragment() {
         return inflater.inflate(R.layout.quiz_attempts_list_view, container, false)
     }
 
-    override fun updateStartButton(contentAttempts: ArrayList<DomainContentAttempt>) {
-        startButton.visibility = View.GONE
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        contentId = requireArguments().getLong(ContentActivity.CONTENT_ID)
+        attemptList = view.findViewById(R.id.attempt_list)
+
+        viewModel.getContent(contentId).observe(viewLifecycleOwner, Observer {
+            when (it?.status) {
+                Status.SUCCESS -> {
+                    content = it.data!!
+                    loadAttempts()
+                }
+            }
+        })
     }
 
+    private fun loadAttempts() {
+        val url = content.attemptsUrl ?: "/api/v2.3/contents/${content.id}/attempts/"
+        viewModel.loadContentAttempts(url, contentId)
+            .observe(viewLifecycleOwner, Observer { resource ->
+                when (resource.status) {
+                    Status.SUCCESS -> {
+                        contentAttempts = resource.data!!
+                        display()
+                    }
+                }
+            })
+    }
+
+    fun display() {
+        val greenDaoContent = content.getGreenDaoContent(requireContext())
+        val attempts = content.getGreenDaoContentAttempts(requireContext())
+        attemptList.apply {
+            isNestedScrollingEnabled = false
+            layoutManager = LinearLayoutManager(activity)
+            adapter = ContentAttemptListAdapter(activity, greenDaoContent, attempts.reversed())
+            visibility = View.VISIBLE
+        }
+        attemptList.setHasFixedSize(true)
+    }
 }

--- a/course/src/main/res/layout/quiz_attempts_list_view.xml
+++ b/course/src/main/res/layout/quiz_attempts_list_view.xml
@@ -2,7 +2,6 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/testpress_blue"
     android:orientation="vertical">
 
     <androidx.recyclerview.widget.RecyclerView

--- a/course/src/main/res/layout/quiz_attempts_list_view.xml
+++ b/course/src/main/res/layout/quiz_attempts_list_view.xml
@@ -2,37 +2,8 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    xmlns:tools="http://schemas.android.com/tools"
+    android:background="@color/testpress_blue"
     android:orientation="vertical">
-
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:orientation="vertical"
-        android:paddingTop="20dp"
-        tools:ignore="ScrollViewSize">
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_gravity="bottom">
-
-            <androidx.appcompat.widget.AppCompatButton
-                android:id="@+id/start_exam"
-                android:layout_width="match_parent"
-                android:layout_height="37dp"
-                android:layout_marginLeft="20dp"
-                android:layout_marginTop="20dp"
-                android:layout_marginRight="20dp"
-                android:layout_marginBottom="30dp"
-                android:background="@drawable/testpress_green_curved_edge_background"
-                android:gravity="center"
-                android:visibility="gone"
-                android:text="@string/testpress_start"
-                android:textColor="@android:color/white"
-                android:textSize="16sp" />
-        </LinearLayout>
-    </LinearLayout>
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/attempt_list"


### PR DESCRIPTION
- Problem is for exam we will show either start screen or attempts list screen. And both these screens will have start button. So we have BaseExamWidgetFragment which will have a start button. Exam Start screen and exam attempts screen will inherit from this BaseExamWidgetFragment.
- Now for the quiz we are going to show both start view and attempts list in same screen. So earlier we reused the exam attempts list and hidden the start button alone.
- But as logic to display attempts list is very small we can write separate quiz attempts list instead of reusing exams attempts list and hiding start button
- This was it will be more straight forward.