### PR TITLE
fix: Display payment status screen after product purchase

### DIFF
--- a/store/src/main/java/in/testpress/store/ui/OrderConfirmActivity.java
+++ b/store/src/main/java/in/testpress/store/ui/OrderConfirmActivity.java
@@ -15,6 +15,7 @@ import android.widget.ProgressBar;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
 
+import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
 
 
@@ -256,6 +257,17 @@ public class OrderConfirmActivity extends BaseToolBarActivity implements Payment
     }
 
     @Override
+    protected void onActivityResult(int requestCode, int resultCode, @Nullable Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+        if (resultCode == RESULT_OK) {
+            showPaymentStatus();
+        } else {
+            setResult(resultCode, data);
+            finish();
+        }
+    }
+
+    @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         if (item.getItemId() == android.R.id.home) {
             onBackPressed();
@@ -323,6 +335,6 @@ public class OrderConfirmActivity extends BaseToolBarActivity implements Payment
 
     @Override
     public void onPaymentCancel() {
-
+        showPaymentFailedScreen();
     }
 }

--- a/store/src/main/java/in/testpress/store/ui/OrderConfirmActivity.java
+++ b/store/src/main/java/in/testpress/store/ui/OrderConfirmActivity.java
@@ -29,6 +29,7 @@ import in.testpress.store.PaymentGatewayFactory;
 import in.testpress.store.PaymentGateway;
 import in.testpress.store.PaymentGatewayListener;
 import in.testpress.store.R;
+import in.testpress.store.TestpressStore;
 import in.testpress.store.models.Order;
 import in.testpress.store.models.OrderConfirmErrorDetails;
 import in.testpress.store.models.OrderItem;
@@ -259,7 +260,7 @@ public class OrderConfirmActivity extends BaseToolBarActivity implements Payment
     @Override
     protected void onActivityResult(int requestCode, int resultCode, @Nullable Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
-        if (resultCode == RESULT_OK) {
+        if (resultCode == RESULT_OK && data != null && !data.getBooleanExtra(TestpressStore.PAYMENT_SUCCESS, false)) {
             showPaymentStatus();
         } else {
             setResult(resultCode, data);


### PR DESCRIPTION
- The issue is if a user purchases a product in a store, after payment its shows a blank screen, and this is fixed in the commit by showing the payment status screen after purchase.
