### PR TITLE
Fix Exoplayer crash on app crash

### DIFF
--- a/course/src/main/java/in/testpress/course/util/ExoPlayerUtil.java
+++ b/course/src/main/java/in/testpress/course/util/ExoPlayerUtil.java
@@ -51,6 +51,7 @@ import com.google.android.exoplayer2.trackselection.MappingTrackSelector;
 import com.google.android.exoplayer2.trackselection.TrackSelection;
 import com.google.android.exoplayer2.ui.PlayerView;
 import com.google.android.exoplayer2.upstream.DataSource;
+import com.google.android.exoplayer2.util.Log;
 import com.google.android.exoplayer2.util.Util;
 
 import java.util.HashMap;
@@ -384,7 +385,11 @@ public class ExoPlayerUtil {
             }
         }
         if (usbConnectionStateReceiver != null) {
-            activity.unregisterReceiver(usbConnectionStateReceiver);
+            try {
+                activity.unregisterReceiver(usbConnectionStateReceiver);
+            } catch (Exception e) {
+                Log.i("ExoplayerUtil", "unregisterReceiver: "+ e.getMessage());
+            }
             mediaRouter.removeCallback(mediaRouterCallback);
         }
     }

--- a/course/src/main/java/in/testpress/course/util/ExoPlayerUtil.java
+++ b/course/src/main/java/in/testpress/course/util/ExoPlayerUtil.java
@@ -387,8 +387,8 @@ public class ExoPlayerUtil {
         if (usbConnectionStateReceiver != null) {
             try {
                 activity.unregisterReceiver(usbConnectionStateReceiver);
-            } catch (Exception e) {
-                Log.i("ExoplayerUtil", "unregisterReceiver: "+ e.getMessage());
+            } catch (IllegalArgumentException exception) {
+                Log.i("ExoplayerUtil", "unregisterReceiver: "+ exception.getMessage());
             }
             mediaRouter.removeCallback(mediaRouterCallback);
         }


### PR DESCRIPTION
### Changes done
- Issue: The broadcast receiver is unregistered before even registering
- The receiver is registered when we are in the onStart. onPause is called at the time user receive phone call, so there the receiver is unregistered. When phone call ended onResume is been called and while closing the activity again we are trying to unregister the receiver where it already been unregistered. [ref](https://stackoverflow.com/a/28778985/12883471)
- This issue is fixed by wrapping it in a try-catch block so when the receiver is not registered and we try to unregister we are catching it in the catch [ref](https://stackoverflow.com/a/36530677/12883471)
