### PR TITLE
Add null check for video duration in DownloadTask

### DIFF
--- a/course/src/main/java/in/testpress/course/helpers/DownloadTask.kt
+++ b/course/src/main/java/in/testpress/course/helpers/DownloadTask.kt
@@ -31,8 +31,8 @@ class DownloadTask(val url: String, val context: Context) {
         val offlineVideo = OfflineVideo(
             title = content.title,
             description = content.description,
-            duration = content.video!!.duration!!,
-            url = content.video.hlsUrl(),
+            duration = content.video?.duration ?: "0",
+            url = content.video?.hlsUrl(),
             contentId = content.id,
             remoteThumbnail = content.coverImageMedium,
             courseId = content.courseId


### PR DESCRIPTION
### Changes done
- Added a null check on duration field of Offline video in DownloadTask and assigned "0" if the duration is null.

### Reason for the changes
- `NullPointerException` was thrown as we were assigning null to duration field of OfflineVideo.