### PR TITLE
Fix access denied error on downloading attachment content 

### DIFF
--- a/course/src/main/java/in/testpress/course/fragments/AttachmentContentFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/AttachmentContentFragment.kt
@@ -51,7 +51,9 @@ class AttachmentContentFragment : BaseContentDetailFragment() {
 
         downloadButton.setOnClickListener {
             forceReloadContent()
-            context!!.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(content.attachment!!.attachmentUrl)))
+            if (isNetworkCallSuccess) {
+                context!!.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(attachment.attachmentUrl)))
+            }
         }
         attachmentContentLayout.visibility = View.VISIBLE
         viewModel.createContentAttempt(contentId)

--- a/course/src/main/java/in/testpress/course/fragments/AttachmentContentFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/AttachmentContentFragment.kt
@@ -50,8 +50,7 @@ class AttachmentContentFragment : BaseContentDetailFragment() {
         }
 
         downloadButton.setOnClickListener {
-            forceReloadContent()
-            if (isNetworkCallSuccess) {
+            forceReloadContent {
                 context!!.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(attachment.attachmentUrl)))
             }
         }

--- a/course/src/main/java/in/testpress/course/fragments/AttachmentContentFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/AttachmentContentFragment.kt
@@ -50,7 +50,8 @@ class AttachmentContentFragment : BaseContentDetailFragment() {
         }
 
         downloadButton.setOnClickListener {
-            context!!.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(attachment.attachmentUrl)))
+            forceReloadContent()
+            context!!.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(content.attachment!!.attachmentUrl)))
         }
         attachmentContentLayout.visibility = View.VISIBLE
         viewModel.createContentAttempt(contentId)

--- a/course/src/main/java/in/testpress/course/fragments/BaseContentDetailFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/BaseContentDetailFragment.kt
@@ -6,7 +6,6 @@ import `in`.testpress.course.TestpressCourse
 import `in`.testpress.course.TestpressCourse.CONTENT_TYPE
 import `in`.testpress.course.TestpressCourse.PRODUCT_SLUG
 import `in`.testpress.course.di.InjectorUtils
-import `in`.testpress.course.domain.DomainAttachmentContent
 import `in`.testpress.course.domain.DomainContent
 import `in`.testpress.enums.Status
 import `in`.testpress.course.ui.ContentActivity.CONTENT_ID

--- a/course/src/main/java/in/testpress/course/fragments/BaseContentDetailFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/BaseContentDetailFragment.kt
@@ -38,6 +38,7 @@ abstract class BaseContentDetailFragment : Fragment(), BookmarkListener,
     protected var contentId: Long = -1
     private var productSlug: String? = null
     open var isBookmarkEnabled = true
+    protected var isNetworkCallSuccess = false
     protected lateinit var content: DomainContent
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     lateinit var bookmarkFragment: BookmarkFragment
@@ -125,6 +126,7 @@ abstract class BaseContentDetailFragment : Fragment(), BookmarkListener,
 
     @VisibleForTesting(otherwise = VisibleForTesting.PROTECTED)
     fun forceReloadContent() {
+        isNetworkCallSuccess = false
         swipeRefresh.isRefreshing = true
         viewModel.getContent(contentId, forceRefresh = true).observe(viewLifecycleOwner,
             Observer { resource ->
@@ -132,6 +134,7 @@ abstract class BaseContentDetailFragment : Fragment(), BookmarkListener,
                 if (resource != null) {
                     when (resource.status) {
                         Status.SUCCESS -> {
+                            isNetworkCallSuccess = true
                             content = resource.data!!
                             display()
                         }

--- a/course/src/main/java/in/testpress/course/fragments/BaseContentDetailFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/BaseContentDetailFragment.kt
@@ -6,6 +6,7 @@ import `in`.testpress.course.TestpressCourse
 import `in`.testpress.course.TestpressCourse.CONTENT_TYPE
 import `in`.testpress.course.TestpressCourse.PRODUCT_SLUG
 import `in`.testpress.course.di.InjectorUtils
+import `in`.testpress.course.domain.DomainAttachmentContent
 import `in`.testpress.course.domain.DomainContent
 import `in`.testpress.enums.Status
 import `in`.testpress.course.ui.ContentActivity.CONTENT_ID
@@ -38,7 +39,6 @@ abstract class BaseContentDetailFragment : Fragment(), BookmarkListener,
     protected var contentId: Long = -1
     private var productSlug: String? = null
     open var isBookmarkEnabled = true
-    protected var isNetworkCallSuccess = false
     protected lateinit var content: DomainContent
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     lateinit var bookmarkFragment: BookmarkFragment
@@ -125,8 +125,7 @@ abstract class BaseContentDetailFragment : Fragment(), BookmarkListener,
     }
 
     @VisibleForTesting(otherwise = VisibleForTesting.PROTECTED)
-    fun forceReloadContent() {
-        isNetworkCallSuccess = false
+    fun forceReloadContent(onSuccessCallback: (() -> Unit) = {}) {
         swipeRefresh.isRefreshing = true
         viewModel.getContent(contentId, forceRefresh = true).observe(viewLifecycleOwner,
             Observer { resource ->
@@ -134,9 +133,9 @@ abstract class BaseContentDetailFragment : Fragment(), BookmarkListener,
                 if (resource != null) {
                     when (resource.status) {
                         Status.SUCCESS -> {
-                            isNetworkCallSuccess = true
                             content = resource.data!!
                             display()
+                            onSuccessCallback.invoke()
                         }
                         Status.ERROR -> {
                             toast.show()


### PR DESCRIPTION
- Attachment URL will be valid only for some time (5 mins in our case). So when the user tries to download the attachment after URL expiry it will show access denied.
- Solution is to fetch the attachment URL whenever the user clicks the download button and use that attachment URL.