### PR TITLE
Fix incorrect video watch duration update to API

### DIFF
--- a/core/src/main/java/in/testpress/util/TimeUtils.kt
+++ b/core/src/main/java/in/testpress/util/TimeUtils.kt
@@ -1,0 +1,8 @@
+package `in`.testpress.util
+
+object TimeUtils {
+    @JvmStatic
+    fun convertMilliSecondsToSeconds(milliseconds: Long): Float {
+        return maxOf(0, milliseconds).toFloat() / 1000
+    }
+}

--- a/core/src/main/java/in/testpress/util/TimeUtils.kt
+++ b/core/src/main/java/in/testpress/util/TimeUtils.kt
@@ -2,7 +2,7 @@ package `in`.testpress.util
 
 object TimeUtils {
     @JvmStatic
-    fun convertMilliSecondsToSeconds(milliseconds: Long): Float {
-        return maxOf(0, milliseconds).toFloat() / 1000
+    fun convertMilliSecondsToSeconds(milliseconds: Long): Long {
+        return maxOf(0, milliseconds) / 1000
     }
 }

--- a/course/src/main/java/in/testpress/course/util/ExoPlayerUtil.java
+++ b/course/src/main/java/in/testpress/course/util/ExoPlayerUtil.java
@@ -84,10 +84,9 @@ import static com.google.android.exoplayer2.ExoPlaybackException.TYPE_SOURCE;
 import static in.testpress.course.api.TestpressCourseApiClient.LAST_POSITION;
 import static in.testpress.course.api.TestpressCourseApiClient.TIME_RANGES;
 
-public class ExoPlayerUtil implements VideoWatchPositionListener {
+public class ExoPlayerUtil implements VideoTimeRangeListener {
 
     private static final int OVERLAY_POSITION_CHANGE_INTERVAL = 15000; // 15s
-    private static final String TAG = "ExoPlayerUtil";
 
     private FrameLayout exoPlayerMainFrame;
     private View exoPlayerLayout;
@@ -102,7 +101,7 @@ public class ExoPlayerUtil implements VideoWatchPositionListener {
     private Dialog fullscreenDialog;
     private TrackSelectionDialog trackSelectionDialog;
     private YouTubeOverlay youtubeOverlay;
-    List<String[]> watchedPositions = new ArrayList<>();
+    List<String[]> watchedTimeRanges = new ArrayList<>();
 
 
     private Activity activity;
@@ -628,7 +627,7 @@ public class ExoPlayerUtil implements VideoWatchPositionListener {
         Map<String, Object> parameters = new HashMap<>();
         float currentPosition = getCurrentPosition();
         parameters.put(LAST_POSITION, currentPosition);
-        parameters.put(TIME_RANGES, watchedPositions);
+        parameters.put(TIME_RANGES, watchedTimeRanges);
         return parameters;
     }
 
@@ -714,8 +713,8 @@ public class ExoPlayerUtil implements VideoWatchPositionListener {
     }
 
     @Override
-    public void onWatchDurationChange(long startTime, long endTime) {
-        watchedPositions.add(new String[]{String.valueOf(startTime), String.valueOf(endTime)});
+    public void onTimeRangeChange(long startTime, long endTime) {
+        watchedTimeRanges.add(new String[]{String.valueOf(startTime), String.valueOf(endTime)});
     }
 
     private class PlayerEventListener implements Player.EventListener {

--- a/course/src/main/java/in/testpress/course/util/ExoplayerAnalyticsListener.kt
+++ b/course/src/main/java/in/testpress/course/util/ExoplayerAnalyticsListener.kt
@@ -3,7 +3,7 @@ package `in`.testpress.course.util
 import `in`.testpress.util.TimeUtils.convertMilliSecondsToSeconds
 import com.google.android.exoplayer2.analytics.AnalyticsListener
 
-class ExoplayerAnalyticsListener(val watchPositionListener: VideoWatchPositionListener): AnalyticsListener {
+class ExoplayerAnalyticsListener(val videoTimeRangeListener: VideoTimeRangeListener): AnalyticsListener {
     var endPosition: Long = 0
     var startPosition: Long = 0
 
@@ -12,7 +12,7 @@ class ExoplayerAnalyticsListener(val watchPositionListener: VideoWatchPositionLi
         endPosition = convertMilliSecondsToSeconds(eventTime.currentPlaybackPositionMs).toLong()
 
         if (startPosition < endPosition) {
-            watchPositionListener.onWatchDurationChange(startPosition, endPosition)
+            videoTimeRangeListener.onTimeRangeChange(startPosition, endPosition)
         }
     }
 
@@ -22,6 +22,6 @@ class ExoplayerAnalyticsListener(val watchPositionListener: VideoWatchPositionLi
     }
 }
 
-interface VideoWatchPositionListener {
-    fun onWatchDurationChange(startTime: Long, endTime: Long)
+interface VideoTimeRangeListener {
+    fun onTimeRangeChange(startTime: Long, endTime: Long)
 }

--- a/course/src/main/java/in/testpress/course/util/ExoplayerAnalyticsListener.kt
+++ b/course/src/main/java/in/testpress/course/util/ExoplayerAnalyticsListener.kt
@@ -1,0 +1,27 @@
+package `in`.testpress.course.util
+
+import `in`.testpress.util.TimeUtils.convertMilliSecondsToSeconds
+import com.google.android.exoplayer2.analytics.AnalyticsListener
+
+class ExoplayerAnalyticsListener(val watchPositionListener: VideoWatchPositionListener): AnalyticsListener {
+    var endPosition: Long = 0
+    var startPosition: Long = 0
+
+    override fun onSeekStarted(eventTime: AnalyticsListener.EventTime) {
+        super.onSeekStarted(eventTime)
+        endPosition = convertMilliSecondsToSeconds(eventTime.currentPlaybackPositionMs).toLong()
+
+        if (startPosition < endPosition) {
+            watchPositionListener.onWatchDurationChange(startPosition, endPosition)
+        }
+    }
+
+    override fun onPositionDiscontinuity(eventTime: AnalyticsListener.EventTime, reason: Int) {
+        super.onPositionDiscontinuity(eventTime, reason)
+        startPosition = convertMilliSecondsToSeconds(eventTime.currentPlaybackPositionMs).toLong()
+    }
+}
+
+interface VideoWatchPositionListener {
+    fun onWatchDurationChange(startTime: Long, endTime: Long)
+}


### PR DESCRIPTION
- Issue is if user moves forward then we send only that duration data to server but since API is throttled server may discard it. So only some watch duration will be stored in server.
- Solution is to send all watch duration data to server.
- This is done by listening to player seek events and storing all watch duration data. Once user presses back button/seek/play/pause all the stored watch duration will be sent to server
