### PR TITLE
Fix exam not ending when maximum number of questions given

### DIFF
--- a/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
@@ -912,7 +912,7 @@ public class TestFragment extends BaseFragment implements LoaderManager.LoaderCa
                             if (exception.isForbidden() && isMaxQuestionsAttemptedError(errorDetails)) {
                                 clearAndLoadSameQuestion(position);
                                 saveAnswerAlertDialog = showMaxQuestionsAttemptedError(errorDetails);
-
+                                progressDialog.dismiss();
                             } else {
                                 stopTimer();
                                 progressDialog.dismiss();


### PR DESCRIPTION
### Changes done
- Stopped the progress bar after displaying maximum questions attempted

### Reason for the changes
- As user ends the exam attending with more than maximum number of questions, this progress dialog will be shown, but its not dismissed. So the user could not end the exam.
