### PR TITLE
Refresh contents list on back press from content detail

### DIFF
--- a/course/src/main/java/in/testpress/course/fragments/BaseContentDetailFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/BaseContentDetailFragment.kt
@@ -7,6 +7,7 @@ import `in`.testpress.course.TestpressCourse.CONTENT_TYPE
 import `in`.testpress.course.TestpressCourse.PRODUCT_SLUG
 import `in`.testpress.course.di.InjectorUtils
 import `in`.testpress.course.domain.DomainContent
+import `in`.testpress.course.ui.ContentActivity
 import `in`.testpress.enums.Status
 import `in`.testpress.course.ui.ContentActivity.CONTENT_ID
 import `in`.testpress.course.ui.ContentActivity.HIDE_BOTTOM_NAVIGATION
@@ -14,7 +15,9 @@ import `in`.testpress.course.viewmodels.ContentViewModel
 import `in`.testpress.fragments.EmptyViewFragment
 import `in`.testpress.fragments.EmptyViewListener
 import android.app.Activity
+import android.content.Context
 import android.content.Intent
+import android.content.SharedPreferences
 import android.os.Bundle
 import android.view.MenuItem
 import android.view.View
@@ -27,7 +30,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 
-abstract class BaseContentDetailFragment : Fragment(), BookmarkListener,
+abstract class BaseContentDetailFragment : Fragment(), BookmarkListener, ContentActivity.OnBackPressedListener,
     EmptyViewListener {
     protected lateinit var swipeRefresh: SwipeRefreshLayout
     @VisibleForTesting(otherwise = VisibleForTesting.PROTECTED)
@@ -181,6 +184,14 @@ abstract class BaseContentDetailFragment : Fragment(), BookmarkListener,
 
     override fun onRetryClick() {
         forceReloadContent()
+    }
+
+    override fun onBackPressed() {
+        val prefs: SharedPreferences = requireActivity().getSharedPreferences(
+                ContentActivity.TESTPRESS_CONTENT_SHARED_PREFS,
+                Context.MODE_PRIVATE
+        )
+        prefs.edit().putBoolean(ContentActivity.FORCE_REFRESH, true).apply()
     }
 
     abstract fun display()

--- a/course/src/main/java/in/testpress/course/fragments/BaseContentDetailFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/BaseContentDetailFragment.kt
@@ -187,6 +187,7 @@ abstract class BaseContentDetailFragment : Fragment(), BookmarkListener, Content
     }
 
     override fun onBackPressed() {
+        // ChapterDetailActivity will force refresh content list if FORCE_REFRESH is true in preference
         val prefs: SharedPreferences = requireActivity().getSharedPreferences(
                 ContentActivity.TESTPRESS_CONTENT_SHARED_PREFS,
                 Context.MODE_PRIVATE

--- a/course/src/main/java/in/testpress/course/ui/ContentActivity.java
+++ b/course/src/main/java/in/testpress/course/ui/ContentActivity.java
@@ -55,11 +55,20 @@ public class ContentActivity extends BaseToolBarActivity implements ContentFragm
             if (getCallingActivity() != null) {
                 return false;
             } else {
+                delegateBackPressToFragments()
                 super.onBackPressed();
             }
             return true;
         }
         return super.onOptionsItemSelected(item);
+    }
+
+    private void delegateBackPressToFragments() {
+        for (Fragment fragment : getSupportFragmentManager().getFragments()) {
+            if(fragment instanceof OnBackPressedListener){
+                ((OnBackPressedListener)fragment).onBackPressed();
+            }
+        }
     }
 
     @Override
@@ -81,5 +90,9 @@ public class ContentActivity extends BaseToolBarActivity implements ContentFragm
         for (Fragment fragment : getSupportFragmentManager().getFragments()) {
             fragment.onActivityResult(requestCode, resultCode, data);
         }
+    }
+
+    public interface OnBackPressedListener {
+        public void onBackPressed();
     }
 }

--- a/course/src/main/java/in/testpress/course/ui/ContentActivity.java
+++ b/course/src/main/java/in/testpress/course/ui/ContentActivity.java
@@ -52,15 +52,21 @@ public class ContentActivity extends BaseToolBarActivity implements ContentFragm
     @Override
     public boolean onOptionsItemSelected(final MenuItem item) {
         if(item.getItemId() == android.R.id.home) {
+            delegateBackPressToFragments();
             if (getCallingActivity() != null) {
                 return false;
             } else {
-                delegateBackPressToFragments();
                 super.onBackPressed();
             }
             return true;
         }
         return super.onOptionsItemSelected(item);
+    }
+
+    @Override
+    public void onBackPressed() {
+        super.onBackPressed();
+        delegateBackPressToFragments();
     }
 
     private void delegateBackPressToFragments() {

--- a/course/src/main/java/in/testpress/course/ui/ContentActivity.java
+++ b/course/src/main/java/in/testpress/course/ui/ContentActivity.java
@@ -55,7 +55,7 @@ public class ContentActivity extends BaseToolBarActivity implements ContentFragm
             if (getCallingActivity() != null) {
                 return false;
             } else {
-                delegateBackPressToFragments()
+                delegateBackPressToFragments();
                 super.onBackPressed();
             }
             return true;


### PR DESCRIPTION
- Issue is if progressive lock is enabled and if user completes a content then on clicking back next content is not unlocked.
- Another Issue is attempted tick is not displayed when an user views a content detail and goes back.
- So to solve this content list is refetched in the background once the user presses back button from content detail
