### PR TITLE
Revert " fix: Prevent viewing locked content on notification redirection #422"

### DIFF
--- a/course/src/main/java/in/testpress/course/fragments/ContentLoadingFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/ContentLoadingFragment.kt
@@ -122,19 +122,7 @@ class ContentLoadingFragment : Fragment(),
     }
 
     private fun changeFragment(content: DomainContent) {
-        if(content.isLocked == true) {
-            showPermissionDeniedMessage()
-        }else {
-            fragmentChangeListener.changeFragment(content)
-        }
-    }
-
-    private fun showPermissionDeniedMessage(){
-        loadingLayout.visibility = View.GONE
-        emptyViewFragment.setEmptyText(
-            `in`.testpress.R.string.permission_denied,
-            `in`.testpress.R.string.testpress_no_permission,
-            `in`.testpress.R.drawable.ic_error_outline_black_18dp)
+        fragmentChangeListener.changeFragment(content)
     }
 
     override fun onRetryClick() {


### PR DESCRIPTION
- This reverts commit b3e4ccb631d56971c6fcc21f378dec2b8168a788.
- Because we planned to re-fetch locked content on the content loading page and show the error message from API on the permission denied page if the content is locked.




