### PR TITLE
fix: Fix home button on payment success page not redirecting to learn tab

### DIFF
--- a/course/src/main/java/in/testpress/course/ui/CourseListActivity.java
+++ b/course/src/main/java/in/testpress/course/ui/CourseListActivity.java
@@ -1,10 +1,15 @@
 package in.testpress.course.ui;
 
+import android.content.Intent;
 import android.os.Bundle;
 import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
 
 import in.testpress.course.R;
 import in.testpress.ui.BaseToolBarActivity;
+import in.testpress.store.TestpressStore;
+import android.app.Activity;
+
 
 public class CourseListActivity extends BaseToolBarActivity {
 
@@ -18,4 +23,13 @@ public class CourseListActivity extends BaseToolBarActivity {
                 .commitAllowingStateLoss();
     }
 
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, @Nullable Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+        if (requestCode == TestpressStore.STORE_REQUEST_CODE && resultCode == Activity.RESULT_OK && data != null && !data.getBooleanExtra(TestpressStore.CONTINUE_PURCHASE, false)) {
+            for (Fragment fragment : getSupportFragmentManager().getFragments()) {
+                fragment.onActivityResult(requestCode, resultCode, data);
+            }
+        }
+    }
 }

--- a/course/src/main/java/in/testpress/course/ui/CourseListFragment.java
+++ b/course/src/main/java/in/testpress/course/ui/CourseListFragment.java
@@ -1,6 +1,10 @@
 package in.testpress.course.ui;
 
+import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
+
+import android.app.Activity;
+import android.content.Intent;
 import android.os.Bundle;
 import com.google.android.material.tabs.TabLayout;
 import androidx.fragment.app.FragmentManager;
@@ -16,9 +20,13 @@ import java.util.List;
 import in.testpress.core.TestpressSdk;
 import in.testpress.core.TestpressSession;
 import in.testpress.course.R;
+import in.testpress.store.TestpressStore;
 import in.testpress.ui.BaseFragment;
 
 public class CourseListFragment extends BaseFragment {
+    private TabLayout tabs;
+    private Adapter adapter;
+
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -32,14 +40,14 @@ public class CourseListFragment extends BaseFragment {
         ViewPager viewPager = (ViewPager) view.findViewById(R.id.viewpager);
         setupViewPager(viewPager);
 
-        TabLayout tabs = (TabLayout) view.findViewById(R.id.tab_layout);
+        tabs = (TabLayout) view.findViewById(R.id.tab_layout);
         tabs.setupWithViewPager(viewPager);
 
         return view;
     }
 
     private void setupViewPager(ViewPager viewPager) {
-        Adapter adapter = new Adapter(getChildFragmentManager());
+        adapter = new Adapter(getChildFragmentManager());
         adapter.addFragment(new MyCoursesFragment(), getString(R.string.my_course_title));
 
         TestpressSession session = TestpressSdk.getTestpressSession(getContext());
@@ -81,6 +89,13 @@ public class CourseListFragment extends BaseFragment {
         }
     }
 
-
-
+    @Override
+    public void onActivityResult(int requestCode, int resultCode, @Nullable Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+        if (requestCode == TestpressStore.STORE_REQUEST_CODE && resultCode == Activity.RESULT_OK && data != null && !data.getBooleanExtra(TestpressStore.CONTINUE_PURCHASE, false)) {
+            tabs.getTabAt(0).select();
+            MyCoursesFragment fragment = (MyCoursesFragment) adapter.getItem(0);
+            fragment.clearItemsAndRefresh();
+        }
+    }
 }

