### PR TITLE
Remove downloaded videos for which course is not present

### DIFF
--- a/core/src/main/java/in/testpress/database/OfflineVideo.kt
+++ b/core/src/main/java/in/testpress/database/OfflineVideo.kt
@@ -16,5 +16,6 @@ data class OfflineVideo(
     val contentId: Long? = null,
     var percentageDownloaded: Int = 0,
     var bytesDownloaded: Long = 0,
-    var totalSize: Long = 0
+    var totalSize: Long = 0,
+    val courseId: Long? = null
 )

--- a/core/src/main/java/in/testpress/database/Room.kt
+++ b/core/src/main/java/in/testpress/database/Room.kt
@@ -6,7 +6,7 @@ import androidx.room.Room
 import androidx.room.RoomDatabase
 
 
-@Database(version = 2, entities = [ContentEntity::class, OfflineVideo::class])
+@Database(version = 3, entities = [ContentEntity::class, OfflineVideo::class])
 abstract class TestpressDatabase: RoomDatabase() {
     abstract fun contentDao(): ContentDao
     abstract fun offlineVideoDao(): OfflineVideoDao

--- a/course/src/main/java/in/testpress/course/domain/DomainOfflineVideo.kt
+++ b/course/src/main/java/in/testpress/course/domain/DomainOfflineVideo.kt
@@ -13,7 +13,8 @@ data class DomainOfflineVideo(
     val contentId: Long? = null,
     val percentageDownloaded: Int = 0,
     val bytesDownloaded: Long = 0,
-    val totalSize: Long = 0
+    val totalSize: Long = 0,
+    val courseId: Long = -1
 ) {
     val isDownloadCompleted = percentageDownloaded == 100
 }
@@ -36,6 +37,7 @@ fun OfflineVideo.asDomainModel(): DomainOfflineVideo {
         contentId = contentId,
         percentageDownloaded = percentageDownloaded,
         bytesDownloaded = bytesDownloaded,
-        totalSize = totalSize
+        totalSize = totalSize,
+        courseId = courseId!!
     )
 }

--- a/course/src/main/java/in/testpress/course/fragments/DownloadsFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/DownloadsFragment.kt
@@ -1,6 +1,7 @@
 package `in`.testpress.course.fragments
 
 import `in`.testpress.course.R
+import `in`.testpress.course.helpers.DownloadedVideoRemoveHandler
 import `in`.testpress.course.repository.OfflineVideoRepository
 import `in`.testpress.course.services.VideoDownloadService
 import `in`.testpress.course.ui.OfflineVideoListAdapter
