### PR TITLE
Fix: Title should be visible for scheduled content

### DIFF
--- a/exam/src/main/res/layout/content_list_item.xml
+++ b/exam/src/main/res/layout/content_list_item.xml
@@ -111,10 +111,10 @@
         android:id="@+id/info_conatainer"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:orientation="vertical"
         android:layout_marginStart="8dp"
         android:layout_marginTop="8dp"
         android:layout_marginLeft="0dp"
+        android:orientation="vertical"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@+id/container"
         app:layout_constraintTop_toTopOf="parent">
@@ -150,7 +150,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="horizontal"
-                android:visibility="visible">
+                android:visibility="gone">
 
                 <TextView
                     android:id="@+id/scheduled_info"
@@ -158,7 +158,7 @@
                     android:layout_height="wrap_content"
                     android:lineSpacingExtra="4dp"
                     android:maxLines="1"
-                    android:text="Extra Info dewfdew"
+                    android:text=""
                     android:textColor="@color/testpress_text_gray_medium"
                     android:textSize="12sp" />
 

--- a/exam/src/main/res/layout/content_list_item.xml
+++ b/exam/src/main/res/layout/content_list_item.xml
@@ -11,7 +11,7 @@
         android:id="@+id/container"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        app:layout_constraintEnd_toStartOf="@+id/content_details_container"
+        app:layout_constraintEnd_toStartOf="@+id/info_conatainer"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent">
 
@@ -108,13 +108,13 @@
     </androidx.constraintlayout.widget.ConstraintLayout>
 
     <LinearLayout
-        android:id="@+id/content_details_container"
+        android:id="@+id/info_conatainer"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:orientation="vertical"
         android:layout_marginStart="8dp"
         android:layout_marginTop="8dp"
         android:layout_marginLeft="0dp"
-        android:orientation="vertical"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@+id/container"
         app:layout_constraintTop_toTopOf="parent">
@@ -131,23 +131,37 @@
             android:textSize="16sp" />
 
         <LinearLayout
-            android:id="@+id/scheduled_info_container"
+            android:id="@+id/content_details_container"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginTop="5dp"
-            android:orientation="horizontal"
-            android:visibility="gone">
-
-            <TextView
-                android:id="@+id/scheduled_info"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:lineSpacingExtra="4dp"
-                android:maxLines="1"
-                android:text="Extra Info"
-                android:textColor="@color/testpress_text_gray_medium"
-                android:textSize="12sp" />
+            android:layout_marginStart="8dp"
+            android:layout_marginTop="8dp"
+            android:layout_marginLeft="0dp"
+            android:orientation="vertical"
+            android:visibility="visible"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@+id/container"
+            app:layout_constraintTop_toTopOf="parent">
 
         </LinearLayout>
-    </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/scheduled_info_container"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:visibility="visible">
+
+                <TextView
+                    android:id="@+id/scheduled_info"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:lineSpacingExtra="4dp"
+                    android:maxLines="1"
+                    android:text="Extra Info dewfdew"
+                    android:textColor="@color/testpress_text_gray_medium"
+                    android:textSize="12sp" />
+
+            </LinearLayout>
+        </LinearLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/exam/src/main/res/layout/exam_content_list_item.xml
+++ b/exam/src/main/res/layout/exam_content_list_item.xml
@@ -114,7 +114,8 @@
         android:orientation="vertical"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@+id/container"
-        app:layout_constraintTop_toTopOf="parent">
+        app:layout_constraintTop_toTopOf="parent"
+        android:layout_marginLeft="0dp">
 
         <TextView
             android:id="@+id/title"
@@ -187,7 +188,7 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="5dp"
             android:orientation="horizontal"
-            android:visibility="gone">
+            android:visibility="visible">
 
             <TextView
                 android:id="@+id/scheduled_info"

--- a/exam/src/main/res/layout/exam_content_list_item.xml
+++ b/exam/src/main/res/layout/exam_content_list_item.xml
@@ -188,7 +188,7 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="5dp"
             android:orientation="horizontal"
-            android:visibility="visible">
+            android:visibility="gone">
 
             <TextView
                 android:id="@+id/scheduled_info"


### PR DESCRIPTION
- In  [747530c2](https://github.com/testpress/android-sdk/commit/747530c2645e3e2ebf8c67512c7d2d434e99ea0e) the scheduled info is been wrapped in the content detail layout. when the content is scheduled we are not showing the content details hence the schedule info is also being hidden.
- Solution: We have moved the scheduled info from content details layout