### PR TITLE
Add support to download DRM protected video

### DIFF
--- a/course/src/main/java/in/testpress/course/helpers/DownloadTask.kt
+++ b/course/src/main/java/in/testpress/course/helpers/DownloadTask.kt
@@ -115,4 +115,11 @@ object VideoDownload {
         val download = downloadIndex.getDownload(url)
         return if (download != null && download.state != Download.STATE_FAILED) download.request else null
     }
+
+    @JvmStatic
+    fun getDownload(url: String, context: Context): Download? {
+        val downloadManager = VideoDownloadManager(context).get()
+        val downloadIndex = downloadManager.downloadIndex
+        return downloadIndex.getDownload(url)
+    }
 }

--- a/course/src/main/java/in/testpress/course/helpers/VideoDownloadManager.kt
+++ b/course/src/main/java/in/testpress/course/helpers/VideoDownloadManager.kt
@@ -3,6 +3,8 @@ package `in`.testpress.course.helpers
 import `in`.testpress.course.util.ExoPlayerDataSourceFactory
 import android.content.Context
 import com.google.android.exoplayer2.database.ExoDatabaseProvider
+import com.google.android.exoplayer2.offline.DefaultDownloadIndex
+import com.google.android.exoplayer2.offline.DownloadIndex
 import com.google.android.exoplayer2.offline.DownloadManager
 import com.google.android.exoplayer2.upstream.cache.Cache
 import com.google.android.exoplayer2.upstream.cache.NoOpCacheEvictor
@@ -38,6 +40,10 @@ class VideoDownloadManager {
             ExoPlayerDataSourceFactory(context).getHttpDataSourceFactory(),
             Executors.newFixedThreadPool(6)
         )
