### PR TITLE
Add file type question support

### DIFF
--- a/core/src/main/assets/TestpressTestEngine.js
+++ b/core/src/main/assets/TestpressTestEngine.js
@@ -63,6 +63,14 @@ function onCheckBoxOptionClick(option) {
     }
 }
 
+function onFileUploadClick(button) {
+    OptionsSelectionListener.onFileUploadClick();
+}
+
+function onClearUploadsClick(button) {
+    OptionsSelectionListener.onClearUploadsClick();
+}
+
 function reviewButtonClick(button) {
     OptionsSelectionListener.onMarkStateChange();
     if(button.innerHTML == "MARKED") {

--- a/core/src/main/assets/testpress_questions_typebase.css
+++ b/core/src/main/assets/testpress_questions_typebase.css
@@ -202,7 +202,7 @@ p {
     margin-right: 10px;
 }
 
-.mark-button {
+.mark-button, .upload-button  {
     color: #ffffff;
     border: 0px;
     border-radius: 100px;
@@ -214,7 +214,7 @@ p {
     outline: 0;
  }
 
- .unmark-button {
+ .unmark-button, .clear-upload-button {
     color: #ffa31a;
     border: 1px solid #ffa319;
     border-radius: 100px;
@@ -475,4 +475,8 @@ video {
     width: 95%;
     margin-left: 10px;
     margin-right: 10px;
+}
+
+.upload-button, .clear-upload-button {
+    margin-top: 10px;
 }

--- a/core/src/main/java/in/testpress/models/FileDetails.java
+++ b/core/src/main/java/in/testpress/models/FileDetails.java
@@ -3,7 +3,7 @@ package in.testpress.models;
 public class FileDetails {
 
     private String url;
-
+    private String id;
     public String getUrl() {
         return url;
     }
@@ -12,4 +12,11 @@ public class FileDetails {
         this.url = url;
     }
 
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
 }

--- a/core/src/main/java/in/testpress/util/Misc.kt
+++ b/core/src/main/java/in/testpress/util/Misc.kt
@@ -2,6 +2,7 @@ package `in`.testpress.util
 
 import android.content.Context
 import android.net.ConnectivityManager
+import java.net.URL
 import java.util.*
 
 object Misc {
@@ -17,5 +18,9 @@ object Misc {
         c.timeInMillis = milliSeconds
         c.add(Calendar.DAY_OF_MONTH, noOfDays)
         return c.timeInMillis
+    }
+
+    fun getPathFromURL(url: String) {
+        URL(url).path.replaceFirst("/", "")
     }
 }

--- a/core/src/main/java/in/testpress/util/ProgressDialog.kt
+++ b/core/src/main/java/in/testpress/util/ProgressDialog.kt
@@ -1,0 +1,31 @@
+package `in`.testpress.util
+
+import `in`.testpress.R
+import android.content.Context
+import android.view.LayoutInflater
+import android.view.View
+import android.widget.TextView
+import androidx.appcompat.app.AlertDialog
+
+class ProgressDialog {
+    fun getAlertDialog(
+        context: Context,
+        layout: Int,
+        setCancellationOnTouchOutside: Boolean
+    ): AlertDialog {
+        val builder: AlertDialog.Builder = AlertDialog.Builder(context)
+        val inflater = context.getSystemService(Context.LAYOUT_INFLATER_SERVICE) as LayoutInflater
+        val customLayout: View = inflater.inflate(layout, null)
+        builder.setView(customLayout)
+        val dialog = builder.create()
+        dialog.setCanceledOnTouchOutside(setCancellationOnTouchOutside)
+        return dialog
+    }
+
+    fun showProgressDialog(context: Context, message: String): AlertDialog {
+        val dialog = getAlertDialog(context, R.layout.custom_progress_dialog, setCancellationOnTouchOutside = false)
+        dialog.show()
+        dialog.findViewById<TextView>(R.id.text_progress_bar)?.text = message
+        return dialog
+    }
+}

--- a/core/src/main/java/in/testpress/util/ProgressDialog.kt
+++ b/core/src/main/java/in/testpress/util/ProgressDialog.kt
@@ -24,7 +24,6 @@ class ProgressDialog {
 
     fun showProgressDialog(context: Context, message: String): AlertDialog {
         val dialog = getAlertDialog(context, R.layout.custom_progress_dialog, setCancellationOnTouchOutside = false)
-        dialog.show()
         dialog.findViewById<TextView>(R.id.text_progress_bar)?.text = message
         return dialog
     }

--- a/core/src/main/res/layout/custom_progress_dialog.xml
+++ b/core/src/main/res/layout/custom_progress_dialog.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:gravity="center"
+    android:orientation="horizontal"
+    android:paddingLeft="30dp"
+    android:paddingTop="30dp"
+    android:paddingRight="30dp"
+    android:paddingBottom="30dp">
+
+    <ProgressBar
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:indeterminate="true"
+        android:paddingRight="20dp" />
+
+    <TextView
+        android:id="@+id/text_progress_bar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textSize="20sp" />
+
+</LinearLayout>

--- a/exam/build.gradle
+++ b/exam/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     api rootProject.chart
     api rootProject.imageCropper
     api rootProject.lottie
+    api 'com.github.HBiSoft:PickiT:0.1.14'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
     testImplementation rootProject.junit
     testImplementation rootProject.mockito

--- a/exam/src/main/java/in/testpress/exam/api/TestpressExamApiClient.java
+++ b/exam/src/main/java/in/testpress/exam/api/TestpressExamApiClient.java
@@ -169,6 +169,7 @@ public class TestpressExamApiClient extends TestpressApiClient {
             answer.put("selected_answers", attemptItem.getSavedAnswers());
             answer.put("short_text", attemptItem.getCurrentShortText());
         }
+        answer.put("files", attemptItem.getUnSyncedFiles());
         answer.put("review", attemptItem.getCurrentReview());
         return getExamService().postAnswer(attemptItem.getUrlFrag(), answer);
     }

--- a/exam/src/main/java/in/testpress/exam/models/AttemptItem.java
+++ b/exam/src/main/java/in/testpress/exam/models/AttemptItem.java
@@ -2,6 +2,7 @@ package in.testpress.exam.models;
 
 import android.os.Parcel;
 import android.os.Parcelable;
+import android.util.Log;
 
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -10,7 +11,6 @@ import java.util.Collections;
 import java.util.List;
 
 import in.testpress.models.greendao.AttemptSection;
-import in.testpress.util.CommonUtils;
 
 public class AttemptItem implements Parcelable {
 
@@ -27,7 +27,7 @@ public class AttemptItem implements Parcelable {
     private AttemptSection attemptSection;
     private String essayText;
     private String localEssayText;
-    private List<String> files = new ArrayList<String>();
+    private List<UserUploadedFile> files = new ArrayList<UserUploadedFile>();
     private List<String> unSyncedFiles = new ArrayList<String>();
 
     AttemptItem() {
@@ -54,7 +54,7 @@ public class AttemptItem implements Parcelable {
         attemptSection = in.readParcelable(AttemptSection.class.getClassLoader());
         in.readList(selectedAnswers, Integer.class.getClassLoader());
         in.readList(savedAnswers, Integer.class.getClassLoader());
-        in.readList(files, String.class.getClassLoader());
+        in.createTypedArrayList(UserUploadedFile.CREATOR);
         in.readList(unSyncedFiles, String.class.getClassLoader());
     }
 
@@ -76,7 +76,7 @@ public class AttemptItem implements Parcelable {
         dest.writeParcelable(attemptSection, flags);
         dest.writeList(selectedAnswers);
         dest.writeList(savedAnswers);
-        dest.writeList(files);
+        dest.writeTypedList(files);
         dest.writeList(unSyncedFiles);
     }
 
@@ -132,7 +132,19 @@ public class AttemptItem implements Parcelable {
     }
 
     public Boolean hasChanged() {
-        return !isSelectedAnswersSynced() || !isMarkForReviewSynced() || !isShortTextSynced() || !isEssaySynced();
+        return !isSelectedAnswersSynced() || !isMarkForReviewSynced() || !isShortTextSynced() || !isEssaySynced()
+    || !isFilesSynced();
+    }
+
+    private boolean isFilesSynced() {
+        List<String> fileURLs = new ArrayList<>(files.size());
+        for (UserUploadedFile file : files) {
+            fileURLs.add(file.getPath());
+        }
+
+        Collections.sort(fileURLs);
+        Collections.sort(unSyncedFiles);
+        return unSyncedFiles.equals(fileURLs);
     }
 
     /**
@@ -290,11 +302,19 @@ public class AttemptItem implements Parcelable {
         return localEssayText;
     }
 
-    public List<String> getFiles() {
+    public List<UserUploadedFile> getFiles() {
         return files;
     }
 
-    public void setFiles(List<String> files) {
+    public List<String> getFileURLs() {
+        List<String> fileURLs = new ArrayList<>(files.size());
+        for (UserUploadedFile file : files) {
+            fileURLs.add(file.getPath());
+        }
+        return fileURLs;
+    }
+
+    public void setFiles(List<UserUploadedFile> files) {
         this.files = files;
     }
 

--- a/exam/src/main/java/in/testpress/exam/models/AttemptItem.java
+++ b/exam/src/main/java/in/testpress/exam/models/AttemptItem.java
@@ -27,6 +27,8 @@ public class AttemptItem implements Parcelable {
     private AttemptSection attemptSection;
     private String essayText;
     private String localEssayText;
+    private List<String> files = new ArrayList<String>();
+    private List<String> unSyncedFiles = new ArrayList<String>();
 
     AttemptItem() {
         selectedAnswers = new ArrayList<Integer>();
@@ -52,6 +54,8 @@ public class AttemptItem implements Parcelable {
         attemptSection = in.readParcelable(AttemptSection.class.getClassLoader());
         in.readList(selectedAnswers, Integer.class.getClassLoader());
         in.readList(savedAnswers, Integer.class.getClassLoader());
+        in.readList(files, String.class.getClassLoader());
+        in.readList(unSyncedFiles, String.class.getClassLoader());
     }
 
     @Override
@@ -72,6 +76,8 @@ public class AttemptItem implements Parcelable {
         dest.writeParcelable(attemptSection, flags);
         dest.writeList(selectedAnswers);
         dest.writeList(savedAnswers);
+        dest.writeList(files);
+        dest.writeList(unSyncedFiles);
     }
 
     @Override
@@ -282,5 +288,33 @@ public class AttemptItem implements Parcelable {
 
     public String getLocalEssayText() {
         return localEssayText;
+    }
+
+    public List<String> getFiles() {
+        return files;
+    }
+
+    public void setFiles(List<String> files) {
+        this.files = files;
+    }
+
+    public List<String> getUnSyncedFiles() {
+        return unSyncedFiles;
+    }
+
+    public void setUnSyncedFiles(List<String> files) {
+        this.unSyncedFiles = files;
+    }
+
+    public String getFiletypeDisplayHtml() {
+        String htmlContent = "";
+        for (int i=0; i < getUnSyncedFiles().size(); i++) {
+            htmlContent += String.format("<li> File %d</li>", i + 1);
+        }
+        htmlContent += "<div class='review_later_button_layout'>" +
+                "<button class='upload-button' onClick='onFileUploadClick(this)'> Upload File </button>" +
+                "<button class='clear-upload-button' onClick='onClearUploadsClick(this)'> Clear Uploads </button>" +
+                "</div>";
+        return htmlContent;
     }
 }

--- a/exam/src/main/java/in/testpress/exam/models/UserUploadedFile.kt
+++ b/exam/src/main/java/in/testpress/exam/models/UserUploadedFile.kt
@@ -1,0 +1,37 @@
+package `in`.testpress.exam.models
+
+import android.os.Parcel
+import android.os.Parcelable
+
+data class UserUploadedFile(
+    val id: Long? = null,
+    val url: String? = null,
+    val path: String? = null
+): Parcelable {
+    constructor(parcel: Parcel) : this(
+        parcel.readValue(Long::class.java.classLoader) as? Long,
+        parcel.readString(),
+        parcel.readString()
+    ) {
+    }
+
+    override fun writeToParcel(parcel: Parcel, flags: Int) {
+        parcel.writeValue(id)
+        parcel.writeString(url)
+        parcel.writeString(path)
+    }
+
+    override fun describeContents(): Int {
+        return 0
+    }
+
+    companion object CREATOR : Parcelable.Creator<UserUploadedFile> {
+        override fun createFromParcel(parcel: Parcel): UserUploadedFile {
+            return UserUploadedFile(parcel)
+        }
+
+        override fun newArray(size: Int): Array<UserUploadedFile?> {
+            return arrayOfNulls(size)
+        }
+    }
+}

--- a/exam/src/main/java/in/testpress/exam/ui/TestActivity.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestActivity.java
@@ -644,6 +644,8 @@ public class TestActivity extends BaseToolBarActivity implements LoaderManager.L
         if ((requestCode == CarouselFragment.TEST_TAKEN_REQUEST_CODE) && (Activity.RESULT_OK == resultCode)) {
             setResult(resultCode);
             finish();
+        } else {
+            super.onActivityResult(requestCode, resultCode, data);
         }
     }
 

--- a/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
@@ -875,6 +875,7 @@ public class TestFragment extends BaseFragment implements LoaderManager.LoaderCa
                             attemptItem.setSelectedAnswers(newAttemptItem.getSelectedAnswers());
                             attemptItem.setShortText(newAttemptItem.getShortText());
                             attemptItem.setReview(newAttemptItem.getReview());
+                            attemptItem.setFiles(newAttemptItem.getFiles());
 
                             if (isNonSectionalOrIBPSExam() || (attempt.hasSectionalLock() && sections.get(currentSectionPosition).equals("Running"))) {
                                 attemptItemList.set(position, attemptItem);

--- a/exam/src/main/java/in/testpress/exam/ui/TestQuestionFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestQuestionFragment.java
@@ -134,7 +134,7 @@ public class TestQuestionFragment extends Fragment implements PickiTCallbacks {
         attemptItem.setCurrentShortText(attemptItem.getShortText());
         attemptItem.setCurrentReview(attemptItem.getReview());
         attemptItem.setLocalEssayText(attemptItem.getEssayText());
-        attemptItem.setUnSyncedFiles(attemptItem.getFiles());
+        attemptItem.setUnSyncedFiles(attemptItem.getFileURLs());
     }
 
     private String getQuestionItemHtml() {

--- a/exam/src/main/java/in/testpress/exam/ui/TestQuestionFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestQuestionFragment.java
@@ -286,7 +286,6 @@ public class TestQuestionFragment extends Fragment implements PickiTCallbacks {
         @JavascriptInterface
         public void onFileUploadClick() {
             pickFile();
-            Toast.makeText(requireContext(), "Hello", Toast.LENGTH_LONG).show();
         }
 
         @JavascriptInterface
@@ -319,10 +318,8 @@ public class TestQuestionFragment extends Fragment implements PickiTCallbacks {
 
     @Override
     public void onActivityResult(int requestCode, int resultCode, @Nullable Intent data) {
-        Log.d("TAG", "onActivityResult: " + resultCode + requestCode + data.toString());
         if (requestCode == 42 && resultCode == Activity.RESULT_OK) {
             if (data != null) {
-                Log.d("TAG", "onActivityResult: ");
                 pickiT.getPath(data.getData(), Build.VERSION.SDK_INT);
             }
         } else {
@@ -337,7 +334,6 @@ public class TestQuestionFragment extends Fragment implements PickiTCallbacks {
                     public void onSuccess(FileDetails fileDetails) {
                         saveUploadedFileURL(fileDetails);
                         progressDialog.hide();
-                        Toast.makeText(getContext(), "Uploaded files successfully", Toast.LENGTH_LONG).show();
                         update();
                     }
 


### PR DESCRIPTION
- Used PickiT library to handle file picking support. Picked files will be uploaded to testpress and then its path will be stored in attempt item.
- Once user presses next or pauses or ends exam. File paths from attempt item will be stored in backend.
