### PR TITLE
Fix start button not displayed for shallow cloned exams

### DIFF
--- a/course/src/main/java/in/testpress/course/domain/DomainContent.kt
+++ b/course/src/main/java/in/testpress/course/domain/DomainContent.kt
@@ -10,6 +10,8 @@ import `in`.testpress.models.greendao.CourseAttemptDao
 import `in`.testpress.util.FormatDate
 import android.content.Context
 import android.text.format.DateUtils
+import com.google.android.exoplayer2.C
+import com.google.android.exoplayer2.util.Util
 
 data class DomainContent(
     val id: Long,

--- a/course/src/main/java/in/testpress/course/domain/DomainContent.kt
+++ b/course/src/main/java/in/testpress/course/domain/DomainContent.kt
@@ -82,8 +82,11 @@ data class DomainContent(
     fun hasNotAttempted() = !hasAttempted()
 
     private fun canBeRetaken(): Boolean {
-        return exam!!.allowRetake!! &&
-                (attemptsCount!! <= exam!!.maxRetakes!! || exam!!.maxRetakes!! < 0)
+        if (exam?.allowRetake == true) {
+            return attemptsCount!! <= exam!!.maxRetakes!!
+        }
+
+        return false
     }
 
     fun canAttemptExam(): Boolean {

--- a/course/src/main/java/in/testpress/course/domain/DomainContent.kt
+++ b/course/src/main/java/in/testpress/course/domain/DomainContent.kt
@@ -10,8 +10,6 @@ import `in`.testpress.models.greendao.CourseAttemptDao
 import `in`.testpress.util.FormatDate
 import android.content.Context
 import android.text.format.DateUtils
-import com.google.android.exoplayer2.C
-import com.google.android.exoplayer2.util.Util
 
 data class DomainContent(
     val id: Long,
@@ -81,7 +79,7 @@ data class DomainContent(
 
     fun hasNotAttempted() = !hasAttempted()
 
-    private fun canBeRetaken(): Boolean {
+    private fun canRetakeExam(): Boolean {
         if (exam?.allowRetake == true) {
             return attemptsCount!! <= exam!!.maxRetakes!!
         }
@@ -98,7 +96,7 @@ data class DomainContent(
             return false
         }
 
-        return canBeRetaken() || hasNotAttempted()
+        return canRetakeExam() || hasNotAttempted()
     }
 }
 

--- a/course/src/main/java/in/testpress/course/domain/DomainContent.kt
+++ b/course/src/main/java/in/testpress/course/domain/DomainContent.kt
@@ -86,12 +86,16 @@ data class DomainContent(
                 (attemptsCount!! <= exam!!.maxRetakes!! || exam!!.maxRetakes!! < 0)
     }
 
-    fun canExamAttempted(): Boolean {
+    fun canAttemptExam(): Boolean {
         if (exam == null) {
             return false
         }
 
-        return exam!!.isNotEnded() && (canBeRetaken() || hasNotAttempted()) && !exam!!.isWebOnly()
+        if (exam!!.isEnded() || exam!!.isWebOnly()) {
+            return false
+        }
+
+        return canBeRetaken() || hasNotAttempted()
     }
 }
 

--- a/course/src/main/java/in/testpress/course/domain/DomainContent.kt
+++ b/course/src/main/java/in/testpress/course/domain/DomainContent.kt
@@ -78,6 +78,21 @@ data class DomainContent(
     fun hasAttempted(): Boolean {
         return (attemptsCount ?: 0) > 0
     }
+
+    fun hasNotAttempted() = !hasAttempted()
+
+    private fun canBeRetaken(): Boolean {
+        return exam!!.allowRetake!! &&
+                (attemptsCount!! <= exam!!.maxRetakes!! || exam!!.maxRetakes!! < 0)
+    }
+
+    fun canExamAttempted(): Boolean {
+        if (exam == null) {
+            return false
+        }
+
+        return exam!!.isNotEnded() && (canBeRetaken() || hasNotAttempted()) && !exam!!.isWebOnly()
+    }
 }
 
 fun createDomainContent(contentEntity: ContentEntity): DomainContent {

--- a/course/src/main/java/in/testpress/course/domain/DomainExamContent.kt
+++ b/course/src/main/java/in/testpress/course/domain/DomainExamContent.kt
@@ -64,12 +64,7 @@ data class DomainExamContent(
         return deviceAccessControl != null && deviceAccessControl == "web"
     }
 
-    private fun canRetake(): Boolean {
-        return allowRetake!! &&
-            (attemptsCount!! <= maxRetakes!! || maxRetakes < 0)
-    }
-
-    private fun isEnded(): Boolean {
+    fun isEnded(): Boolean {
         val simpleDateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ")
         simpleDateFormat.timeZone = TimeZone.getTimeZone("UTC")
         try {
@@ -82,11 +77,13 @@ data class DomainExamContent(
         return false
     }
 
+    fun isNotEnded() = !isEnded()
+
     fun canBeAttempted(): Boolean {
         if (isEnded()) {
             return false
         }
-        return if (attemptsCount == 0 || canRetake()) {
+        return if (attemptsCount == 0) {
             !isWebOnly()
         } else false
     }

--- a/course/src/main/java/in/testpress/course/domain/DomainExamContent.kt
+++ b/course/src/main/java/in/testpress/course/domain/DomainExamContent.kt
@@ -77,17 +77,6 @@ data class DomainExamContent(
         return false
     }
 
-    fun isNotEnded() = !isEnded()
-
-    fun canBeAttempted(): Boolean {
-        if (isEnded()) {
-            return false
-        }
-        return if (attemptsCount == 0) {
-            !isWebOnly()
-        } else false
-    }
-
     fun hasMultipleLanguages() = languages.size > 1
 }
 

--- a/course/src/main/java/in/testpress/course/fragments/BaseExamWidgetFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/BaseExamWidgetFragment.kt
@@ -127,7 +127,7 @@ open class BaseExamWidgetFragment : Fragment() {
     }
 
     private fun updateStartButtonTextAndVisibility(exam: DomainExamContent, pausedAttempt: DomainContentAttempt?) {
-        if (pausedAttempt == null && exam.canBeAttempted()) {
+        if (pausedAttempt == null && content.canExamAttempted()) {
             if (contentAttempts.isEmpty()) {
                 startButton.text = getString(R.string.testpress_start)
             } else {
@@ -155,7 +155,7 @@ open class BaseExamWidgetFragment : Fragment() {
             return
         }
 
-        if (pausedAttempt == null && exam.canBeAttempted()) {
+        if (pausedAttempt == null && content.canExamAttempted()) {
             if (contentAttempts.isEmpty()) {
                 startButton.text = getString(R.string.testpress_start)
             } else {

--- a/course/src/main/java/in/testpress/course/fragments/BaseExamWidgetFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/BaseExamWidgetFragment.kt
@@ -23,7 +23,6 @@ import `in`.testpress.exam.util.RetakeExamUtil
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
-import android.util.Log
 import android.view.View
 import android.widget.Button
 import androidx.fragment.app.Fragment
@@ -127,7 +126,7 @@ open class BaseExamWidgetFragment : Fragment() {
     }
 
     private fun updateStartButtonTextAndVisibility(exam: DomainExamContent, pausedAttempt: DomainContentAttempt?) {
-        if (pausedAttempt == null && content.canExamAttempted()) {
+        if (pausedAttempt == null && content.canAttemptExam()) {
             if (contentAttempts.isEmpty()) {
                 startButton.text = getString(R.string.testpress_start)
             } else {
@@ -155,7 +154,7 @@ open class BaseExamWidgetFragment : Fragment() {
             return
         }
 
-        if (pausedAttempt == null && content.canExamAttempted()) {
+        if (pausedAttempt == null && content.canAttemptExam()) {
             if (contentAttempts.isEmpty()) {
                 startButton.text = getString(R.string.testpress_start)
             } else {


### PR DESCRIPTION
- Issue is start button is not displayed for shallow cloned exams. This happens when user attempts one of the clone and if user tries to attend the another clone then start button won't be displayed. This is because user already has attempted the exam.
- This issue is fixed by considering attempt count of chapter content instead of exam