### PR TITLE
Fix Question collapse on quiz type exam

### DIFF
--- a/course/src/main/java/in/testpress/course/fragments/QuizQuestionFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/QuizQuestionFragment.kt
@@ -72,7 +72,7 @@ class QuizQuestionFragment : Fragment() {
         viewModel.getUserSelectedAnswers(attemptId).observe(viewLifecycleOwner, Observer {
             when(it.status) {
                 Status.SUCCESS -> {
-                    userSelectedAnswer = it.data?.get(position)!!
+                    userSelectedAnswer = it.data?.sortedBy { it.order }?.get(position)!!
                     initWebview()
                 }
             }

--- a/course/src/main/java/in/testpress/course/fragments/QuizReviewFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/QuizReviewFragment.kt
@@ -102,7 +102,7 @@ class QuizReviewFragment: Fragment() {
         viewModel.getUserSelectedAnswers(attemptId).observe(viewLifecycleOwner, Observer {
             when(it.status) {
                 Status.SUCCESS -> {
-                    userSelectedAnswer = it.data?.get(position)!!
+                    userSelectedAnswer = it.data?.sortedBy { it.order }?.get(position)!!
                     initWebview()
                 }
             }


### PR DESCRIPTION
### Changes done
- Sorted the data from viewModel on QuizQuestion Frag and QuizReview Frag.

### Reason for the changes
- Previously, both and questions and answers were retrived by basis of position. But it's not sorted by order. So it displayed questiions randomly in some cases.