@@ -21,6 +22,7 @@ import com.facebook.shimmer.ShimmerFrameLayout
 
 class DownloadsFragment : Fragment() {
     private val TAG = "DownloadsFragment"
+    private lateinit var downloadedVideoRemoveHandler: DownloadedVideoRemoveHandler
     private val viewModel by lazy {
         ViewModelProvider(this, object : ViewModelProvider.Factory {
             override fun <T : ViewModel?> create(modelClass: Class<T>): T {
@@ -79,6 +81,11 @@ class DownloadsFragment : Fragment() {
     private fun initializeObservers() {
         showLoadingPlaceholder()
         viewModel.offlineVideos.observe(viewLifecycleOwner, Observer {
+            downloadedVideoRemoveHandler = DownloadedVideoRemoveHandler(it, requireContext())
+            if (downloadedVideoRemoveHandler.hasVideosToRemove()) {
+                downloadedVideoRemoveHandler.remove()
+            }
+
             hideLoadingPlaceholder()
             if (it.isEmpty()) {
                 showEmptyScreen()

--- a/course/src/main/java/in/testpress/course/fragments/DownloadsFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/DownloadsFragment.kt
@@ -22,7 +22,6 @@ import com.facebook.shimmer.ShimmerFrameLayout
 
 class DownloadsFragment : Fragment() {
     private val TAG = "DownloadsFragment"
-    private lateinit var downloadedVideoRemoveHandler: DownloadedVideoRemoveHandler
     private val viewModel by lazy {
         ViewModelProvider(this, object : ViewModelProvider.Factory {
             override fun <T : ViewModel?> create(modelClass: Class<T>): T {
@@ -81,9 +80,9 @@ class DownloadsFragment : Fragment() {
     private fun initializeObservers() {
         showLoadingPlaceholder()
         viewModel.offlineVideos.observe(viewLifecycleOwner, Observer {
-            downloadedVideoRemoveHandler = DownloadedVideoRemoveHandler(it, requireContext())
-            if (downloadedVideoRemoveHandler.hasVideosToRemove()) {
-                downloadedVideoRemoveHandler.remove()
+            val handler = DownloadedVideoRemoveHandler(it, requireContext())
+            if (handler.hasVideosToRemove()) {
+                handler.remove()
             }
 
             hideLoadingPlaceholder()

--- a/course/src/main/java/in/testpress/course/helpers/DownloadTask.kt
+++ b/course/src/main/java/in/testpress/course/helpers/DownloadTask.kt
@@ -34,7 +34,8 @@ class DownloadTask(val url: String, val context: Context) {
             duration = content.video!!.duration!!,
             url = content.video.hlsUrl(),
             contentId = content.id,
-            remoteThumbnail = content.video.thumbnailMedium
+            remoteThumbnail = content.video.thumbnailMedium,
+            courseId = content.courseId
         )
         val offlineVideoDao = TestpressDatabase(context).offlineVideoDao()
 

--- a/course/src/main/java/in/testpress/course/helpers/DownloadedVideoRemoveHandler.kt
+++ b/course/src/main/java/in/testpress/course/helpers/DownloadedVideoRemoveHandler.kt
@@ -1,0 +1,53 @@
+package `in`.testpress.course.helpers
+
+import `in`.testpress.core.TestpressSDKDatabase
+import `in`.testpress.course.domain.DomainOfflineVideo
+import `in`.testpress.models.greendao.CourseDao
+import android.content.Context
+
+class DownloadedVideoRemoveHandler(val videos: List<DomainOfflineVideo>, val context: Context) {
+    val courseDao: CourseDao = TestpressSDKDatabase.getCourseDao(context)
+    private val videosByCourseId = hashMapOf<Long, List<DomainOfflineVideo>>()
+    private val userCourseIds: List<Long>
+
+    init {
+        val courses = courseDao.queryBuilder()
+            .where(CourseDao.Properties.IsMyCourse.eq(true)).list()
+        userCourseIds = courses.map { it.id }
+        mapVideosWithItsCourseIds()
+    }
+
+    private fun mapVideosWithItsCourseIds() {
+        for (video in videos) {
+            val videos = mutableListOf<DomainOfflineVideo>()
+            if (videosByCourseId.containsKey(video.courseId)) {
+                videos.addAll(videosByCourseId[video.courseId]!!)
+            } else {
+                videos.add(video)
+            }
+            videosByCourseId[video.courseId] = videos
+        }
+    }
+
+    fun hasVideosToRemove(): Boolean {
+        val videoCourseIds = videosByCourseId.keys
+        return (videoCourseIds subtract userCourseIds).isNotEmpty()
+    }
+
+    fun remove() {
+        val courseIdsToRemove = videosByCourseId.keys subtract userCourseIds
+        val videosToRemove = getVideosToRemove(courseIdsToRemove)
+        for (video in videosToRemove) {
+            val downloadTask = DownloadTask(video.url!!, context)
+            downloadTask.delete()
+        }
+    }
+
+    private fun getVideosToRemove(courseIds: Set<Long>): MutableList<DomainOfflineVideo> {
+        val videos = mutableListOf<DomainOfflineVideo>()
+        for (courseId in courseIds) {
+            videos.addAll(videosByCourseId[courseId]!!)
+        }
+        return videos
+    }
+}


### PR DESCRIPTION
### Changes done
-  If a user downloads a video and after that, if his access for that course is revoked then the video should be deleted
- So we delete videos whose course id is not present in course list of local db

