### PR TITLE
Fix exam ended status message

### DIFF
--- a/course/src/main/java/in/testpress/course/fragments/ExamStartScreenFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/ExamStartScreenFragment.kt
@@ -151,7 +151,7 @@ class ExamStartScreenFragment : BaseExamWidgetFragment() {
         examStatusDescription.text = getString(R.string.testpress_all_the_best)
         examStatusDescription.setTextColor(resources.getColor(R.color.testpress_black))
 
-        examStatusIcon.setImageDrawable(resources.getDrawable(R.drawable.ic_baseline_info_24))
+        examStatusIcon.setImageDrawable(resources.getDrawable(R.drawable.ic_thumb_up_black_18dp))
         examStatusIcon.setColorFilter(resources.getColor(R.color.testpress_black))
     }
 }

--- a/course/src/main/java/in/testpress/course/fragments/ExamStartScreenFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/ExamStartScreenFragment.kt
@@ -98,7 +98,7 @@ class ExamStartScreenFragment : BaseExamWidgetFragment() {
         showDescription()
         showOrHideExamDate(exam)
         showExamDuration(exam)
-        showExamStatusViews(exam)
+        showExamStatus(exam)
     }
 
     private fun showDescription() {
@@ -128,17 +128,17 @@ class ExamStartScreenFragment : BaseExamWidgetFragment() {
         }
     }
 
-    private fun showExamStatusViews(exam: DomainExamContent) {
+    private fun showExamStatus(exam: DomainExamContent) {
         if (exam.isEnded()){
-            displayExamEndedView()
+            displayExamEndedMessage()
         }
         else {
-            displayAllTheBestView()
+            displayAllTheBestMessage()
         }
     }
 
     @SuppressLint("UseCompatLoadingForDrawables")
-    private fun displayExamEndedView(){
+    private fun displayExamEndedMessage(){
         examStatusDescription.text = getString(R.string.testpress_exam_ended)
         examStatusDescription.setTextColor(resources.getColor(R.color.testpress_red))
 
@@ -147,7 +147,7 @@ class ExamStartScreenFragment : BaseExamWidgetFragment() {
     }
 
     @SuppressLint("UseCompatLoadingForDrawables")
-    private fun displayAllTheBestView(){
+    private fun displayAllTheBestMessage(){
         examStatusDescription.text = getString(R.string.testpress_all_the_best)
         examStatusDescription.setTextColor(resources.getColor(R.color.testpress_black))
 

--- a/course/src/main/java/in/testpress/course/fragments/ExamStartScreenFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/ExamStartScreenFragment.kt
@@ -7,11 +7,13 @@ import `in`.testpress.course.domain.getGreenDaoContentAttempt
 import `in`.testpress.course.ui.ContentActivity
 import `in`.testpress.exam.api.TestpressExamApiClient.STATE_PAUSED
 import `in`.testpress.util.ViewUtils
+import android.annotation.SuppressLint
 import android.os.Bundle
 import android.text.Html
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.TextView
 
@@ -30,6 +32,8 @@ class ExamStartScreenFragment : BaseExamWidgetFragment() {
     private lateinit var negativeMarkLabel: TextView
     private lateinit var dateLabel: TextView
     private lateinit var languageLabel: TextView
+    private lateinit var examStatusDescription: TextView
+    private lateinit var examStatusIcon: ImageView
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -60,6 +64,8 @@ class ExamStartScreenFragment : BaseExamWidgetFragment() {
         negativeMarkLabel = view.findViewById(R.id.negative_marks_label)
         dateLabel = view.findViewById(R.id.date_label)
         languageLabel = view.findViewById(R.id.language_label)
+        examStatusDescription = view.findViewById(R.id.exam_status_description)
+        examStatusIcon = view.findViewById(R.id.exam_status_icon)
 
         ViewUtils.setTypeface(
             arrayOf(
@@ -92,6 +98,7 @@ class ExamStartScreenFragment : BaseExamWidgetFragment() {
         showDescription()
         showOrHideExamDate(exam)
         showExamDuration(exam)
+        showExamStatusViews(exam)
     }
 
     private fun showDescription() {
@@ -119,5 +126,32 @@ class ExamStartScreenFragment : BaseExamWidgetFragment() {
                 examDuration.text = greendaoContentAttempt.assessment.remainingTime
             }
         }
+    }
+
+    private fun showExamStatusViews(exam: DomainExamContent) {
+        if (exam.isEnded()){
+            displayExamEndedView()
+        }
+        else {
+            displayAllTheBestView()
+        }
+    }
+
+    @SuppressLint("UseCompatLoadingForDrawables")
+    private fun displayExamEndedView(){
+        examStatusDescription.text = getString(R.string.testpress_exam_ended)
+        examStatusDescription.setTextColor(resources.getColor(R.color.testpress_red))
+
+        examStatusIcon.setImageDrawable(resources.getDrawable(R.drawable.ic_baseline_info_24))
+        examStatusIcon.setColorFilter(resources.getColor(R.color.testpress_red))
+    }
+
+    @SuppressLint("UseCompatLoadingForDrawables")
+    private fun displayAllTheBestView(){
+        examStatusDescription.text = getString(R.string.testpress_all_the_best)
+        examStatusDescription.setTextColor(resources.getColor(R.color.testpress_black))
+
+        examStatusIcon.setImageDrawable(resources.getDrawable(R.drawable.ic_baseline_info_24))
+        examStatusIcon.setColorFilter(resources.getColor(R.color.testpress_black))
     }
 }

--- a/course/src/main/res/drawable/ic_baseline_info_24.xml
+++ b/course/src/main/res/drawable/ic_baseline_info_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM13,17h-2v-6h2v6zM13,9h-2L11,7h2v2z"/>
+</vector>

--- a/exam/src/main/res/layout-xlarge/testpress_exam_details_layout.xml
+++ b/exam/src/main/res/layout-xlarge/testpress_exam_details_layout.xml
@@ -223,6 +223,7 @@
         tools:ignore="UseCompoundDrawables">
 
         <ImageView
+            android:id="@+id/exam_status_icon"
             android:layout_width="18dp"
             android:layout_height="18dp"
             android:tint="@color/testpress_black"
@@ -231,6 +232,7 @@
             android:src="@drawable/ic_thumb_up_black_18dp" />
 
         <TextView
+            android:id="@+id/exam_status_description"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:textColor="@color/testpress_black"

--- a/exam/src/main/res/layout/testpress_exam_details_layout.xml
+++ b/exam/src/main/res/layout/testpress_exam_details_layout.xml
@@ -215,6 +215,7 @@
         tools:ignore="UseCompoundDrawables">
 
         <ImageView
+            android:id="@+id/exam_status_icon"
             android:layout_width="18dp"
             android:layout_height="18dp"
             android:tint="@color/testpress_black"
@@ -224,6 +225,7 @@
             />
 
         <TextView
+            android:id="@+id/exam_status_description"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:textColor="@color/testpress_black"


### PR DESCRIPTION
### Changes done
- Exam start screen will let the user know whether the exam is ended or not by a description message at the bottom of the screen.

### Reason for the changes
- Previously, even if the exam was ended, an "All the Best" description message was displayed on the UI which confused the users. So the description message was changed to "The Exam was ended" if the exam was ended. 

