### PR TITLE
refactor: AttemptItem clearing to use clearAttemptItem() in END_SECTION

### DIFF
--- a/exam/src/main/java/in/testpress/exam/repository/AttemptRepository.kt
+++ b/exam/src/main/java/in/testpress/exam/repository/AttemptRepository.kt
@@ -277,7 +277,7 @@ class AttemptRepository(val context: Context) {
                 val offlineAttemptSection = offlineAttemptSectionDao.getByAttemptIdAndId(attempt.id, attempt.currentSectionPosition.toLong())
                 offlineAttemptSection?.state = Attempt.COMPLETED
                 offlineAttemptSectionDao.update(offlineAttemptSection!!)
-                attemptItem.clear()
+                clearAttemptItem()
                 _updateSectionResource.postValue(Resource.success(Pair(offlineAttemptSection.asNetworkModel(), action)))
             }
             Action.START_SECTION -> {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of section completion for a smoother experience. No visible changes to user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->