### PR TITLE
refactor: Send customer_key to zoom sdk while joining meeting

### DIFF
--- a/course/src/main/java/in/testpress/course/util/ZoomMeetHandler.kt
+++ b/course/src/main/java/in/testpress/course/util/ZoomMeetHandler.kt
@@ -138,6 +138,9 @@ class ZoomMeetHandler(
         options.no_bottom_toolbar = false
         options.no_webinar_register_dialog = profileDetails != null && profileDetails.email.isEmailValid()
         options.no_invite = true
+        if (profileDetails != null) {
+            options.customer_key = profileDetails.username
+        }
         return options
     }
 


### PR DESCRIPTION
- This customer key parameter will be sent back when we access zoom reports, so we can use this to uniquely identify user
