### PR TITLE
Fix locked and scheduled content accessible from bottom navigation

### DIFF
--- a/course/src/main/java/in/testpress/course/fragments/ContentBottomNavigationFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/ContentBottomNavigationFragment.kt
@@ -92,10 +92,13 @@ class ContentBottomNavigationFragment : Fragment() {
     fun initializeAndShowNavigationButtons() {
         bottomLayout.visibility = View.VISIBLE
         val contentsFromChapterObserver = Observer<List<DomainContent>> { contents ->
-            val position = contents.indexOf(content)
-            initNextButton(position)
-            initPrevButton(position, contents)
-            pageNumber.text = String.format("%d/%d", position + 1, contents.size)
+            val openableContents = contents.filter { content ->
+                content.isLocked == false && content.isScheduled == false
+            }
+            val position = openableContents.indexOf(content)
+            initNextButton(position, openableContents)
+            initPrevButton(position, openableContents)
+            pageNumber.text = String.format("%d/%d", contents.indexOf(content) + 1, contents.size)
         }
 
         viewModel.getContent(contentId).observe(viewLifecycleOwner, Observer { resource ->
@@ -122,18 +125,12 @@ class ContentBottomNavigationFragment : Fragment() {
     }
 
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-    fun initNextButton(position: Int) {
-        val contentsFromChapterObserver = Observer<List<DomainContent>> { contents ->
-            if (hasNextContent(position, contents)) {
-                nextShouldOpenNextContentOnClick(position, contents)
-            } else {
-                nextShouldOpenMenuOnClick()
-            }
+    fun initNextButton(position: Int, contents: List<DomainContent>) {
+        if (hasNextContent(position, contents)) {
+            nextShouldOpenNextContentOnClick(position, contents)
+        } else {
+            nextShouldOpenMenuOnClick()
         }
-
-        viewModel.getContentsForChapter(
-                content.chapterId!!)?.observe(
-                viewLifecycleOwner, contentsFromChapterObserver)
     }
 
     private fun hasNextContent(position: Int, contents: List<DomainContent>): Boolean {

--- a/course/src/main/java/in/testpress/course/fragments/ContentBottomNavigationFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/ContentBottomNavigationFragment.kt
@@ -92,12 +92,12 @@ class ContentBottomNavigationFragment : Fragment() {
     fun initializeAndShowNavigationButtons() {
         bottomLayout.visibility = View.VISIBLE
         val contentsFromChapterObserver = Observer<List<DomainContent>> { contents ->
-            val openableContents = contents.filter { content ->
+            val unLockedContents = contents.filter { content ->
                 content.isLocked == false && content.isScheduled == false
             }
-            val position = openableContents.indexOf(content)
-            initNextButton(position, openableContents)
-            initPrevButton(position, openableContents)
+            val position = unLockedContents.indexOf(content)
+            initNextButton(position, unLockedContents)
+            initPrevButton(position, unLockedContents)
             pageNumber.text = String.format("%d/%d", contents.indexOf(content) + 1, contents.size)
         }
 

--- a/course/src/test/java/in/testpress/course/fragments/ContentBottomNavigationFragmentTest.kt
+++ b/course/src/test/java/in/testpress/course/fragments/ContentBottomNavigationFragmentTest.kt
@@ -45,6 +45,12 @@ class ContentBottomNavigationFragmentTest {
     private val content = DomainContent(1, chapterId = 1,
             active = true, contentType = "dummy", hasStarted = true,
             isLocked = false, isScheduled = false, isCourseAvailable = false)
+    private val lockedContent = DomainContent(2, chapterId = 1,
+        active = true, contentType = "dummy", hasStarted = true,
+        isLocked = true, isScheduled = false, isCourseAvailable = false)
+    private val scheduledContent = DomainContent(3, chapterId = 1,
+        active = true, contentType = "dummy", hasStarted = true,
+        isLocked = false, isScheduled = true, isCourseAvailable = false)
 
     @Before
     fun setUp() {
@@ -83,7 +89,7 @@ class ContentBottomNavigationFragmentTest {
         val contents = MutableLiveData<List<DomainContent>>(listOf(content))
         contentFragment.content = content
         `when`(contentFragment.viewModel.getContentsForChapter(anyLong())).thenReturn(contents)
-        contentFragment.initNextButton(0)
+        contentFragment.initNextButton(0, listOf())
         Assert.assertEquals(View.VISIBLE, contentFragment.nextButton.visibility)
         Assert.assertEquals(context.getString(R.string.testpress_menu), contentFragment.nextButton.text)
     }
@@ -93,7 +99,7 @@ class ContentBottomNavigationFragmentTest {
         val contents = MutableLiveData<List<DomainContent>>(listOf(content, content))
         contentFragment.content = content
         `when`(contentFragment.viewModel.getContentsForChapter(anyLong())).thenReturn(contents)
-        contentFragment.initNextButton(0)
+        contentFragment.initNextButton(0, listOf(content, content))
         Assert.assertEquals(View.VISIBLE, contentFragment.nextButton.visibility)
         Assert.assertEquals(context.getString(R.string.testpress_next_content), contentFragment.nextButton.text)
     }
@@ -107,6 +113,41 @@ class ContentBottomNavigationFragmentTest {
         Assert.assertEquals(contentFragment.pageNumber.text, "1/1")
         // verify(contentFragment).initNextButton(0)
         // verify(contentFragment).initPrevButton(0, listOf())
+    }
+    @Test
+    fun nextButtonShouldNotBeShownForLockedContent() {
+        val contents = MutableLiveData<List<DomainContent>>(listOf(content, lockedContent, lockedContent))
+        `when`(contentFragment.viewModel.getContentsForChapter(anyLong())).thenReturn(contents)
+        contentFragment.initializeAndShowNavigationButtons()
+
+        Assert.assertEquals(context.getString(R.string.testpress_menu), contentFragment.nextButton.text)
+    }
+
+    @Test
+    fun nextButtonShouldNotBeShownForScheduledContent() {
+        val contents = MutableLiveData<List<DomainContent>>(listOf(content, scheduledContent, scheduledContent))
+        `when`(contentFragment.viewModel.getContentsForChapter(anyLong())).thenReturn(contents)
+        contentFragment.initializeAndShowNavigationButtons()
+
+        Assert.assertEquals(context.getString(R.string.testpress_menu), contentFragment.nextButton.text)
+    }
+
+    @Test
+    fun previousButtonShouldNotBeShownForScheduledContent() {
+        val contents = MutableLiveData<List<DomainContent>>(listOf(scheduledContent, scheduledContent, content))
+        `when`(contentFragment.viewModel.getContentsForChapter(anyLong())).thenReturn(contents)
+        contentFragment.initializeAndShowNavigationButtons()
+
+        Assert.assertEquals(View.INVISIBLE, contentFragment.previousButton.visibility)
+    }
+
+    @Test
+    fun previousButtonShouldNotBeShownForLockedContent() {
+        val contents = MutableLiveData<List<DomainContent>>(listOf(lockedContent, lockedContent, content))
+        `when`(contentFragment.viewModel.getContentsForChapter(anyLong())).thenReturn(contents)
+        contentFragment.initializeAndShowNavigationButtons()
+
+        Assert.assertEquals(View.INVISIBLE, contentFragment.previousButton.visibility)
     }
 
     @After


### PR DESCRIPTION
# Changes done
- Next/Prev button in bottom navigation should skip locked/scheduled content
 

No of test cases - 4