### PR TITLE
Fix App crash while opening zoom meetings on non-zoom ingrated app

### DIFF
--- a/course/src/main/java/in/testpress/course/fragments/VideoConferenceFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/VideoConferenceFragment.kt
@@ -16,6 +16,7 @@ import android.view.ViewGroup
 import android.widget.Button
 import android.widget.LinearLayout
 import android.widget.TextView
+import android.widget.Toast
 
 class VideoConferenceFragment : BaseContentDetailFragment() {
     private lateinit var titleView: TextView
@@ -75,8 +76,14 @@ class VideoConferenceFragment : BaseContentDetailFragment() {
     }
 
     private fun initializeVideoConferenceHandler(videoConference: DomainVideoConferenceContent?) {
-        videoConferenceHandler =  VideoConferenceHandler(requireContext(), videoConference!!, profileDetails)
-        videoConferenceHandler?.init()
+        try {
+            videoConferenceHandler =  VideoConferenceHandler(requireContext(), videoConference!!, profileDetails)
+            videoConferenceHandler?.init()
+        }
+        catch(e: NoClassDefFoundError){
+            Toast.makeText(context, "Zoom integration is not enabled in the app, please contact admin", Toast.LENGTH_LONG).show()
+        }
+
     }
 
     override fun onDestroy() {


### PR DESCRIPTION
### Changes done
- Handled `NoClassDefFoundError` while opening zoom meeting on Non-zoom enabled app.

### Reason for the changes
- Zoom plugin may or may not be enabled on app. So while invoking the method to open zoom meeting, if the plugin was not added, then it make the app crash by throwing `NoClassDefFoundError`. So handled this error in SDK side by displaying the appropriate toast message.
