### PR TITLE
fix: Refetch locked content on content loading page

### DIFF
--- a/core/src/main/java/in/testpress/network/NetworkBoundResource.kt
+++ b/core/src/main/java/in/testpress/network/NetworkBoundResource.kt
@@ -67,7 +67,9 @@ abstract class NetworkBoundResource<ResultDataType, NetworkDataType> {
         } else {
             onFetchFailed()
             val exception = TestpressException.httpError(response)
-            setValue(Resource.error(exception, null))
+            withContext(Dispatchers.Main) {
+                setValue(Resource.error(exception, null))
+            }
         }
     }
 

--- a/course/src/main/java/in/testpress/course/fragments/ContentLoadingFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/ContentLoadingFragment.kt
@@ -89,6 +89,7 @@ class ContentLoadingFragment : Fragment(),
     }
 
     private fun isContentLoaded(content: DomainContent): Boolean {
+        if(content.isLocked == true) return false
         return when(content.contentType) {
             "Exam" -> (content.exam != null) && (content.attemptsUrl != null)
             "Video" -> content.video != null


### PR DESCRIPTION
- Re-fetched locked content on the content loading page, showed permission denied message if the content is locked.
