### PR TITLE
fix: Not able to purchase course from store Using Card Payment

### DIFF
--- a/store/src/main/java/in/testpress/store/payu/PayuPaymentGateway.kt
+++ b/store/src/main/java/in/testpress/store/payu/PayuPaymentGateway.kt
@@ -56,6 +56,7 @@ class PayuPaymentGateway(order: Order, context: Activity): PaymentGateway(order,
                 .setEmail(order.email)
                 .setSurl(redirectURL)
                 .setFurl(redirectURL)
+                .setUserCredential("default")
                 .setAdditionalParams(getAdditionalParameters())
         return builder.build()
     }


### PR DESCRIPTION
- This issue raises in institutes with custom payment, while users try to purchase a package from the store using the card, the app shows the Payment failure page because Payu raises an error `Card can not be stored! user_credentials is missing!`.
- This is fixed by passing the user credentials parameter to PayUCheckoutPro open function.
