### PR TITLE
Add support to update download details to offline video

### DIFF
--- a/course/src/main/java/in/testpress/course/fragments/VideoContentFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/VideoContentFragment.kt
@@ -73,7 +73,7 @@ class VideoContentFragment : BaseContentDetailFragment() {
             VideoDownloadQualityChooserDialog(content)
         videoQualityChooserDialog.show(childFragmentManager, null)
         videoQualityChooserDialog.setOnSubmitListener {downloadRequest ->
-            DownloadTask(downloadRequest.uri.toString(), requireContext()).start(downloadRequest)
+            DownloadTask(downloadRequest.uri.toString(), requireContext()).start(downloadRequest, content)
         }
     }
 

--- a/course/src/main/java/in/testpress/course/helpers/VideoDownloadMonitor.kt
+++ b/course/src/main/java/in/testpress/course/helpers/VideoDownloadMonitor.kt
@@ -1,0 +1,65 @@
+package `in`.testpress.course.helpers
+
+import android.os.Handler
+import com.google.android.exoplayer2.offline.Download
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlin.coroutines.CoroutineContext
+
+class VideoDownloadMonitor() : CoroutineScope {
+    override val coroutineContext: CoroutineContext
+        get() = Dispatchers.IO
+
+    var downloadProgressUpdateHandler = Handler()
+    private val runnable: Runnable
+    var callback: Callback? = null
+
+    init {
+        runnable = Runnable {
+            update()
+        }
+    }
+
+    fun start() {
+        downloadProgressUpdateHandler.postDelayed(runnable, 1000)
+    }
+
+    fun stop() {
+        downloadProgressUpdateHandler.removeCallbacks(runnable)
+        downloadProgressUpdateHandler.removeCallbacksAndMessages(null)
+    }
+
+    fun deleteVideo(download: Download) {
+        launch {
+            callback?.onDelete(download)
+        }
+    }
+
+    fun updateVideoProgress(download: Download) {
+        launch {
+            callback?.onUpdate(download)
+        }
+    }
+
+    private fun update() {
+        launch {
+            withContext(Dispatchers.IO) {
+                callback?.onCurrentDownloadsUpdate()
+                downloadProgressUpdateHandler.removeCallbacks(runnable)
+                downloadProgressUpdateHandler.removeCallbacksAndMessages(null)
+            }
+        }
+    }
+
+    fun isRunning(): Boolean {
+        return downloadProgressUpdateHandler.hasCallbacks(runnable)
+    }
+
+    interface Callback {
+        suspend fun onCurrentDownloadsUpdate()
+        suspend fun onUpdate(download: Download)
+        suspend fun onDelete(download: Download)
+    }
+}

--- a/course/src/main/java/in/testpress/course/repository/OfflineVideoRepository.kt
+++ b/course/src/main/java/in/testpress/course/repository/OfflineVideoRepository.kt
@@ -1,0 +1,32 @@
+package `in`.testpress.course.repository
+
+import `in`.testpress.course.helpers.VideoDownloadManager
+import `in`.testpress.database.TestpressDatabase
+import android.content.Context
+import com.google.android.exoplayer2.offline.Download
+
+class OfflineVideoRepository(val context: Context) {
+    private val offlineVideoDao = TestpressDatabase(context).offlineVideoDao()
+    val offlineVideos = offlineVideoDao.getAll()
+    private val downloadManager = VideoDownloadManager(context).get()
+
+    fun updateOfflineVideoDownloadStatus() {
+        for (download in downloadManager.currentDownloads) {
+            updateOfflineVideoDownloadStatus(download)
+        }
+    }
+
+    fun updateOfflineVideoDownloadStatus(download: Download) {
+        val offlineVideo = offlineVideoDao.getByUrl(download.request.uri.toString())
+        offlineVideo?.let {
+            offlineVideo.percentageDownloaded = download.percentDownloaded.toInt()
+            offlineVideo.bytesDownloaded = download.bytesDownloaded
+            offlineVideo.totalSize = download.contentLength
+            offlineVideoDao.insert(offlineVideo)
+        }
+    }
+
+    fun deleteOfflineVideo(download: Download) {
+        offlineVideoDao.deleteByUrl(download.request.uri.toString())
+    }
+}

