### PR TITLE
Fix App crash on opening and quickly closing the download chooser dialog

### DIFF
--- a/course/src/main/java/in/testpress/course/ui/VideoDownloadQualityChooserDialog.kt
+++ b/course/src/main/java/in/testpress/course/ui/VideoDownloadQualityChooserDialog.kt
@@ -66,10 +66,8 @@ class VideoDownloadQualityChooserDialog(val content: DomainContent) : DialogFrag
 
     private fun setOnClickListeners() {
         okButton.setOnClickListener {
-            if (::overrides.isInitialized) {
-                val downloadRequest = videoDownloadRequestCreateHandler.buildDownloadRequest(overrides)
-                onSubmitListener?.invoke(downloadRequest)
-            }
+            val downloadRequest = videoDownloadRequestCreateHandler.buildDownloadRequest(overrides)
+            onSubmitListener?.invoke(downloadRequest)
             dismiss()
         }
 

--- a/course/src/main/java/in/testpress/course/ui/VideoDownloadQualityChooserDialog.kt
+++ b/course/src/main/java/in/testpress/course/ui/VideoDownloadQualityChooserDialog.kt
@@ -66,8 +66,10 @@ class VideoDownloadQualityChooserDialog(val content: DomainContent) : DialogFrag
 
     private fun setOnClickListeners() {
         okButton.setOnClickListener {
-            val downloadRequest = videoDownloadRequestCreateHandler.buildDownloadRequest(overrides)
-            onSubmitListener?.invoke(downloadRequest)
+            if (::overrides.isInitialized) {
+                val downloadRequest = videoDownloadRequestCreateHandler.buildDownloadRequest(overrides)
+                onSubmitListener?.invoke(downloadRequest)
+            }
             dismiss()
         }
 
@@ -75,7 +77,9 @@ class VideoDownloadQualityChooserDialog(val content: DomainContent) : DialogFrag
     }
 
     private fun showLoading() {
-        loadingProgress.visibility = View.VISIBLE
+        if (loadingProgress != null) {
+            loadingProgress.visibility = View.VISIBLE
+        }
     }
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
@@ -107,7 +111,9 @@ class VideoDownloadQualityChooserDialog(val content: DomainContent) : DialogFrag
     }
 
     private fun hideLoading() {
-        loadingProgress.visibility = View.GONE
+        if (loadingProgress != null) {
+            loadingProgress.visibility = View.GONE
+        }
     }
 
     override fun onTrackSelectionChanged(


### PR DESCRIPTION
- We have used progress bar in video download chooser dialog to show loading 
- This Progressbar is hidden on clossing the dialog box
- The issue is we are trying to close the progressbar before its being initialized.
- This is handled by checking if progressbar is null before closing the dialog.
