### PR TITLE
fix: Add support to access embedded DRM-protected content

### DIFF
--- a/core/src/main/java/in/testpress/util/FullScreenChromeClient.java
+++ b/core/src/main/java/in/testpress/util/FullScreenChromeClient.java
@@ -90,6 +90,7 @@ public class FullScreenChromeClient extends WebChromeClient {
         this.filePathCallback = null;
     }
 
+    //Reference https://github.com/videojs/video.js/issues/5563
     public void onPermissionRequest(PermissionRequest request) {
         String[] permissions = {PermissionRequest.RESOURCE_PROTECTED_MEDIA_ID};
         request.grant(permissions);

--- a/core/src/main/java/in/testpress/util/FullScreenChromeClient.java
+++ b/core/src/main/java/in/testpress/util/FullScreenChromeClient.java
@@ -5,6 +5,7 @@ import android.content.ActivityNotFoundException;
 import android.content.Intent;
 import android.net.Uri;
 import android.view.View;
+import android.webkit.PermissionRequest;
 import android.webkit.ValueCallback;
 import android.webkit.WebChromeClient;
 import android.webkit.WebView;
@@ -87,5 +88,10 @@ public class FullScreenChromeClient extends WebChromeClient {
         }
         this.filePathCallback.onReceiveValue(FileChooserParams.parseResult(resultCode, data));
         this.filePathCallback = null;
+    }
+
+    public void onPermissionRequest(PermissionRequest request) {
+        String[] permissions = {PermissionRequest.RESOURCE_PROTECTED_MEDIA_ID};
+        request.grant(permissions);
     }
 }


### PR DESCRIPTION
- Issue is embedded DRM-protected video not playing because we haven't provided the permission to webview to access protected media, 
- That permission was given to the webview in this commit.