### PR TITLE
Display Thumbnail for offline videos

### DIFF
--- a/course/src/main/java/in/testpress/course/helpers/DownloadTask.kt
+++ b/course/src/main/java/in/testpress/course/helpers/DownloadTask.kt
@@ -34,7 +34,7 @@ class DownloadTask(val url: String, val context: Context) {
             duration = content.video!!.duration!!,
             url = content.video.hlsUrl(),
             contentId = content.id,
-            remoteThumbnail = content.video.thumbnailMedium,
+            remoteThumbnail = content.coverImageMedium,
             courseId = content.courseId
         )
         val offlineVideoDao = TestpressDatabase(context).offlineVideoDao()


### PR DESCRIPTION
Recently the course content api has changed. Now video thumbnails are exposed 
in content instead of video.