### PR TITLE
Fix zoom live class can be recorded randomnly bug

### DIFF
--- a/course/src/main/java/in/testpress/course/ui/ZoomMeetActivity.kt
+++ b/course/src/main/java/in/testpress/course/ui/ZoomMeetActivity.kt
@@ -1,19 +1,31 @@
 package `in`.testpress.course.ui
 
 import `in`.testpress.core.TestpressSdk
-import android.os.Bundle
+import android.view.View
 import android.view.WindowManager
 import us.zoom.sdk.MeetingActivity
 
 class ZoomMeetActivity: MeetingActivity() {
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        val session = TestpressSdk.getTestpressSession(this)
-        if (session != null && session.instituteSettings.isScreenshotDisabled) {
-            window.setFlags(
-                WindowManager.LayoutParams.FLAG_SECURE,
-                WindowManager.LayoutParams.FLAG_SECURE
-            )
+    val session = TestpressSdk.getTestpressSession(this)
+
+    override fun setContentView(layoutResID: Int) {
+        if (session?.instituteSettings?.isScreenshotDisabled == true) {
+            disableScreenRecording()
         }
+        super.setContentView(layoutResID)
+    }
+
+    override fun setContentView(view: View?) {
+        if (session?.instituteSettings?.isScreenshotDisabled == true) {
+            disableScreenRecording()
+        }
+        super.setContentView(view)
+    }
+
+    private fun disableScreenRecording() {
+        window.setFlags(
+            WindowManager.LayoutParams.FLAG_SECURE,
+            WindowManager.LayoutParams.FLAG_SECURE
+        )
     }
 }


### PR DESCRIPTION
- Issue is sometimes zoom live class can be recorded.
- This is because screen recording disabling should be done before setting content view.
- So instead of onCreate screen record disabling is done in setContentView

