### PR TITLE
Make track selection dialog reusable for both player and download

### DIFF
--- a/course/src/main/java/in/testpress/course/util/ExoPlayerUtil.java
+++ b/course/src/main/java/in/testpress/course/util/ExoPlayerUtil.java
@@ -661,4 +661,14 @@ public class ExoPlayerUtil {
         }
     }
 
+    public static int getRendererIndex(int trackType, MappingTrackSelector.MappedTrackInfo mappedTrackInfo) {
+        for (int i=0; i < mappedTrackInfo.getRendererCount(); i++) {
+            if (mappedTrackInfo.getRendererType(i) == trackType) {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
 }

--- a/course/src/main/java/in/testpress/course/util/ExoPlayerUtil.java
+++ b/course/src/main/java/in/testpress/course/util/ExoPlayerUtil.java
@@ -4,6 +4,7 @@ import android.app.Activity;
 import android.app.Dialog;
 import android.content.BroadcastReceiver;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.pm.ActivityInfo;
@@ -93,6 +94,7 @@ public class ExoPlayerUtil {
     private SimpleExoPlayer player;
     private ImageView fullscreenIcon;
     private Dialog fullscreenDialog;
+    private TrackSelectionDialog trackSelectionDialog;
 
 
     private Activity activity;
@@ -132,6 +134,7 @@ public class ExoPlayerUtil {
     AudioManager audioManager;
     AudioManager.OnAudioFocusChangeListener audioFocusChangeListener;
     private DefaultTrackSelector trackSelector;
+    private DialogInterface.OnClickListener dialogOnClickListener;
 
     public ExoPlayerUtil(Activity activity, FrameLayout exoPlayerMainFrame, String url,
                          float startPosition) {
@@ -250,7 +253,8 @@ public class ExoPlayerUtil {
                                     && mappedTrackInfo.getTypeSupport(C.TRACK_TYPE_VIDEO)
                                     == MappingTrackSelector.MappedTrackInfo.RENDERER_SUPPORT_NO_TRACKS);
 
-                    TrackSelectionDialog trackSelectionDialog = new TrackSelectionDialog(trackSelector);
+                    trackSelectionDialog = new TrackSelectionDialog(trackSelector);
+                    trackSelectionDialog.setOnClickListener(trackSelectionListener());
                     trackSelectionDialog.show(((AppCompatActivity)activity).getSupportFragmentManager(), null);
                 }
             }
@@ -305,6 +309,23 @@ public class ExoPlayerUtil {
         }
 
         addPlayPauseOnClickListener();
+    }
+
+    private DialogInterface.OnClickListener trackSelectionListener() {
+        if (dialogOnClickListener == null) {
+            dialogOnClickListener = new DialogInterface.OnClickListener() {
+                @Override
+                public void onClick(DialogInterface dialog, int which) {
+                    MappingTrackSelector.MappedTrackInfo mappedTrackInfo = trackSelector.getCurrentMappedTrackInfo();
+                    int rendererIndex = getRendererIndex(C.TRACK_TYPE_VIDEO, mappedTrackInfo);
+                    DefaultTrackSelector.ParametersBuilder parametersBuilder = trackSelector.buildUponParameters();
+                    parametersBuilder.clearSelectionOverrides(rendererIndex)
+                            .setSelectionOverride(rendererIndex, mappedTrackInfo.getTrackGroups(rendererIndex), trackSelectionDialog.getOverrides().get(0));
+                }
+            };
+        }
+
+        return dialogOnClickListener;
     }
 
     private void addPlayPauseOnClickListener() {

--- a/course/src/main/java/in/testpress/course/util/TrackSelectionDialog.kt
+++ b/course/src/main/java/in/testpress/course/util/TrackSelectionDialog.kt
@@ -13,7 +13,6 @@ import com.google.android.exoplayer2.C
 import com.google.android.exoplayer2.trackselection.DefaultTrackSelector
 import com.google.android.exoplayer2.trackselection.MappingTrackSelector
 import com.google.android.exoplayer2.ui.TrackSelectionView
-import com.google.android.exoplayer2.util.Assertions
 import kotlinx.android.synthetic.main.track_selection_dialog.*
 
 class TrackSelectionDialog(
@@ -24,7 +23,7 @@ class TrackSelectionDialog(
 
     private lateinit var trackSelectionView: TrackSelectionView
     private var allowAdaptiveSelections = false
-    private val rendererIndex = ExoPlayerUtil.getRendererIndex(C.TRACK_TYPE_VIDEO)
+    private val rendererIndex = ExoPlayerUtil.getRendererIndex(C.TRACK_TYPE_VIDEO, mappedTrackInfo)
     private val trackGroup = mappedTrackInfo.getTrackGroups(rendererIndex)
     var overrides: List<DefaultTrackSelector.SelectionOverride>
     var onClickListener: DialogInterface.OnClickListener? = null

--- a/course/src/main/java/in/testpress/course/util/TrackSelectionDialog.kt
+++ b/course/src/main/java/in/testpress/course/util/TrackSelectionDialog.kt
@@ -2,6 +2,7 @@ package `in`.testpress.course.util
 
 import `in`.testpress.course.R
 import android.app.Dialog
+import android.content.DialogInterface
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -10,20 +11,28 @@ import androidx.appcompat.app.AppCompatDialog
 import androidx.fragment.app.DialogFragment
 import com.google.android.exoplayer2.C
 import com.google.android.exoplayer2.trackselection.DefaultTrackSelector
+import com.google.android.exoplayer2.trackselection.MappingTrackSelector
 import com.google.android.exoplayer2.ui.TrackSelectionView
 import com.google.android.exoplayer2.util.Assertions
 import kotlinx.android.synthetic.main.track_selection_dialog.*
 
-class TrackSelectionDialog(private val trackSelector: DefaultTrackSelector) : DialogFragment(),
+class TrackSelectionDialog(
+    private val parameters: DefaultTrackSelector.Parameters,
+    val mappedTrackInfo: MappingTrackSelector.MappedTrackInfo
+) : DialogFragment(),
     TrackSelectionView.TrackSelectionListener {
 
     private lateinit var trackSelectionView: TrackSelectionView
     private var allowAdaptiveSelections = false
-    private val parameters = trackSelector.parameters
-    private val mappedTrackInfo = Assertions.checkNotNull(trackSelector.currentMappedTrackInfo)
-    private val rendererIndex = getRendererIndex(C.TRACK_TYPE_VIDEO)
+    private val rendererIndex = ExoPlayerUtil.getRendererIndex(C.TRACK_TYPE_VIDEO)
     private val trackGroup = mappedTrackInfo.getTrackGroups(rendererIndex)
-    private var overrides: List<DefaultTrackSelector.SelectionOverride>
+    var overrides: List<DefaultTrackSelector.SelectionOverride>
+    var onClickListener: DialogInterface.OnClickListener? = null
+
+    constructor(trackSelector: DefaultTrackSelector) : this(
+        trackSelector.parameters,
+        trackSelector.currentMappedTrackInfo!!
+    )
 
     init {
         val selectionOverrides = parameters.getSelectionOverride(rendererIndex, trackGroup)
@@ -58,35 +67,13 @@ class TrackSelectionDialog(private val trackSelector: DefaultTrackSelector) : Di
         trackSelectionView.init(mappedTrackInfo, rendererIndex, false, overrides, this)
     }
 
-    private fun getRendererIndex(trackType: Int): Int {
-        for (rendererIndex in 0 until mappedTrackInfo.rendererCount) {
-            if (mappedTrackInfo.getRendererType(rendererIndex) == trackType) {
-                return rendererIndex
-            }
-        }
-
-        return -1
-    }
-
     private fun setOnClickListeners() {
         okButton.setOnClickListener {
-            changeSelectedTrack()
+            onClickListener?.onClick(dialog, DialogInterface.BUTTON_POSITIVE)
             dismiss()
         }
 
         cancelButton.setOnClickListener { dismiss() }
-    }
-
-    private fun changeSelectedTrack() {
-        val parametersBuilder = parameters.buildUpon()
-        parametersBuilder
-            .clearSelectionOverrides(rendererIndex)
-            .setSelectionOverride(
-                rendererIndex,
-                mappedTrackInfo.getTrackGroups(rendererIndex),
-                overrides[0]
-            )
-        trackSelector.setParameters(parametersBuilder)
     }
 
     fun setAllowAdaptiveSelections(allow: Boolean) {


### PR DESCRIPTION
### Changes done
Right now track selection dialog box can be used only by the player, but for downloading also we need track selection dialog box

The Download APIs of ExoPlayer won't expose TrackSelection handle. They only give the parameters and mappedTrackInfo

So instead of passing trackselector we can pass only parameters and mappedTrackinfo to Track Selection Dialog.
 
In addition to this, the On click of track selection box is changed as an interface. This is done so that upper layer can implement it as per requirements.

