### PR TITLE
Update travis build tools version to 29.0.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
   global:
     - ANDROID_API_LEVEL=28  # Compile SDK version
     - EMULATOR_API_LEVEL=19
-    - ANDROID_BUILD_TOOLS_VERSION=28.0.3
+    - ANDROID_BUILD_TOOLS_VERSION=29.0.2
     - ANDROID_ABI=armeabi-v7a
     - ANDROID_TAG=google_apis
     - ADB_INSTALL_TIMEOUT=20 # minutes (2 minutes by default)


### PR DESCRIPTION
- Since travis minimum build tools version changed to 29.0.2, the travis unable to download the build tools, hence changed the travis build tools version to 29.0.2