--- a/store/src/main/java/in/testpress/store/TestpressStore.java
+++ b/store/src/main/java/in/testpress/store/TestpressStore.java
@@ -20,6 +20,7 @@ public class TestpressStore {
     public static final int STORE_REQUEST_CODE = 1000;
     public static final String CONTINUE_PURCHASE = "continue_purchase";
     public static final String PAYMENT_SUCCESS = "payment_success";
+    public static final String PAYMENT_FAILURE = "payment_failure";
 
     /**
      * Use when testpress store need to be open in a container as a fragment.

--- a/store/src/main/java/in/testpress/store/ui/OrderConfirmActivity.java
+++ b/store/src/main/java/in/testpress/store/ui/OrderConfirmActivity.java
@@ -45,6 +45,7 @@ import in.testpress.util.UIUtils;
 
 import static android.view.inputmethod.EditorInfo.IME_ACTION_DONE;
 import static in.testpress.store.TestpressStore.PAYMENT_SUCCESS;
+import static in.testpress.store.TestpressStore.PAYMENT_FAILURE;
 import static in.testpress.store.TestpressStore.STORE_REQUEST_CODE;
 import static in.testpress.store.ui.ProductDetailsActivity.PRODUCT;
 
@@ -264,9 +265,11 @@ public class OrderConfirmActivity extends BaseToolBarActivity implements Payment
     @Override
     protected void onActivityResult(int requestCode, int resultCode, @Nullable Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
-        setResult(resultCode, data);
-        if (requestCode == STORE_REQUEST_CODE && data.getBooleanExtra(PAYMENT_SUCCESS, false)){
-            finish();
+        if (data != null){
+            if (requestCode == STORE_REQUEST_CODE && data.getBooleanExtra(PAYMENT_SUCCESS, false) || data.getBooleanExtra(PAYMENT_FAILURE, false)){
+                setResult(resultCode, data);
+                finish();
+            }
         }
     }
 
@@ -343,9 +346,8 @@ public class OrderConfirmActivity extends BaseToolBarActivity implements Payment
     void showPaymentFailedScreen() {
         progressBar.setVisibility(View.GONE);
         logEvent(EventsTrackerFacade.PAYMENT_SUCCESS);
-        finish();
         Intent intent = new Intent(this, PaymentFailureActivity.class);
-        startActivity(intent);
+        startActivityForResult(intent, STORE_REQUEST_CODE);
     }
 
     @Override

--- a/store/src/main/java/in/testpress/store/ui/OrderConfirmActivity.java
+++ b/store/src/main/java/in/testpress/store/ui/OrderConfirmActivity.java
@@ -44,6 +44,8 @@ import in.testpress.util.TextWatcherAdapter;
 import in.testpress.util.UIUtils;
 
 import static android.view.inputmethod.EditorInfo.IME_ACTION_DONE;
+import static in.testpress.store.TestpressStore.CONTINUE_PURCHASE;
+import static in.testpress.store.TestpressStore.PAYMENT_SUCCESS;
 import static in.testpress.store.TestpressStore.STORE_REQUEST_CODE;
 import static in.testpress.store.ui.ProductDetailsActivity.PRODUCT;
 
@@ -252,7 +254,6 @@ public class OrderConfirmActivity extends BaseToolBarActivity implements Payment
 
     void showPaymentStatus() {
         progressBar.setVisibility(View.GONE);
-        finish();
         logEvent(EventsTrackerFacade.PAYMENT_SUCCESS);
         Intent intent = new Intent(this, PaymentSuccessActivity.class);
         intent.putExtra(ORDER, order);
@@ -265,6 +266,9 @@ public class OrderConfirmActivity extends BaseToolBarActivity implements Payment
     protected void onActivityResult(int requestCode, int resultCode, @Nullable Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
         setResult(resultCode, data);
+        if (requestCode == STORE_REQUEST_CODE && data.getBooleanExtra(PAYMENT_SUCCESS, false)){
+            finish();
+        }
     }
 
     @Override

--- a/store/src/main/java/in/testpress/store/ui/OrderConfirmActivity.java
+++ b/store/src/main/java/in/testpress/store/ui/OrderConfirmActivity.java
@@ -44,7 +44,6 @@ import in.testpress.util.TextWatcherAdapter;
 import in.testpress.util.UIUtils;
 
 import static android.view.inputmethod.EditorInfo.IME_ACTION_DONE;
-import static in.testpress.store.TestpressStore.CONTINUE_PURCHASE;
 import static in.testpress.store.TestpressStore.PAYMENT_SUCCESS;
 import static in.testpress.store.TestpressStore.STORE_REQUEST_CODE;
 import static in.testpress.store.ui.ProductDetailsActivity.PRODUCT;

--- a/store/src/main/java/in/testpress/store/ui/PaymentFailureActivity.kt
+++ b/store/src/main/java/in/testpress/store/ui/PaymentFailureActivity.kt
@@ -1,7 +1,9 @@
 package `in`.testpress.store.ui
 
 import `in`.testpress.store.R
+import `in`.testpress.store.TestpressStore
 import android.app.Activity
+import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import android.widget.Button
@@ -22,6 +24,15 @@ class PaymentFailureActivity: Activity() {
 
     private fun setOnClickListeners() {
         val continueButton = findViewById<View>(R.id.back_button) as Button
-        continueButton.setOnClickListener { finish() }
+        continueButton.setOnClickListener {
+            backToProductDetail()
+        }
+    }
+
+    private fun backToProductDetail() {
+        val intent = Intent()
+        intent.putExtra(TestpressStore.PAYMENT_FAILURE, true)
+        setResult(RESULT_OK, intent)
+        finish()
     }
 }

--- a/store/src/main/java/in/testpress/store/ui/PaymentFailureActivity.kt
+++ b/store/src/main/java/in/testpress/store/ui/PaymentFailureActivity.kt
@@ -25,11 +25,11 @@ class PaymentFailureActivity: Activity() {
     private fun setOnClickListeners() {
         val continueButton = findViewById<View>(R.id.back_button) as Button
         continueButton.setOnClickListener {
-            backToProductDetail()
+            showProductDetail()
         }
     }
 
-    private fun backToProductDetail() {
+    private fun showProductDetail() {
         val intent = Intent()
         intent.putExtra(TestpressStore.PAYMENT_FAILURE, true)
         setResult(RESULT_OK, intent)

--- a/store/src/main/java/in/testpress/store/ui/ProductDetailsActivity.java
+++ b/store/src/main/java/in/testpress/store/ui/ProductDetailsActivity.java
@@ -33,6 +33,7 @@ import in.testpress.util.UIUtils;
 import in.testpress.util.ViewUtils;
 import in.testpress.util.ZoomableImageString;
 
+import static in.testpress.store.TestpressStore.PAYMENT_SUCCESS;
 import static in.testpress.store.TestpressStore.STORE_REQUEST_CODE;
 
 public class ProductDetailsActivity extends BaseToolBarActivity {
@@ -247,7 +248,7 @@ public class ProductDetailsActivity extends BaseToolBarActivity {
 
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
-        if (requestCode == STORE_REQUEST_CODE && resultCode == RESULT_OK) {
+        if (requestCode == STORE_REQUEST_CODE && resultCode == RESULT_OK && data.getBooleanExtra(PAYMENT_SUCCESS, false)) {
             setResult(RESULT_OK, data);
             finish();
         }


### PR DESCRIPTION
- Issue is, that the Goto home button on the payment success page was not redirecting the user to learn tab on click. 
- It's because we haven't called the finish method in the PaymentSucessActivity result. which is why it's showing the product detail page on the button click.
- This is fixed by calling the finish method on the PaymentSucessActivity result and redirecting the user to learn tab and refreshing the course on the CourseListActivity onActivityResult if the request code is Testpress store request code and the continue purchase flag is false.