### PR TITLE
fix: Fix exam title shows in multiple lines in instructions screen

### DIFF
--- a/exam/src/main/java/in/testpress/exam/ui/ExamInstructions.kt
+++ b/exam/src/main/java/in/testpress/exam/ui/ExamInstructions.kt
@@ -33,7 +33,6 @@ class ExamInstructions(val startExam: () -> Unit) : BaseFragment() {
     }
 
     private lateinit var instructionsView: WebView;
-    private lateinit var toolbarTitle: TextView;
     private lateinit var confirmButton: Button
     lateinit var webViewUtils: WebViewUtils
 
@@ -55,15 +54,11 @@ class ExamInstructions(val startExam: () -> Unit) : BaseFragment() {
         val toolbar: Toolbar = view.findViewById(R.id.toolbar)
         toolbar.setNavigationIcon(R.drawable.ic_baseline_arrow_back_24)
         toolbar.setNavigationOnClickListener(View.OnClickListener { requireActivity().onBackPressed() })
-
-        val examTitle = requireArguments().getString(TITLE_FLAG)
-        toolbarTitle.text = examTitle;
     }
 
     private fun bindViews(view: View){
         instructionsView = view.findViewById(R.id.instructions_text)
         confirmButton = view.findViewById(R.id.confirm_button)
-        toolbarTitle = view.findViewById(R.id.exam_name)
     }
 
     private fun displayInstructions(){

--- a/exam/src/main/res/layout/fragment_test_instructions.xml
+++ b/exam/src/main/res/layout/fragment_test_instructions.xml
@@ -18,7 +18,7 @@
             android:id="@+id/exam_name"
             android:layout_width="wrap_content"
             android:layout_height="match_parent"
-            android:text="Fragment title"
+            android:text="Instructions"
             android:textSize="20sp"
             android:textColor="@color/testpress_white"
             android:gravity="center_vertical"


### PR DESCRIPTION
- If exam title is very big then it is displayed in multiple lines in Instructions screen.
- This is fixed by displaying "Instructions" instead of exam title in Instructions screen. We display exam title properly in previous screen so it need not to be displayed again.