### PR TITLE
Fix App crash on Clicking download button

### DIFF
--- a/course/src/main/java/in/testpress/course/ui/VideoDownloadQualityChooserDialog.kt
+++ b/course/src/main/java/in/testpress/course/ui/VideoDownloadQualityChooserDialog.kt
@@ -107,7 +107,9 @@ class VideoDownloadQualityChooserDialog(val content: DomainContent) : DialogFrag
     }
 
     private fun hideLoading() {
-        loadingProgress.visibility = View.GONE
+        if (loadingProgress != null) {
+            loadingProgress.visibility = View.GONE
+        }
     }
 
     override fun onTrackSelectionChanged(


### PR DESCRIPTION
- **Issue:** the hideProgressbar method is being called after the view being destroyed.
- Since the Exoplayer video download handler is asynchronous even though, When user clicks on the download button and before loading the download dialog box if the user came out of that activity, the hideProgress is being called by the Exoplayer video download handler.
**Fix:** Need to hide the progress bar only when the view is visible