### PR TITLE
fix: H:MM:SS duration string is not clickable in video

### DIFF
--- a/course/src/main/java/in/testpress/course/fragments/VideoContentFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/VideoContentFragment.kt
@@ -8,6 +8,7 @@ import `in`.testpress.course.repository.OfflineVideoRepository
 import `in`.testpress.course.services.VideoDownloadService
 import `in`.testpress.course.ui.DownloadsActivity
 import `in`.testpress.course.ui.VideoDownloadQualityChooserDialog
+import `in`.testpress.course.util.DateUtils.convertDurationStringToSeconds
 import `in`.testpress.course.util.PatternEditableBuilder
 import `in`.testpress.course.viewmodels.OfflineVideoViewModel
 import `in`.testpress.models.InstituteSettings
@@ -223,13 +224,8 @@ class VideoContentFragment : BaseContentDetailFragment() {
                 Color.parseColor("#2D9BE8"),
                 object : PatternEditableBuilder.SpannableClickedListener {
                     override fun onSpanClicked(text: String) {
-                        val dateFormat: DateFormat = SimpleDateFormat("HH:mm:ss")
-                        dateFormat.timeZone = TimeZone.getTimeZone("UTC")
-                        try {
-                            val date: Date = dateFormat.parse(text)
-                            videoWidgetFragment.seekTo(date.time)
-                        } catch (ignore: ParseException) {
-                        }
+                        val seconds = convertDurationStringToSeconds(text)
+                        videoWidgetFragment.seekTo(seconds * 1000L)
                     }
                 }).into(description)
             toggleDescription(true)

--- a/course/src/main/java/in/testpress/course/fragments/VideoContentFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/VideoContentFragment.kt
@@ -216,7 +216,8 @@ class VideoContentFragment : BaseContentDetailFragment() {
     private fun parseVideoDescription() {
         content.description?.let {
             description.text = HtmlCompat.fromHtml(it, HtmlCompat.FROM_HTML_MODE_LEGACY)
-            val pattern: Pattern = Pattern.compile("\\d\\d:\\d\\d:\\d\\d")
+            val durationRegex = "([0-2]?[0-9]?:?[0-5]?[0-9]:[0-5][0-9])"
+            val pattern: Pattern = Pattern.compile(durationRegex)
             PatternEditableBuilder().addPattern(
                 pattern,
                 Color.parseColor("#2D9BE8"),

--- a/course/src/main/java/in/testpress/course/util/DateUtils.kt
+++ b/course/src/main/java/in/testpress/course/util/DateUtils.kt
@@ -20,4 +20,17 @@ object DateUtils {
             Settings.System.getInt(context.contentResolver, Settings.System.AUTO_TIME, 0) != 1;
         }
     }
+
+    fun convertDurationStringToSeconds(durationString: String): Int {
+        val durationList = durationString.split(":").toMutableList()
+        var seconds = 0
+        var minutes = 1
+
+        while (durationList.size > 0) {
+            seconds += minutes * durationList.removeLast().toInt()
+            minutes *= 60
+        }
+
+        return seconds
+    }
 }


### PR DESCRIPTION
- Previously we were supporting only HH:MM:SS
- Modified regex to support the following
  - HH:MM:SS	
  - H:MM:SS
  - MM:SS
  - M:SS
