### PR TITLE
Fix: Title overlap with delete downloaded video menu icon

### DIFF
--- a/course/src/main/res/layout/downloaded_video_list_item.xml
+++ b/course/src/main/res/layout/downloaded_video_list_item.xml
@@ -61,17 +61,16 @@
         android:layout_marginLeft="10dp"
         android:layout_toRightOf="@id/image_layout">
 
-        <RelativeLayout
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
 
             <LinearLayout
-                android:layout_width="wrap_content"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:id="@+id/title_layout"
-                android:layout_alignParentStart="true"
                 android:orientation="vertical"
-                android:layout_alignParentLeft="true">
+                android:layout_weight="3">
 
                 <TextView
                     android:id="@+id/title"
@@ -79,7 +78,8 @@
                     android:layout_height="wrap_content"
                     android:text=""
                     android:textColor="#333"
-                    android:textSize="18sp" />
+                    android:textSize="18sp"
+                    android:maxLines="2"/>
 
                 <TextView
                     android:id="@+id/size"
@@ -94,13 +94,11 @@
             <ImageButton
                 android:id="@+id/menu_button"
                 android:layout_width="30dp"
-                android:layout_toLeftOf="@id/title_layout"
-                android:layout_alignParentEnd="true"
                 android:layout_height="wrap_content"
                 android:background="?android:attr/actionBarItemBackground"
                 android:src="@drawable/ic_baseline_more_vert_24"
-                android:layout_alignParentRight="true" />
-        </RelativeLayout>
+                android:layout_weight="0.1" />
+        </LinearLayout>
 
 
         <LinearLayout


### PR DESCRIPTION
when the downloaded video title is long, the title is overlapped with delete menu icon, So added layout weight to avoid overlapping