### PR TITLE
Fix video status not updated if user didn't pause or skip video

### DIFF
--- a/course/src/main/java/in/testpress/course/util/ExoPlayerUtil.java
+++ b/course/src/main/java/in/testpress/course/util/ExoPlayerUtil.java
@@ -743,6 +743,11 @@ public class ExoPlayerUtil implements VideoTimeRangeListener, DrmSessionManagerP
                 progressBar.setVisibility(View.GONE);
             }
 
+            if (playbackState == Player.STATE_ENDED) {
+                onTimeRangeChange((long)startPosition, (long)getCurrentPosition());
+                updateVideoAttempt();
+            }
+
             playerView.setKeepScreenOn(playbackState != Player.STATE_IDLE && playbackState != Player.STATE_ENDED);
         }
 


### PR DESCRIPTION
- If user watches video fully without pausing or fast forwarding video, then video watch status is not getting updated.
