### PR TITLE
Fix Sectional Time Duration Lock is not working while resume the exam

### DIFF
--- a/core/src/main/java/in/testpress/core/TestpressSDKDatabase.java
+++ b/core/src/main/java/in/testpress/core/TestpressSDKDatabase.java
@@ -9,6 +9,7 @@ import in.testpress.models.greendao.AnswerDao;
 import in.testpress.models.greendao.AnswerTranslationDao;
 import in.testpress.models.greendao.AttachmentDao;
 import in.testpress.models.greendao.AttemptDao;
+import in.testpress.models.greendao.AttemptSectionDao;
 import in.testpress.models.greendao.BookmarkDao;
 import in.testpress.models.greendao.BookmarkFolderDao;
 import in.testpress.models.greendao.ChapterDao;
@@ -106,6 +107,10 @@ public class TestpressSDKDatabase {
 
     public static AttemptDao getAttemptDao(Context context) {
         return getDaoSession(context).getAttemptDao();
+    }
+
+    public static AttemptSectionDao getAttemptSectionDao(Context context) {
+        return getDaoSession(context).getAttemptSectionDao();
     }
 
     public static CourseDao getCourseDao(Context context) {

--- a/core/src/main/java/in/testpress/models/greendao/CourseAttempt.java
+++ b/core/src/main/java/in/testpress/models/greendao/CourseAttempt.java
@@ -12,6 +12,9 @@ import in.testpress.core.TestpressSDKDatabase;
 
 import android.content.Context;
 import android.os.Parcel;
+import android.util.Log;
+
+import java.util.List;
 // KEEP INCLUDES END
 
 /**
@@ -344,12 +347,18 @@ public class CourseAttempt implements android.os.Parcelable {
     };
 
     public void saveInDB(Context context, Content content) {
+        AttemptSectionDao attemptSectionDao = TestpressSDKDatabase.getAttemptSectionDao(context);
         CourseAttemptDao courseAttemptDao = TestpressSDKDatabase.getCourseAttemptDao(context);
         AttemptDao attemptDao = TestpressSDKDatabase.getAttemptDao(context);
         Attempt attempt = getRawAssessment();
         attemptDao.insertOrReplace(attempt);
         setAssessmentId(attempt.getId());
         setChapterContentId(content.getId());
+        attemptSectionDao.insertOrReplaceInTx(attempt.getRawSections());
+        for (AttemptSection attemptSection: attempt.getRawSections()) {
+            attemptSection.setAttemptId(attempt.getId());
+            attemptSectionDao.insertOrReplaceInTx(attemptSection);
+        }
         courseAttemptDao.insertOrReplace(this);
     }
 

--- a/core/src/main/java/in/testpress/models/greendao/CourseAttempt.java
+++ b/core/src/main/java/in/testpress/models/greendao/CourseAttempt.java
@@ -352,10 +352,6 @@ public class CourseAttempt implements android.os.Parcelable {
         setAssessmentId(attempt.getId());
         setChapterContentId(content.getId());
         attemptSectionDao.insertOrReplaceInTx(attempt.getRawSections());
-        for (AttemptSection attemptSection: attempt.getRawSections()) {
-            attemptSection.setAttemptId(attempt.getId());
-            attemptSectionDao.insertOrReplaceInTx(attemptSection);
-        }
         courseAttemptDao.insertOrReplace(this);
     }
 

--- a/core/src/main/java/in/testpress/models/greendao/CourseAttempt.java
+++ b/core/src/main/java/in/testpress/models/greendao/CourseAttempt.java
@@ -12,9 +12,6 @@ import in.testpress.core.TestpressSDKDatabase;
 
 import android.content.Context;
 import android.os.Parcel;
-import android.util.Log;
-
-import java.util.List;
 // KEEP INCLUDES END
 
 /**

--- a/exam/src/test/java/in/testpress/exam/ui/SaveAttemptSectionTest.kt
+++ b/exam/src/test/java/in/testpress/exam/ui/SaveAttemptSectionTest.kt
@@ -1,0 +1,45 @@
+package `in`.testpress.exam.ui
+
+import `in`.testpress.core.TestpressSDKDatabase
+import `in`.testpress.models.greendao.*
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class SaveAttemptSectionTest {
+
+    private val attempt = Attempt()
+
+    private val attemptSectionDao =
+            TestpressSDKDatabase.getAttemptSectionDao(ApplicationProvider.getApplicationContext())
+
+
+    @Before
+    fun setup() {
+        saveAttempt()
+        saveAttemptSection()
+    }
+
+    @Test
+    fun testSectionShouldSaveCorrectly() {
+        val section = attemptSectionDao.queryBuilder().where(AttemptSectionDao.Properties.AttemptId.eq(1)).list()
+        Assert.assertFalse(section.isEmpty())
+    }
+
+    private fun saveAttemptSection() {
+        val attemptSection = listOf(AttemptSection(
+                1,"state", "Url","Start", "End",
+                "time", "name", "duration", 1,
+                "instruction", 1))
+        attemptSectionDao.insertOrReplaceInTx(attemptSection)
+    }
+
+    private fun saveAttempt() {
+        val attemptDao = TestpressSDKDatabase.getAttemptDao(ApplicationProvider.getApplicationContext())
+        attemptDao.insertOrReplace(Attempt(1))
+    }
+}

--- a/exam/src/test/java/in/testpress/exam/ui/SaveAttemptSectionTest.kt
+++ b/exam/src/test/java/in/testpress/exam/ui/SaveAttemptSectionTest.kt
@@ -22,16 +22,13 @@ class SaveAttemptSectionTest {
     private val attemptSectionDao =
             TestpressSDKDatabase.getAttemptSectionDao(context)
 
-
-    @Before
-    fun setup() {
-        saveAttempt()
-        saveAttemptSection()
-    }
-
     @Test
     fun saveInDBShouldSaveAttemptSection() {
+        saveAttempt()
+        saveAttemptSection()
+
         courseAttempt.saveInDB(context, Content(1))
+
         val section = attemptSectionDao.queryBuilder().where(AttemptSectionDao.Properties.AttemptId.eq(1)).list()
         Assert.assertFalse(section.isEmpty())
     }

--- a/exam/src/test/java/in/testpress/exam/ui/SaveAttemptSectionTest.kt
+++ b/exam/src/test/java/in/testpress/exam/ui/SaveAttemptSectionTest.kt
@@ -8,25 +8,32 @@ import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.Mockito
+import org.mockito.MockitoAnnotations
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
 class SaveAttemptSectionTest {
 
-    private val attempt = Attempt()
+    private val attempt = Attempt(1)
 
-    private val courseAttempt = CourseAttempt()
+    var courseAttempt: CourseAttempt = Mockito.mock(CourseAttempt::class.java)
 
     private val context: Context = ApplicationProvider.getApplicationContext()
 
     private val attemptSectionDao =
             TestpressSDKDatabase.getAttemptSectionDao(context)
 
-    @Test
-    fun saveInDBShouldSaveAttemptSection() {
+    @Before
+    fun setup() {
+        MockitoAnnotations.initMocks(this)
+        Mockito.`when`(courseAttempt.rawAssessment).thenReturn(attempt)
         saveAttempt()
         saveAttemptSection()
+    }
 
+    @Test
+    fun saveInDBShouldSaveAttemptSection() {
         courseAttempt.saveInDB(context, Content(1))
 
         val section = attemptSectionDao.queryBuilder().where(AttemptSectionDao.Properties.AttemptId.eq(1)).list()
@@ -35,7 +42,7 @@ class SaveAttemptSectionTest {
 
     private fun saveAttemptSection() {
         val attemptSection = listOf(AttemptSection(
-                1,"state", "https://sandox.testpress.in","Start", "End",
+                1, "state", "https://sandox.testpress.in", "Start", "End",
                 "time", "name", "duration", 1,
                 "instruction", 1))
         attemptSectionDao.insertOrReplaceInTx(attemptSection)
@@ -44,8 +51,8 @@ class SaveAttemptSectionTest {
     private fun saveAttempt() {
         val attemptDao = TestpressSDKDatabase.getAttemptDao(ApplicationProvider.getApplicationContext())
         attemptDao.insertOrReplace(Attempt(
-                "https://sandox.testpress.in",1,"date",10,"10","2","10",
-                "reviewUrl","Question url",2,1,"","","","","",1,1,"per"
+                "https://sandox.testpress.in", 1, "date", 10, "10", "2", "10",
+                "reviewUrl", "Question url", 2, 1, "", "", "", "", "", 1, 1, "per"
         ))
     }
 }

--- a/exam/src/test/java/in/testpress/exam/ui/SaveAttemptSectionTest.kt
+++ b/exam/src/test/java/in/testpress/exam/ui/SaveAttemptSectionTest.kt
@@ -2,6 +2,7 @@ package `in`.testpress.exam.ui
 
 import `in`.testpress.core.TestpressSDKDatabase
 import `in`.testpress.models.greendao.*
+import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import org.junit.Assert
 import org.junit.Before
@@ -14,8 +15,12 @@ class SaveAttemptSectionTest {
 
     private val attempt = Attempt()
 
+    private val courseAttempt = CourseAttempt()
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
     private val attemptSectionDao =
-            TestpressSDKDatabase.getAttemptSectionDao(ApplicationProvider.getApplicationContext())
+            TestpressSDKDatabase.getAttemptSectionDao(context)
 
 
     @Before
@@ -25,14 +30,15 @@ class SaveAttemptSectionTest {
     }
 
     @Test
-    fun testSectionShouldSaveCorrectly() {
+    fun saveInDBShouldSaveAttemptSection() {
+        courseAttempt.saveInDB(context, Content(1))
         val section = attemptSectionDao.queryBuilder().where(AttemptSectionDao.Properties.AttemptId.eq(1)).list()
         Assert.assertFalse(section.isEmpty())
     }
 
     private fun saveAttemptSection() {
         val attemptSection = listOf(AttemptSection(
-                1,"state", "Url","Start", "End",
+                1,"state", "https://sandox.testpress.in","Start", "End",
                 "time", "name", "duration", 1,
                 "instruction", 1))
         attemptSectionDao.insertOrReplaceInTx(attemptSection)
@@ -40,6 +46,9 @@ class SaveAttemptSectionTest {
 
     private fun saveAttempt() {
         val attemptDao = TestpressSDKDatabase.getAttemptDao(ApplicationProvider.getApplicationContext())
-        attemptDao.insertOrReplace(Attempt(1))
+        attemptDao.insertOrReplace(Attempt(
+                "https://sandox.testpress.in",1,"date",10,"10","2","10",
+                "reviewUrl","Question url",2,1,"","","","","",1,1,"per"
+        ))
     }
 }

--- a/exam/src/test/java/in/testpress/exam/ui/ShareToUnlockActivityTest.kt
+++ b/exam/src/test/java/in/testpress/exam/ui/ShareToUnlockActivityTest.kt
@@ -49,7 +49,7 @@ class ShareToUnlockActivityTest {
         val shareIntent = activity.getShareIntent()
 
         Assert.assertEquals(shareIntent.action, Intent.ACTION_SEND)
-        Assert.assertEquals(shareIntent.extras[EXTRA_TEXT], messageToShare)
+        Assert.assertEquals(shareIntent.extras?.get(EXTRA_TEXT), messageToShare)
         Assert.assertEquals(shareIntent.type, "text/html")
     }
 

--- a/exam/src/test/java/in/testpress/exam/ui/ShareToUnlockActivityTest.kt
+++ b/exam/src/test/java/in/testpress/exam/ui/ShareToUnlockActivityTest.kt
@@ -49,7 +49,7 @@ class ShareToUnlockActivityTest {
         val shareIntent = activity.getShareIntent()
 
         Assert.assertEquals(shareIntent.action, Intent.ACTION_SEND)
-        Assert.assertEquals(shareIntent.extras?.get(EXTRA_TEXT), messageToShare)
+        Assert.assertEquals(shareIntent.extras[EXTRA_TEXT], messageToShare)
         Assert.assertEquals(shareIntent.type, "text/html")
     }
 


### PR DESCRIPTION
- The issue is the section is not stored in the DB when we start the exam.
- So when we resume an exam the section will be null.
- This is fixed by storing the sections in DB