--- a/course/src/main/java/in/testpress/course/repository/OfflineVideoRepository.kt
+++ b/course/src/main/java/in/testpress/course/repository/OfflineVideoRepository.kt
@@ -10,7 +10,7 @@ class OfflineVideoRepository(val context: Context) {
     val offlineVideos = offlineVideoDao.getAll()
     private val downloadManager = VideoDownloadManager(context).get()
 
-    fun updateOfflineVideoDownloadStatus() {
+    fun refreshCurrentDownloadsProgress() {
         for (download in downloadManager.currentDownloads) {
             updateOfflineVideoDownloadStatus(download)
         }

--- a/course/src/main/java/in/testpress/course/services/VideoDownloadService.kt
+++ b/course/src/main/java/in/testpress/course/services/VideoDownloadService.kt
@@ -117,7 +117,7 @@ class VideoDownloadService : DownloadService(
         launch {
             withContext(Dispatchers.IO) {
                 while (downloadManager.currentDownloads.isNotEmpty()) {
-                    offlineVideoRepository.updateOfflineVideoDownloadStatus()
+                    offlineVideoRepository.refreshCurrentDownloadsProgress()
                     delay(1000)
                 }
                 downloadProgressUpdateHandler.removeCallbacks(runnable)

--- a/course/src/main/java/in/testpress/course/services/VideoDownloadService.kt
+++ b/course/src/main/java/in/testpress/course/services/VideoDownloadService.kt
@@ -2,8 +2,10 @@ package `in`.testpress.course.services
 
 import `in`.testpress.course.R
 import `in`.testpress.course.helpers.VideoDownloadManager
+import `in`.testpress.course.repository.OfflineVideoRepository
 import android.app.Notification
 import android.content.Context
+import android.os.Handler
 import com.google.android.exoplayer2.offline.Download
 import com.google.android.exoplayer2.offline.DownloadManager
 import com.google.android.exoplayer2.offline.DownloadService
@@ -12,6 +14,12 @@ import com.google.android.exoplayer2.scheduler.Scheduler
 import com.google.android.exoplayer2.ui.DownloadNotificationHelper
 import com.google.android.exoplayer2.util.NotificationUtil
 import com.google.android.exoplayer2.util.Util
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlin.coroutines.CoroutineContext
 
 class VideoDownloadService : DownloadService(
     FOREGROUND_NOTIFICATION_ID,
@@ -19,13 +27,23 @@ class VideoDownloadService : DownloadService(
     CHANNEL_ID,
     R.string.download,
     R.string.download_description
-), DownloadManager.Listener {
+), DownloadManager.Listener, CoroutineScope {
+
+    override val coroutineContext: CoroutineContext
+        get() = Dispatchers.IO
+    var downloadProgressUpdateHandler = Handler()
+    lateinit var runnable: Runnable
+    private lateinit var offlineVideoRepository: OfflineVideoRepository
 
     private lateinit var notificationHelper: DownloadNotificationHelper
 
     override fun onCreate() {
         super.onCreate()
+        offlineVideoRepository = OfflineVideoRepository(this)
         notificationHelper = DownloadNotificationHelper(this, CHANNEL_ID)
+        runnable = Runnable {
+            updateDownloadProgressInDB()
+        }
     }
 
     override fun getDownloadManager(): DownloadManager {
@@ -53,25 +71,71 @@ class VideoDownloadService : DownloadService(
 
     override fun onDownloadChanged(downloadManager: DownloadManager, download: Download) {
         var notification: Notification? = null
+
+        if (isDownloadProgressNotBeingUpdated()) {
+            refreshCurrentDownloadsProgress()
+        }
+
         when (download.state) {
             Download.STATE_COMPLETED -> {
-                val message = "Download is completed"
-                notification = notificationHelper.buildDownloadCompletedNotification(
-                    R.drawable.ic_download_done,
-                    null,
-                    message
-                )
+                updateDownloadProgress(download)
+                notification = getCompletedNotification()
             }
-            Download.STATE_FAILED -> {
-                val message = "Download is failed. Please try again"
-                notification = notificationHelper.buildDownloadFailedNotification(
-                    R.drawable.ic_download_done,
-                    null,
-                    message
-                )
+            Download.STATE_FAILED -> notification = getFailedNotification()
+            Download.STATE_REMOVING -> {
+                launch {
+                    offlineVideoRepository.deleteOfflineVideo(download)
+                }
             }
         }
         NotificationUtil.setNotification(this, nextNotificationId, notification)
+    }
+
+    private fun getFailedNotification(): Notification {
+        val message = "Download is failed. Please try again"
+        return notificationHelper.buildDownloadFailedNotification(
+            R.drawable.ic_download_done,
+            null,
+            message
+        )
+    }
+
+    private fun getCompletedNotification(): Notification {
+        val message = "Download is completed"
+        return notificationHelper.buildDownloadCompletedNotification(
+            R.drawable.ic_download_done,
+            null,
+            message
+        )
+    }
+
+    private fun refreshCurrentDownloadsProgress() {
+        downloadProgressUpdateHandler.postDelayed(runnable, 1000)
+    }
+
+    private fun updateDownloadProgressInDB() {
+        launch {
+            withContext(Dispatchers.IO) {
+                while (downloadManager.currentDownloads.isNotEmpty()) {
+                    offlineVideoRepository.updateOfflineVideoDownloadStatus()
+                    delay(1000)
+                }
+                downloadProgressUpdateHandler.removeCallbacks(runnable)
+                downloadProgressUpdateHandler.removeCallbacksAndMessages(null)
+            }
+        }
+    }
+
+    private fun isDownloadProgressNotBeingUpdated(): Boolean {
+        return !downloadProgressUpdateHandler.hasCallbacks(runnable)
+    }
+
+    private fun updateDownloadProgress(download: Download) {
+        launch {
+            withContext(Dispatchers.IO) {
+                offlineVideoRepository.updateOfflineVideoDownloadStatus(download)
+            }
+        }
     }
 
     companion object {


### PR DESCRIPTION
### Changes done
- The download model provided by exoplayer don't store video details like thumbnail, description, title. It will only have download url, percentage, bytes downloaded
- So Whenever the new download is started, progressing or removed it should be updated in OfflineVideo model of ours.
- This way we can use OfflineVideo model to show download details or we can observe it to show progress.

