### PR TITLE
Fix paid quiz can be taken without purchase

### DIFF
--- a/course/src/main/java/in/testpress/course/repository/QuizExamRepository.kt
+++ b/course/src/main/java/in/testpress/course/repository/QuizExamRepository.kt
@@ -47,16 +47,16 @@ open class QuizExamRepository(val context: Context) {
                     if (exception?.isForbidden == true) {
                         _resourceContentAttempt.postValue(Resource.error(exception, null))
                     } else {
-                        val contentAttempt = loadAttemptFromDB(contentId)
-                        _resourceContentAttempt.postValue(Resource.success(contentAttempt.asDomainContentAttempt()))
+                        loadAttemptFromDB(contentId)
                     }
                 }
             })
         return resourceContentAttempt
     }
 
-    fun loadAttemptFromDB(contentId: Long): CourseAttempt {
-        return getRunningAttemptFromDB(contentId) ?: createLocalContentAttempt(contentId)
+    fun loadAttemptFromDB(contentId: Long) {
+        val contentAttempt = getRunningAttemptFromDB(contentId) ?: createLocalContentAttempt(contentId)
+        _resourceContentAttempt.postValue(Resource.success(contentAttempt.asDomainContentAttempt()))
     }
 
     private fun getRunningAttemptFromDB(contentId: Long): CourseAttempt? {

--- a/course/src/main/java/in/testpress/course/repository/QuizExamRepository.kt
+++ b/course/src/main/java/in/testpress/course/repository/QuizExamRepository.kt
@@ -47,7 +47,7 @@ open class QuizExamRepository(val context: Context) {
                     if (exception?.isNetworkError == true) {
                         loadAttemptFromDB(contentId)
                     } else {
-                        _resourceContentAttempt.postValue(Resource.error(exception, null))
+                        _resourceContentAttempt.postValue(Resource.error(exception!!, null))
                     }
                 }
             })

--- a/course/src/main/java/in/testpress/course/repository/QuizExamRepository.kt
+++ b/course/src/main/java/in/testpress/course/repository/QuizExamRepository.kt
@@ -44,10 +44,10 @@ open class QuizExamRepository(val context: Context) {
                 }
 
                 override fun onException(exception: TestpressException?) {
-                    if (exception?.isForbidden == true) {
-                        _resourceContentAttempt.postValue(Resource.error(exception, null))
-                    } else {
+                    if (exception?.isNetworkError == true) {
                         loadAttemptFromDB(contentId)
+                    } else {
+                        _resourceContentAttempt.postValue(Resource.error(exception, null))
                     }
                 }
             })

--- a/course/src/main/java/in/testpress/course/repository/QuizExamRepository.kt
+++ b/course/src/main/java/in/testpress/course/repository/QuizExamRepository.kt
@@ -44,8 +44,12 @@ open class QuizExamRepository(val context: Context) {
                 }
 
                 override fun onException(exception: TestpressException?) {
-                    val contentAttempt = loadAttemptFromDB(contentId)
-                    _resourceContentAttempt.postValue(Resource.success(contentAttempt.asDomainContentAttempt()))
+                    if (exception?.isForbidden == true) {
+                        _resourceContentAttempt.postValue(Resource.error(exception, null))
+                    } else {
+                        val contentAttempt = loadAttemptFromDB(contentId)
+                        _resourceContentAttempt.postValue(Resource.success(contentAttempt.asDomainContentAttempt()))
+                    }
                 }
             })
         return resourceContentAttempt


### PR DESCRIPTION
- To make quiz exams offline first, when an exception occurs we will use or create a local attempt.
- But we should use or create local attempt only for network error.
- All other exceptions should be handled