### PR TITLE
Fix next content not opening after pdf if progressive lock is on

### DIFF
--- a/course/src/main/java/in/testpress/course/fragments/DocumentViewerFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/DocumentViewerFragment.kt
@@ -66,6 +66,7 @@ class DocumentViewerFragment : BaseContentDetailFragment(), PdfDownloadListener,
         pdfDownloader = PDFDownloader(this,requireContext(),fileName)
         if (pdfDownloader.isDownloaded()) {
             displayPDF()
+            viewModel.createContentAttempt(contentId)
         } else {
             content.attachment?.attachmentUrl?.let {
                 pdfDownloader.download(it)
@@ -81,6 +82,7 @@ class DocumentViewerFragment : BaseContentDetailFragment(), PdfDownloadListener,
 
     override fun onDownloadSuccess() {
         displayPDF()
+        viewModel.createContentAttempt(contentId)
     }
 
     private fun displayPDF() {


### PR DESCRIPTION
- Issue is we are not creating content attempt for pdf, so next content is not getting unlocked when progressive lock is enabled.

