### PR TITLE
fix: Get video encryption key with current institute subdomain

### DIFF
--- a/course/src/main/java/in/testpress/course/util/VideoPlayerInterceptor.kt
+++ b/course/src/main/java/in/testpress/course/util/VideoPlayerInterceptor.kt
@@ -4,16 +4,27 @@ import `in`.testpress.core.TestpressSdk
 import android.content.Context
 import okhttp3.Interceptor
 import okhttp3.Response
+import java.net.URI
 
-class VideoPlayerInterceptor (val context: Context) : Interceptor {
+class VideoPlayerInterceptor(val context: Context) : Interceptor {
 
     override fun intercept(chain: Interceptor.Chain): Response {
         var request = chain.request()
 
-        if(request.url.toString().contains("encryption_key")) {
+        if (request.url.toString().contains("encryption_key")) {
             val session = TestpressSdk.getTestpressSession(context)
-            request = request.newBuilder().addHeader("Authorization", "JWT " + session?.token).build()
+            val hostUrl = getHostUrl(context)
+            val updatedUrl = request.url.newBuilder().host(hostUrl).build()
+            request = request.newBuilder()
+                .addHeader("Authorization", "JWT " + session?.token)
+                .url(updatedUrl)
+                .build()
         }
         return chain.proceed(request)
     }
+}
+
+private fun getHostUrl(context: Context): String {
+    val uri = URI.create(TestpressSdk.getTestpressSession(context)?.instituteSettings?.baseUrl)
+    return uri.host
 }


### PR DESCRIPTION
### Changes done
-  Generate a new URL for getting the video encryption key using institute settings

### Reason for the changes
-  If the Institute subdomain will change video encryption key request will fail

Fixes # .
