### PR TITLE
fix: Fix images in exam instruction not visible

### DIFF
--- a/exam/src/main/java/in/testpress/exam/ui/ExamInstructions.kt
+++ b/exam/src/main/java/in/testpress/exam/ui/ExamInstructions.kt
@@ -2,11 +2,12 @@ package `in`.testpress.exam.ui
 
 import `in`.testpress.exam.R
 import `in`.testpress.ui.BaseFragment
+import `in`.testpress.util.WebViewUtils
 import android.os.Bundle
-import android.text.Html
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.webkit.WebView
 import android.widget.Button
 import android.widget.TextView
 import androidx.appcompat.widget.Toolbar
@@ -31,9 +32,10 @@ class ExamInstructions(val startExam: () -> Unit) : BaseFragment() {
         }
     }
 
-    private lateinit var instructionsView: TextView;
+    private lateinit var instructionsView: WebView;
     private lateinit var toolbarTitle: TextView;
     private lateinit var confirmButton: Button
+    lateinit var webViewUtils: WebViewUtils
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?,
                               savedInstanceState: Bundle?): View? {
@@ -66,7 +68,7 @@ class ExamInstructions(val startExam: () -> Unit) : BaseFragment() {
 
     private fun displayInstructions(){
         val instructions = requireArguments().getString(INSTRUCTIONFLAG)
-        instructionsView.text = Html.fromHtml(instructions.toString())
+        WebViewUtils(instructionsView).initWebView(instructions, activity)
     }
 
     private fun setListeners(){

--- a/exam/src/main/res/layout/fragment_test_instructions.xml
+++ b/exam/src/main/res/layout/fragment_test_instructions.xml
@@ -44,7 +44,7 @@
         android:layout_marginHorizontal="12dp"
         android:layout_weight="1">
 
-        <TextView
+        <WebView
             android:id="@+id/instructions_text"
             android:layout_width="match_parent"
             android:layout_height="wrap_content" />


### PR DESCRIPTION
- Issue is images in exam instruction are not visible in the instruction tab instead it's showing a square box with a green background for an image, 
- This is fixed by using the Webview for showing instructions.