+    }
+
+    fun getDownloadIndex(): DefaultDownloadIndex {
+        return DefaultDownloadIndex(databaseProvider)
     }
 
     fun getDownloadDirectory(): File {

--- a/course/src/main/java/in/testpress/course/helpers/VideoDownloadRequestCreationHandler.kt
+++ b/course/src/main/java/in/testpress/course/helpers/VideoDownloadRequestCreationHandler.kt
@@ -1,31 +1,45 @@
 package `in`.testpress.course.helpers
 
+import `in`.testpress.course.domain.DomainContent
+import `in`.testpress.course.util.DRMLicenseFetchCallback
 import `in`.testpress.course.util.ExoPlayerDataSourceFactory
 import `in`.testpress.course.util.ExoPlayerUtil
 import `in`.testpress.course.util.VideoUtils.getLowBitrateTrackIndex
 import android.content.Context
 import android.net.Uri
 import android.util.Log
+import `in`.testpress.course.util.OfflineDRMLicenseHelper
+import `in`.testpress.course.util.VideoUtils.getAudioOrVideoInfoWithDrmInitData
+import android.widget.Toast
 import com.google.android.exoplayer2.C
 import com.google.android.exoplayer2.DefaultRenderersFactory
 import com.google.android.exoplayer2.MediaItem
+import com.google.android.exoplayer2.drm.DefaultDrmSessionManager
+import com.google.android.exoplayer2.drm.DrmInitData
 import com.google.android.exoplayer2.offline.DownloadHelper
 import com.google.android.exoplayer2.offline.DownloadRequest
-import com.google.android.exoplayer2.source.TrackGroup
-import com.google.android.exoplayer2.source.TrackGroupArray
 import com.google.android.exoplayer2.trackselection.DefaultTrackSelector
 import com.google.android.exoplayer2.trackselection.MappingTrackSelector
 import com.google.android.exoplayer2.util.Util
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import java.io.IOException
 
-class VideoDownloadRequestCreationHandler(val context: Context, val url: String, val name: String) :
-    DownloadHelper.Callback {
+class VideoDownloadRequestCreationHandler(
+    val context: Context,
+    val content: DomainContent
+) :
+    DownloadHelper.Callback, DRMLicenseFetchCallback {
     private val downloadHelper: DownloadHelper
     private val trackSelectionParameters: DefaultTrackSelector.Parameters
     var listener: Listener? = null
-    private val mediaItem: MediaItem
+    private val mediaItem:MediaItem
+    private var keySetId:ByteArray? = null
 
     init {
+        val url = content.video!!.getPlaybackURL()!!
+        val uri = Uri.parse(url)
         trackSelectionParameters = DownloadHelper.getDefaultTrackSelectorParameters(context)
         mediaItem = MediaItem.Builder()
             .setUri(url)
@@ -37,17 +51,44 @@ class VideoDownloadRequestCreationHandler(val context: Context, val url: String,
     }
 
     private fun getDownloadHelper(): DownloadHelper {
+        val sessionManager = DefaultDrmSessionManager.Builder()
+            .build(CustomHttpDrmMediaCallback(context, content.id))
+        sessionManager.setMode(DefaultDrmSessionManager.MODE_DOWNLOAD, null)
         val dataSourceFactory = ExoPlayerDataSourceFactory(context).build()
         val renderersFactory = DefaultRenderersFactory(context)
-        return DownloadHelper.forMediaItem(mediaItem, trackSelectionParameters, renderersFactory, dataSourceFactory)
+        return DownloadHelper.forMediaItem(mediaItem, trackSelectionParameters, renderersFactory, dataSourceFactory, sessionManager)
     }
 
     override fun onPrepared(helper: DownloadHelper) {
-        listener?.onDownloadRequestHandlerPrepared(
-            getMappedTrackInfo(),
-            getRendererIndex(),
-            getTrackSelectionOverrides()
-        )
+        val format = getAudioOrVideoInfoWithDrmInitData(helper)
+        if (format == null) {
+            listener?.onDownloadRequestHandlerPrepared(
+                getMappedTrackInfo(),
+                getRendererIndex(),
+                getTrackSelectionOverrides()
+            )
+            return
+        }
+
+        if (!hasSchemaData(format.drmInitData!!)) {
+            Toast.makeText(
+                context,
+                "Download Start Error",
+                Toast.LENGTH_LONG
+            ).show()
+            return
+        }
+
+        OfflineDRMLicenseHelper.fetchLicense(context, content.id, downloadHelper, this)
+    }
+
+    private fun hasSchemaData(drmInitData: DrmInitData): Boolean {
+        for (i in 0 until drmInitData.schemeDataCount) {
+            if (drmInitData[i].hasData()) {
+                return true
+            }
+        }
+        return false
     }
 
     private fun getMappedTrackInfo(): MappingTrackSelector.MappedTrackInfo {
@@ -73,7 +114,8 @@ class VideoDownloadRequestCreationHandler(val context: Context, val url: String,
 
     fun buildDownloadRequest(overrides: List<DefaultTrackSelector.SelectionOverride>): DownloadRequest {
         setSelectedTracks(overrides)
-        return downloadHelper.getDownloadRequest(Util.getUtf8Bytes(name))
+        val name = content.title ?: ""
+        return downloadHelper.getDownloadRequest(Util.getUtf8Bytes(name)).copyWithKeySetId(keySetId)
     }
 
     private fun setSelectedTracks(overrides: List<DefaultTrackSelector.SelectionOverride>) {
@@ -98,5 +140,25 @@ class VideoDownloadRequestCreationHandler(val context: Context, val url: String,
         )
 
         fun onDownloadRequestHandlerPrepareError(helper: DownloadHelper, e: IOException)
+    }
+
+    override fun onLicenseFetchSuccess(keySetId: ByteArray) {
+        CoroutineScope(Dispatchers.Main).launch {
+            listener?.onDownloadRequestHandlerPrepared(
+                getMappedTrackInfo(),
+                getRendererIndex(),
+                getTrackSelectionOverrides()
+            )
+        }
+    }
+
+    override fun onLicenseFetchFailure() {
+        CoroutineScope(Dispatchers.Main).launch {
+            Toast.makeText(
+                context,
+                "Error in starting video download (License fetch error)",
+                Toast.LENGTH_LONG
+            ).show()
+        }
     }
 }

--- a/course/src/main/java/in/testpress/course/services/VideoDownloadService.kt
+++ b/course/src/main/java/in/testpress/course/services/VideoDownloadService.kt
@@ -9,6 +9,7 @@ import android.app.Notification
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
+import android.os.Build
 import com.google.android.exoplayer2.offline.Download
 import com.google.android.exoplayer2.offline.DownloadManager
 import com.google.android.exoplayer2.offline.DownloadService
@@ -97,9 +98,15 @@ class VideoDownloadService : DownloadService(
         val navigateToDownloadsActivity = Intent(this, DownloadsActivity::class.java).apply {
             flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
         }
-        return PendingIntent.getActivity(
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            PendingIntent.getActivity(
+                    this, 0, navigateToDownloadsActivity, PendingIntent.FLAG_IMMUTABLE
+            )
+        } else {
+            PendingIntent.getActivity(
                 this, 0, navigateToDownloadsActivity, PendingIntent.FLAG_UPDATE_CURRENT
-        )
+            )
+        }
     }
 
     private fun getFailedNotification(): Notification {

--- a/course/src/main/java/in/testpress/course/ui/VideoDownloadQualityChooserDialog.kt
+++ b/course/src/main/java/in/testpress/course/ui/VideoDownloadQualityChooserDialog.kt
@@ -35,7 +35,7 @@ class VideoDownloadQualityChooserDialog(val content: DomainContent) : DialogFrag
         videoDownloadRequestCreateHandler =
             VideoDownloadRequestCreationHandler(
                 requireContext(),
-                content.video!!.getPlaybackURL()!!, content.title!!
+                content
             )
         videoDownloadRequestCreateHandler.listener = this
     }

--- a/course/src/main/java/in/testpress/course/util/ExoPlayerUtil.java
+++ b/course/src/main/java/in/testpress/course/util/ExoPlayerUtil.java
@@ -9,6 +9,7 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.pm.ActivityInfo;
 import android.media.AudioManager;
+import android.media.MediaCodec;
 import android.os.Handler;
 import android.view.View;
 import android.view.ViewGroup;
@@ -43,6 +44,7 @@ import com.google.android.exoplayer2.PlaybackPreparer;
 import com.google.android.exoplayer2.Player;
 import com.google.android.exoplayer2.SimpleExoPlayer;
 import com.google.android.exoplayer2.drm.DefaultDrmSessionManager;
+import com.google.android.exoplayer2.drm.DrmSession;
 import com.google.android.exoplayer2.drm.DrmSessionManager;
 import com.google.android.exoplayer2.drm.DrmSessionManagerProvider;
 import com.google.android.exoplayer2.offline.DownloadRequest;
@@ -70,6 +72,7 @@ import in.testpress.core.TestpressUserDetails;
 import in.testpress.course.R;
 import in.testpress.course.api.TestpressCourseApiClient;
 import in.testpress.course.helpers.CustomHttpDrmMediaCallback;
+import in.testpress.course.helpers.DownloadTask;
 import in.testpress.course.helpers.VideoDownload;
 import in.testpress.course.repository.VideoWatchDataRepository;
 import in.testpress.database.OfflineVideoDao;
@@ -87,6 +90,8 @@ import static androidx.mediarouter.media.MediaRouter.RouteInfo.CONNECTION_STATE_
 import static com.google.android.exoplayer2.ExoPlaybackException.TYPE_SOURCE;
 import static in.testpress.course.api.TestpressCourseApiClient.LAST_POSITION;
 import static in.testpress.course.api.TestpressCourseApiClient.TIME_RANGES;
+
+import org.greenrobot.greendao.annotation.NotNull;
 
 public class ExoPlayerUtil implements VideoTimeRangeListener, DrmSessionManagerProvider {
 
@@ -301,8 +306,12 @@ public class ExoPlayerUtil implements VideoTimeRangeListener, DrmSessionManagerP
 
     private void buildPlayer() {
         MediaSourceFactory mediaSourceFactory = new DefaultMediaSourceFactory(new ExoPlayerDataSourceFactory(activity).build());
-        mediaSourceFactory.setDrmSessionManagerProvider(this);
-        MediaItem mediaItem = getMediaItem();
+        DownloadTask downloadTask = new DownloadTask(url, activity);
+        MediaItem mediaItem = getMediaItem(downloadTask.isDownloaded());
+        if (!downloadTask.isDownloaded()) {
+            mediaSourceFactory.setDrmSessionManagerProvider(this);
+        }
+
         player = new SimpleExoPlayer.Builder(activity, new DefaultRenderersFactory(activity))
                 .setMediaSourceFactory(mediaSourceFactory)
                 .setTrackSelector(trackSelector).build();
@@ -317,25 +326,24 @@ public class ExoPlayerUtil implements VideoTimeRangeListener, DrmSessionManagerP
         playerView.controller(youtubeOverlay);
     }
 
-    public MediaItem getMediaItem() {
-        DownloadRequest downloadRequest = VideoDownload.getDownloadRequest(url, activity);
+    public MediaItem getMediaItem(boolean isDownloaded) {
         MediaItem mediaItem = new MediaItem.Builder()
                 .setUri(url)
                 .setDrmUuid(C.WIDEVINE_UUID)
                 .setDrmMultiSession(true).build();
 
-        if (downloadRequest != null) {
+        DownloadRequest downloadRequest = VideoDownload.getDownloadRequest(url, activity);
+        if (isDownloaded) {
             MediaItem.Builder builder = mediaItem.buildUpon();
             builder
-                .setMediaId(downloadRequest.id)
-                .setUri(downloadRequest.uri)
-                .setCustomCacheKey(downloadRequest.customCacheKey)
-                .setMimeType(downloadRequest.mimeType)
-                .setStreamKeys(downloadRequest.streamKeys)
-                .setDrmKeySetId(downloadRequest.keySetId);
+                    .setMediaId(downloadRequest.id)
+                    .setUri(downloadRequest.uri)
+                    .setCustomCacheKey(downloadRequest.customCacheKey)
+                    .setMimeType(downloadRequest.mimeType)
+                    .setStreamKeys(downloadRequest.streamKeys)
+                    .setDrmKeySetId(downloadRequest.keySetId);
             mediaItem = builder.build();
         }
-
         return mediaItem;
     }
 
@@ -737,8 +745,7 @@ public class ExoPlayerUtil implements VideoTimeRangeListener, DrmSessionManagerP
         return new DefaultDrmSessionManager.Builder().build(new CustomHttpDrmMediaCallback(activity, content.getId()));
     }
 
-    private class PlayerEventListener implements Player.EventListener {
-
+    private class PlayerEventListener implements Player.EventListener, DRMLicenseFetchCallback {
         @Override
         public void onPlaybackStateChanged(int playbackState) {
             if(isPreparing && playbackState == Player.STATE_READY){
@@ -775,7 +782,13 @@ public class ExoPlayerUtil implements VideoTimeRangeListener, DrmSessionManagerP
 
         @Override
         public void onPlayerError(ExoPlaybackException exception) {
-            handleError(exception.type == TYPE_SOURCE);
+            Throwable cause = exception.getCause();
+            if (cause instanceof DrmSession.DrmSessionException || cause instanceof MediaCodec.CryptoException) {
+                OfflineDRMLicenseHelper.renewLicense(url, content.getId(), activity, this);
+                displayError(R.string.syncing_video);
+            } else {
+                handleError(exception.type == TYPE_SOURCE);
+            }
         }
 
         @Override
@@ -786,6 +799,24 @@ public class ExoPlayerUtil implements VideoTimeRangeListener, DrmSessionManagerP
         @Override
         public void onSeekProcessed() {
             updateVideoAttempt();
+        }
+
+        @Override
+        public void onLicenseFetchSuccess(@NotNull byte[] keySetId) {
+            activity.runOnUiThread(() -> {
+                float currentPosition = getCurrentPosition();
+                MediaItem mediaItem = getMediaItem(true);
+                player.setMediaItem(mediaItem);
+                errorMessageTextView.setVisibility(View.GONE);
+                preparePlayer();
+                player.setPlayWhenReady(true);
+                player.seekTo((long) (currentPosition * 1000));
+            });
+        }
+
+        @Override
+        public void onLicenseFetchFailure() {
+            displayError(R.string.license_error);
         }
     }
 

--- a/course/src/main/java/in/testpress/course/util/ExoPlayerUtil.java
+++ b/course/src/main/java/in/testpress/course/util/ExoPlayerUtil.java
@@ -83,6 +83,7 @@ import in.testpress.models.greendao.Content;
 import in.testpress.models.greendao.VideoAttempt;
 import in.testpress.ui.ExploreSpinnerAdapter;
 import in.testpress.util.CommonUtils;
+import in.testpress.util.InternetConnectivityChecker;
 import kotlin.Pair;
 
 import static android.content.Context.AUDIO_SERVICE;
@@ -335,7 +336,7 @@ public class ExoPlayerUtil implements VideoTimeRangeListener, DrmSessionManagerP
                 .setDrmMultiSession(true).build();
 
         DownloadRequest downloadRequest = VideoDownload.getDownloadRequest(url, activity);
-        if (isDownloaded) {
+        if (isDownloaded && downloadRequest != null) {
             MediaItem.Builder builder = mediaItem.buildUpon();
             builder
                     .setMediaId(downloadRequest.id)
@@ -790,6 +791,10 @@ public class ExoPlayerUtil implements VideoTimeRangeListener, DrmSessionManagerP
                 DownloadTask downloadTask = new DownloadTask(url, activity);
                 drmLicenseRetries += 1;
                 if (drmLicenseRetries < 2 && downloadTask.isDownloaded()) {
+                    if (!InternetConnectivityChecker.isConnected(activity)) {
+                        displayError(R.string.no_internet_to_sync_license);
+                        return;
+                    }
                     OfflineDRMLicenseHelper.renewLicense(url, content.getId(), activity, this);
                     displayError(R.string.syncing_video);
                 } else {

--- a/course/src/main/java/in/testpress/course/util/OfflineDRMLicenseHelper.kt
+++ b/course/src/main/java/in/testpress/course/util/OfflineDRMLicenseHelper.kt
@@ -1,0 +1,111 @@
+package `in`.testpress.course.util
+
+import `in`.testpress.course.helpers.CustomHttpDrmMediaCallback
+import `in`.testpress.course.helpers.VideoDownload
+import `in`.testpress.course.helpers.VideoDownload.getDownloadRequest
+import `in`.testpress.course.helpers.VideoDownloadManager
+import android.content.Context
+import android.net.Uri
+import com.google.android.exoplayer2.drm.DefaultDrmSessionManager
+import com.google.android.exoplayer2.drm.DrmSession
+import com.google.android.exoplayer2.drm.DrmSessionEventListener
+import com.google.android.exoplayer2.drm.OfflineLicenseHelper
+import com.google.android.exoplayer2.offline.Download
+import com.google.android.exoplayer2.offline.DownloadHelper
+import com.google.android.exoplayer2.offline.DownloadRequest
+import com.google.android.exoplayer2.source.dash.DashUtil
+import com.google.android.exoplayer2.upstream.DefaultHttpDataSource
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+
+object OfflineDRMLicenseHelper {
+    @JvmStatic
+    fun renewLicense(url:String, contentId: Long, context: Context, callback: DRMLicenseFetchCallback) {
+        CoroutineScope(Dispatchers.IO).launch {
+            val dataSource = DefaultHttpDataSource.Factory().createDataSource()
+            val dashManifest = DashUtil.loadManifest(dataSource, Uri.parse(url))
+            val sessionManager = DefaultDrmSessionManager.Builder()
+                .build(CustomHttpDrmMediaCallback(context, contentId))
+            val drmInitData = DashUtil.loadFormatWithDrmInitData(dataSource, dashManifest.getPeriod(0))
+            val keySetId = OfflineLicenseHelper(
+                sessionManager,
+                DrmSessionEventListener.EventDispatcher()
+            ).downloadLicense(
+                drmInitData!!
+            )
+
+            replaceKeysInExistingDownloadedVideo(url, context, keySetId)
+            callback.onLicenseFetchSuccess(keySetId)
+        }
+    }
+
+    private fun replaceKeysInExistingDownloadedVideo(
+        url: String,
+        context: Context,
+        keySetId: ByteArray
+    ) {
+        val downloadRequest = getDownloadRequest(url, context)
+        if (downloadRequest != null) {
+            val newDownloadRequest: DownloadRequest =
+                cloneDownloadRequestWithNewKeys(downloadRequest, keySetId)
+            val download = VideoDownload.getDownload(url, context)
+            val newDownload = cloneDownloadWithNewDownloadRequest(download!!, newDownloadRequest)
+            val dowloadIndex = VideoDownloadManager(context).getDownloadIndex()
+            dowloadIndex.putDownload(newDownload)
+        }
+    }
+
+    private fun cloneDownloadRequestWithNewKeys(downloadRequest: DownloadRequest, keySetId: ByteArray): DownloadRequest {
+        return DownloadRequest.Builder(
+            downloadRequest.id,
+            downloadRequest.uri
+        )
+            .setStreamKeys(downloadRequest.streamKeys)
+            .setCustomCacheKey(downloadRequest.customCacheKey)
+            .setKeySetId(keySetId)
+            .setData(downloadRequest.data)
+            .setMimeType(downloadRequest.mimeType)
+            .build()
+    }
+
+    fun cloneDownloadWithNewDownloadRequest(download: Download, downloadRequest: DownloadRequest): Download {
+        return Download(
+            download.request.copyWithMergedRequest(downloadRequest),
+            download.state,
+            download.startTimeMs,
+            download.updateTimeMs,
+            download.contentLength,
+            download.stopReason,
+            download.failureReason
+        )
+    }
+
+    fun fetchLicense(context: Context, contentId: Long, downloadHelper: DownloadHelper, callback: DRMLicenseFetchCallback) {
+        val sessionManager = DefaultDrmSessionManager.Builder()
+            .build(CustomHttpDrmMediaCallback(context, contentId))
+        val offlineLicenseHelper = OfflineLicenseHelper(
+            sessionManager, DrmSessionEventListener.EventDispatcher()
+        )
+
+        CoroutineScope(Dispatchers.IO).launch {
+            try {
+                val keySetId = offlineLicenseHelper.downloadLicense(
+                    VideoUtils.getAudioOrVideoInfoWithDrmInitData(
+                        downloadHelper
+                    )!!)
+                callback.onLicenseFetchSuccess(keySetId)
+            } catch (e: DrmSession.DrmSessionException) {
+                callback.onLicenseFetchFailure()
+            } finally {
+                offlineLicenseHelper.release()
+            }
+        }
+    }
+}
+
+interface DRMLicenseFetchCallback {
+    fun onLicenseFetchSuccess(keySetId: ByteArray)
+    fun onLicenseFetchFailure()
+}

--- a/course/src/main/java/in/testpress/course/util/VideoUtils.kt
+++ b/course/src/main/java/in/testpress/course/util/VideoUtils.kt
@@ -2,6 +2,8 @@ package `in`.testpress.course.util
 
 import com.google.android.exoplayer2.source.TrackGroup
 import com.google.android.exoplayer2.source.TrackGroupArray
+import com.google.android.exoplayer2.Format
+import com.google.android.exoplayer2.offline.DownloadHelper
 
 object VideoUtils {
     @JvmStatic
@@ -22,5 +24,25 @@ object VideoUtils {
             }
         }
         return Pair(lowBandwithTrackIndex, lowBandwithGroupIndex)
+    }
+
+    @JvmStatic
+    fun getAudioOrVideoInfoWithDrmInitData(helper: DownloadHelper): Format? {
+        for (periodIndex in 0 until helper.periodCount) {
+            val mappedTrackInfo = helper.getMappedTrackInfo(periodIndex)
+            for (rendererIndex in 0 until mappedTrackInfo.rendererCount) {
+                val trackGroups = mappedTrackInfo.getTrackGroups(rendererIndex)
+                for (trackGroupIndex in 0 until trackGroups.length) {
+                    val trackGroup = trackGroups[trackGroupIndex]
+                    for (formatIndex in 0 until trackGroup.length) {
+                        val format = trackGroup.getFormat(formatIndex)
+                        if (format.drmInitData != null) {
+                            return format
+                        }
+                    }
+                }
+            }
+        }
+        return null
     }
 }

--- a/course/src/main/res/values/strings.xml
+++ b/course/src/main/res/values/strings.xml
@@ -63,6 +63,7 @@
     <string name="download_start_error">Failed to start download</string>
     <string name="syncing_video">Please wait... We are syncing video</string>
     <string name="license_error">Error in fetching video license. Please try again</string>
+    <string name="license_request_failed">Couldn\'t fetch decryption key. Please try again</string>
 
     <string-array name="exo_speed_values">
         <item>0.5</item>

--- a/course/src/main/res/values/strings.xml
+++ b/course/src/main/res/values/strings.xml
@@ -62,6 +62,7 @@
     <string name="download_description">Download Descrition</string>
     <string name="download_start_error">Failed to start download</string>
     <string name="syncing_video">Please wait... We are syncing video</string>
+    <string name="no_internet_to_sync_license">Please turn on internet to fetch video license</string>
     <string name="license_error">Error in fetching video license. Please try again</string>
     <string name="license_request_failed">Couldn\'t fetch decryption key. Please try again</string>
 

--- a/course/src/main/res/values/strings.xml
+++ b/course/src/main/res/values/strings.xml
@@ -61,6 +61,8 @@
     <string name="download">Download</string>
     <string name="download_description">Download Descrition</string>
     <string name="download_start_error">Failed to start download</string>
+    <string name="syncing_video">Please wait... We are syncing video</string>
+    <string name="license_error">Error in fetching video license. Please try again</string>
 
     <string-array name="exo_speed_values">
         <item>0.5</item>


### PR DESCRIPTION
- When user downloads a video, we will initially download widevine key and store it in video download request.
- If license expires, we will again download the license and store it in download request.