### PR TITLE
Fix App crash on downloading video

### DIFF
--- a/course/src/main/java/in/testpress/course/ui/VideoDownloadQualityChooserDialog.kt
+++ b/course/src/main/java/in/testpress/course/ui/VideoDownloadQualityChooserDialog.kt
@@ -66,8 +66,10 @@ class VideoDownloadQualityChooserDialog(val content: DomainContent) : DialogFrag
 
     private fun setOnClickListeners() {
         okButton.setOnClickListener {
-            val downloadRequest = videoDownloadRequestCreateHandler.buildDownloadRequest(overrides)
-            onSubmitListener?.invoke(downloadRequest)
+            if (::overrides.isInitialized) {
+                val downloadRequest = videoDownloadRequestCreateHandler.buildDownloadRequest(overrides)
+                onSubmitListener?.invoke(downloadRequest)
+            }
             dismiss()
         }
 


### PR DESCRIPTION
- We have used = video download chooser dialog to select resolution to download video
- on Clicking ok button will request to download video and dismiss the dialog
- The issue is if the user clicks the ok button before the download is prepared. The download request will throw exception, this cause app crash
- This is handled by checking if the tack selection is initialized before building a download request