### PR TITLE
Add support to publish package to github packages

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -114,6 +114,7 @@ dependencies {
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')
+apply from: rootProject.file('gradle/gradle-mvn-github-packages.gradle')
 repositories {
     mavenCentral()
 }

--- a/course/build.gradle
+++ b/course/build.gradle
@@ -90,6 +90,8 @@ dependencies {
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')
+apply from: rootProject.file('gradle/gradle-mvn-github-packages.gradle')
+
 repositories {
     mavenCentral()
 }

--- a/exam/build.gradle
+++ b/exam/build.gradle
@@ -61,6 +61,8 @@ dependencies {
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')
+apply from: rootProject.file('gradle/gradle-mvn-github-packages.gradle')
+
 repositories {
     mavenCentral()
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,7 +22,7 @@ org.gradle.daemon=true
 org.gradle.parallel=true
 
 GROUP=com.github.testpress
-VERSION_NAME=1.4.18
+VERSION_NAME=0.0.7
 
 REPO=android-sdk
 USER_ORG=testpress
@@ -40,3 +40,6 @@ POM_LICENCE_URL=http://www.apache.org/licenses/LICENSE-2.0.txt
 POM_LICENCE_DIST=repo
 android.useAndroidX=true
 android.enableJetifier=true
+
+GITHUB_USERNAME=
+GITHUB_ACCESS_KEY=

--- a/gradle/gradle-mvn-github-packages.gradle
+++ b/gradle/gradle-mvn-github-packages.gradle
@@ -1,0 +1,115 @@
+apply from: rootProject.file("github.properties")
+apply plugin: 'maven-publish'
+
+version = VERSION_NAME
+group = GROUP
+
+task androidJavadoc(type: Javadoc) {
+    source = android.sourceSets.main.java.srcDirs
+    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+    android.libraryVariants.all { variant ->
+        if (variant.name == 'release') {
+            owner.classpath += variant.javaCompileProvider.get().classpath
+        }
+    }
+
+    exclude '**/R.html', '**/R.*.html', '**/index.html'
+    options.encoding 'utf-8'
+    options {
+        addStringOption 'docencoding', 'utf-8'
+        addStringOption 'charset', 'utf-8'
+        links 'https://docs.oracle.com/javase/7/docs/api/'
+        links 'https://d.android.com/reference'
+        links 'https://developer.android.com/reference/androidx/'
+    }
+}
+
+task androidJavadocJar(type: Jar, dependsOn: androidJavadoc) {
+    archiveClassifier.set('javadoc')
+    from androidJavadoc.destinationDir
+
+    preserveFileTimestamps = false
+    reproducibleFileOrder = true
+}
+
+task javaSourcesJar(type: Jar) {
+    archiveClassifier.set('sources')
+    from android.sourceSets.main.java.srcDirs
+
+    preserveFileTimestamps = false
+    reproducibleFileOrder = true
+}
+
+afterEvaluate { project ->
+    publishing {
+        publications {
+            release(MavenPublication) {
+                groupId GROUP
+                artifactId POM_ARTIFACT_ID
+                version VERSION_NAME
+                artifact androidJavadocJar
+                artifact javaSourcesJar
+                artifact "$buildDir/outputs/aar/$project.name-release.aar"
+
+                pom {
+
+                    name = POM_NAME
+                    packaging = POM_PACKAGING
+                    description = POM_DESCRIPTION
+                    url = POM_URL
+                    groupId = GROUP
+                    artifactId = POM_ARTIFACT_ID
+                    version = VERSION_NAME
+
+                    scm {
+                        url = POM_SCM_URL
+                        connection = POM_SCM_CONNECTION
+                        developerConnection = POM_SCM_DEV_CONNECTION
+                    }
+
+                    licenses {
+                        license {
+                            name = POM_LICENCE_NAME
+                            url = POM_LICENCE_URL
+                            distribution = POM_LICENCE_DIST
+                        }
+                    }
+                }
+
+                pom.withXml {
+                    def dependenciesNode = asNode().appendNode('dependencies')
+                    // Iterate over the api dependencies (we don't want the test ones), adding a <dependency> node for each
+                    configurations.api.allDependencies.each {
+                        def dependencyNode = dependenciesNode.appendNode('dependency')
+                        dependencyNode.appendNode('groupId', it.group)
+                        dependencyNode.appendNode('artifactId', it.name)
+                        dependencyNode.appendNode('version', it.version)
+                    }
+                }
+
+
+            }
+        }
+
+        repositories {
+            maven {
+                name = "GitHubPackages"
+                
+                url = uri("https://maven.pkg.github.com/testpress/android-sdk")
+
+                credentials {
+                    username=GITHUB_USERNAME
+                    password=GITHUB_ACCESS_KEY
+                }
+            }
+        }
+    }
+}
+
+task cleanBuildPublishLocal(type: GradleBuild) {
+    tasks = ['clean', 'build', 'publishToMavenLocal']
+}
+
+task cleanBuildPublish(type: GradleBuild) {
+    tasks = ['clean', 'build', 'publish']
+}

--- a/store/build.gradle
+++ b/store/build.gradle
@@ -43,3 +43,4 @@ dependencies {
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')
+apply from: rootProject.file('gradle/gradle-mvn-github-packages.gradle')


### PR DESCRIPTION
- As Bintray is closed, we were using jitpack.io for artifact repository. But we need to manually build and upload artifacts there which is repetitive process.  
- So We moved to github packages to automatically upload artificats
