### PR TITLE
Move NetworkBoundResource to core

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -64,6 +64,8 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     api "androidx.room:room-runtime:$room_version"
     kapt "androidx.room:room-compiler:$room_version"
+    api "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlin_coroutine_version"
+    api "org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlin_coroutine_version"
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/core/src/main/java/in/testpress/network/NetworkBoundResource.kt
+++ b/core/src/main/java/in/testpress/network/NetworkBoundResource.kt
@@ -1,8 +1,6 @@
-package `in`.testpress.course.repository
+package `in`.testpress.network
 
 import `in`.testpress.core.TestpressException
-import `in`.testpress.network.Resource
-import `in`.testpress.network.RetrofitCall
 import androidx.annotation.MainThread
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData

--- a/course/build.gradle
+++ b/course/build.gradle
@@ -45,8 +45,6 @@ dependencies {
     api rootProject.shimmer
     api 'com.github.HotBitmapGG:RingProgressBar:V1.2.3'
     api "androidx.viewpager2:viewpager2:1.0.0"
-    api "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlin_coroutine_version"
-    api "org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlin_coroutine_version"
     testImplementation rootProject.junit
     testImplementation rootProject.mockito
     testImplementation rootProject.powermockJunit

--- a/course/src/main/java/in/testpress/course/repository/ContentRepository.kt
+++ b/course/src/main/java/in/testpress/course/repository/ContentRepository.kt
@@ -7,7 +7,6 @@ import `in`.testpress.course.api.TestpressCourseApiClient.CONTENTS_PATH_v2_4
 import `in`.testpress.course.domain.DomainContent
 import `in`.testpress.course.domain.asDomainContent
 import `in`.testpress.course.domain.asDomainContents
-import `in`.testpress.enums.Status
 import `in`.testpress.course.network.CourseNetwork
 import `in`.testpress.course.network.NetworkContent
 import `in`.testpress.course.network.NetworkContentAttempt
@@ -15,8 +14,10 @@ import `in`.testpress.network.Resource
 import `in`.testpress.course.network.asDatabaseModel
 import `in`.testpress.course.network.asGreenDaoModel
 import `in`.testpress.database.TestpressDatabase
+import `in`.testpress.enums.Status
 import `in`.testpress.models.greendao.Content
 import `in`.testpress.models.greendao.ContentDao
+import `in`.testpress.network.NetworkBoundResource
 import `in`.testpress.network.RetrofitCall
 import android.content.Context
 import androidx.lifecycle.LiveData

--- a/course/src/test/java/in/testpress/course/repository/NetworkBoundResourceTest.kt
+++ b/course/src/test/java/in/testpress/course/repository/NetworkBoundResourceTest.kt
@@ -6,6 +6,7 @@ import `in`.testpress.network.Resource
 import `in`.testpress.course.util.RetrofitCallMock
 import `in`.testpress.course.util.getOrAwaitValue
 import `in`.testpress.course.util.mock
+import `in`.testpress.network.NetworkBoundResource
 import `in`.testpress.network.RetrofitCall
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.LiveData


### PR DESCRIPTION
### Changes done
- Moved NetworkBoundResource to Core
- Added Coroutine dependency in Core

### Reason to change
- NetworkBoundResource is used in both course and store so if NetworkBoundResource is in Core we can avoid file duplication
