### PR TITLE
Update zoom sdk version to 5.11.0.6883

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ ext {
     minSdkVersionForUITest = 21
     buildToolsVersion = '30.0.2'
     supportLib = '27.1.1'
-    exoPlayer = '2.14.0'
+    exoPlayer = '2.16.1'
     powermock = '2.0.5'
 
     junit = 'junit:junit:4.12'

--- a/course/src/main/java/in/testpress/course/services/VideoDownloadService.kt
+++ b/course/src/main/java/in/testpress/course/services/VideoDownloadService.kt
@@ -54,7 +54,7 @@ class VideoDownloadService : DownloadService(
         return downloadManager
     }
 
-    override fun getForegroundNotification(downloads: MutableList<Download>): Notification {
+    override fun getForegroundNotification(downloads: MutableList<Download>, notMetRequirements: Int): Notification {
 
         val navigateToDownloadsActivity = getIntentForNavigateToDownloadsActivity()
 

--- a/course/src/main/java/in/testpress/course/util/ExoPlayerUtil.java
+++ b/course/src/main/java/in/testpress/course/util/ExoPlayerUtil.java
@@ -293,7 +293,6 @@ public class ExoPlayerUtil implements VideoTimeRangeListener, DrmSessionManagerP
             progressBar.setVisibility(View.VISIBLE);
             buildPlayer();
             initializeDoubleClickOverlay();
-            initializeAudioManager();
         }
         preparePlayer();
         player.seekTo(getStartPositionInMilliSeconds());
@@ -364,30 +363,6 @@ public class ExoPlayerUtil implements VideoTimeRangeListener, DrmSessionManagerP
                         youtubeOverlay.setVisibility(View.GONE);
                     }
                 });
-    }
-
-
-    private void initializeAudioManager() {
-        audioManager = (AudioManager) activity.getSystemService(AUDIO_SERVICE);
-        initAudioFocusChangeListener();
-        audioManager.requestAudioFocus(audioFocusChangeListener, AudioManager.STREAM_MUSIC, AudioManager.AUDIOFOCUS_GAIN);
-    }
-
-    private void initAudioFocusChangeListener() {
-        audioFocusChangeListener = new AudioManager.OnAudioFocusChangeListener() {
-            public void onAudioFocusChange(int focusChange) {
-                switch (focusChange) {
-                    case (AudioManager.AUDIOFOCUS_LOSS_TRANSIENT):
-                        player.pause();
-                        break;
-                    case (AudioManager.AUDIOFOCUS_LOSS) :
-                        player.pause();
-                        break;
-                    default:
-                        break;
-                }
-            }
-        };
     }
 
     private void preparePlayer() {
@@ -748,7 +723,7 @@ public class ExoPlayerUtil implements VideoTimeRangeListener, DrmSessionManagerP
 
             if (usbConnectionStateReceiver != null && !isScreenCasted() &&
                     CommonUtils.isUsbConnected(activity)) {
-                
+
                 displayError(R.string.testpress_usb_connected);
             } else {
                 hideError(R.string.testpress_usb_connected);

--- a/course/src/main/java/in/testpress/course/util/ExoPlayerUtil.java
+++ b/course/src/main/java/in/testpress/course/util/ExoPlayerUtil.java
@@ -35,14 +35,13 @@ import com.airbnb.lottie.LottieAnimationView;
 import com.github.vkay94.dtpv.DoubleTapPlayerView;
 import com.github.vkay94.dtpv.youtube.YouTubeOverlay;
 import com.google.android.exoplayer2.C;
-import com.google.android.exoplayer2.DefaultControlDispatcher;
 import com.google.android.exoplayer2.DefaultRenderersFactory;
-import com.google.android.exoplayer2.ExoPlaybackException;
+import com.google.android.exoplayer2.ExoPlayer;
 import com.google.android.exoplayer2.MediaItem;
+import com.google.android.exoplayer2.PlaybackException;
 import com.google.android.exoplayer2.PlaybackParameters;
-import com.google.android.exoplayer2.PlaybackPreparer;
 import com.google.android.exoplayer2.Player;
-import com.google.android.exoplayer2.SimpleExoPlayer;
+import com.google.android.exoplayer2.audio.AudioAttributes;
 import com.google.android.exoplayer2.drm.DefaultDrmSessionManager;
 import com.google.android.exoplayer2.drm.DrmSession;
 import com.google.android.exoplayer2.drm.DrmSessionManager;
@@ -98,6 +97,7 @@ import org.greenrobot.greendao.annotation.NotNull;
 public class ExoPlayerUtil implements VideoTimeRangeListener, DrmSessionManagerProvider {
 
     private static final int OVERLAY_POSITION_CHANGE_INTERVAL = 15000; // 15s
+    private static final int SEEK_TIME_IN_MILLISECOND = 15000; //15s
 
     private FrameLayout exoPlayerMainFrame;
     private View exoPlayerLayout;
@@ -107,7 +107,7 @@ public class ExoPlayerUtil implements VideoTimeRangeListener, DrmSessionManagerP
     private LinearLayout emailIdLayout;
     private TextView emailIdTextView;
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-    public SimpleExoPlayer player;
+    public ExoPlayer player;
     private ImageView fullscreenIcon;
     private Dialog fullscreenDialog;
     private TrackSelectionDialog trackSelectionDialog;
@@ -203,12 +203,6 @@ public class ExoPlayerUtil implements VideoTimeRangeListener, DrmSessionManagerP
             initScreenRecordTrackers();
         }
         setSpeedRate(1);
-        playerView.setPlaybackPreparer(new PlaybackPreparer() {
-            @Override
-            public void preparePlayback() {
-                initializePlayer();
-            }
-        });
 
         ExoTrackSelection.Factory videoTrackSelectionFactory = new AdaptiveTrackSelection.Factory();
         trackSelector =  new DefaultTrackSelector(activity, videoTrackSelectionFactory);
@@ -315,12 +309,15 @@ public class ExoPlayerUtil implements VideoTimeRangeListener, DrmSessionManagerP
             mediaSourceFactory.setDrmSessionManagerProvider(this);
         }
 
-        player = new SimpleExoPlayer.Builder(activity, new DefaultRenderersFactory(activity))
+        player = new ExoPlayer.Builder(activity, new DefaultRenderersFactory(activity))
                 .setMediaSourceFactory(mediaSourceFactory)
+                .setSeekForwardIncrementMs(SEEK_TIME_IN_MILLISECOND)
+                .setSeekBackIncrementMs(SEEK_TIME_IN_MILLISECOND)
                 .setTrackSelector(trackSelector).build();
 
         player.addListener(new PlayerEventListener());
         player.addAnalyticsListener(new ExoplayerAnalyticsListener(this));
+        player.setAudioAttributes(AudioAttributes.DEFAULT,true);
         playerView.setPlayer(player);
         player.setPlayWhenReady(playWhenReady);
         player.setPlaybackParameters(new PlaybackParameters(speedRate));
@@ -407,7 +404,6 @@ public class ExoPlayerUtil implements VideoTimeRangeListener, DrmSessionManagerP
 
     private void registerListeners() {
         registerUsbConnectionStateReceiver();
-        addPlayPauseOnClickListener();
     }
 
     private void registerUsbConnectionStateReceiver() {
@@ -417,19 +413,6 @@ public class ExoPlayerUtil implements VideoTimeRangeListener, DrmSessionManagerP
             mediaRouter.addCallback(mediaRouteSelector, mediaRouterCallback,
                     MediaRouter.CALLBACK_FLAG_PERFORM_ACTIVE_SCAN);
         }
-    }
-
-    private void addPlayPauseOnClickListener() {
-        playerView.setControlDispatcher(new DefaultControlDispatcher() {
-            @Override
-            public boolean dispatchSetPlayWhenReady(Player player, boolean playWhenReady) {
-                if (playWhenReady) {
-                    audioManager.requestAudioFocus(audioFocusChangeListener, AudioManager.STREAM_MUSIC, AudioManager.AUDIOFOCUS_GAIN);
-                }
-                updateVideoAttempt();
-                return super.dispatchSetPlayWhenReady(player, playWhenReady);
-            }
-        });
     }
 
     private DialogInterface.OnClickListener trackSelectionListener() {
@@ -749,6 +732,13 @@ public class ExoPlayerUtil implements VideoTimeRangeListener, DrmSessionManagerP
     }
 
     private class PlayerEventListener implements Player.EventListener, DRMLicenseFetchCallback {
+
+        @Override
+        public void onIsPlayingChanged(boolean isPlaying) {
+            updateVideoAttempt();
+            Player.EventListener.super.onIsPlayingChanged(isPlaying);
+        }
+
         @Override
         public void onPlaybackStateChanged(int playbackState) {
             if(isPreparing && playbackState == Player.STATE_READY){
@@ -784,7 +774,7 @@ public class ExoPlayerUtil implements VideoTimeRangeListener, DrmSessionManagerP
         }
 
         @Override
-        public void onPlayerError(ExoPlaybackException exception) {
+        public void onPlayerError(PlaybackException exception) {
             Throwable cause = exception.getCause();
 
             if (isDRMException(cause)) {
@@ -801,7 +791,7 @@ public class ExoPlayerUtil implements VideoTimeRangeListener, DrmSessionManagerP
                     displayError(R.string.license_request_failed);
                 }
             } else {
-                handleError(exception.type == TYPE_SOURCE);
+                handleError(exception.errorCode == TYPE_SOURCE);
             }
         }
 

--- a/course/src/main/java/in/testpress/course/util/ZoomMeetHandler.kt
+++ b/course/src/main/java/in/testpress/course/util/ZoomMeetHandler.kt
@@ -94,7 +94,6 @@ class ZoomMeetHandler(
     }
 
     override fun onZoomSDKInitializeResult(errorCode: Int, internalErrorCode: Int) {
-        Toast.makeText(context,zoomSDK.getVersion(context),Toast.LENGTH_SHORT).show()
         if (errorCode != ZoomError.ZOOM_ERROR_SUCCESS) {
             Toast.makeText(
                 context,

--- a/course/src/main/java/in/testpress/course/util/ZoomMeetHandler.kt
+++ b/course/src/main/java/in/testpress/course/util/ZoomMeetHandler.kt
@@ -89,7 +89,12 @@ class ZoomMeetHandler(
         }
     }
 
+    override fun onMeetingParameterNotification(p0: MeetingParameter?) {
+
+    }
+
     override fun onZoomSDKInitializeResult(errorCode: Int, internalErrorCode: Int) {
+        Toast.makeText(context,zoomSDK.getVersion(context),Toast.LENGTH_SHORT).show()
         if (errorCode != ZoomError.ZOOM_ERROR_SUCCESS) {
             Toast.makeText(
                 context,
@@ -174,8 +179,8 @@ class ZoomMeetHandler(
     override fun onActiveSpeakerVideoUserChanged(p0: Long) {
     }
 
-    override fun onVideoOrderUpdated(p0: MutableList<Long>?) {
-        
+    override fun onHostVideoOrderUpdated(p0: MutableList<Long>?) {
+
     }
 
     override fun onFollowHostVideoOrderChanged(p0: Boolean) {
@@ -185,8 +190,18 @@ class ZoomMeetHandler(
     override fun onChatMessageReceived(p0: InMeetingChatMessage?) {
     }
 
+    override fun onChatMsgDeleteNotification(p0: String?, p1: ChatMessageDeleteType?) {
+
+    }
+
+
     override fun onUserNetworkQualityChanged(p0: Long) {
     }
+
+    override fun onSinkMeetingVideoQualityChanged(p0: VideoQuality?, p1: Long) {
+
+    }
+
 
     override fun onMeetingUserJoin(p0: MutableList<Long>?) {
     }
@@ -195,12 +210,24 @@ class ZoomMeetHandler(
          
     }
 
-    override fun onLocalRecordingStatus(p0: InMeetingServiceListener.RecordingStatus?) {
-        
+    override fun onLocalRecordingStatus(p0: Long, p1: InMeetingServiceListener.RecordingStatus?) {
+
     }
 
     override fun onInvalidReclaimHostkey() {
         
+    }
+
+    override fun onPermissionRequested(p0: Array<out String>?) {
+
+    }
+
+    override fun onAllHandsLowered() {
+
+    }
+
+    override fun onLocalVideoOrderUpdated(p0: MutableList<Long>?) {
+
     }
 
     override fun onMeetingUserLeave(p0: MutableList<Long>?) {
@@ -213,8 +240,8 @@ class ZoomMeetHandler(
          
     }
 
-    override fun onClosedCaptionReceived(p0: String?) {
-         
+    override fun onClosedCaptionReceived(p0: String?, p1: Long) {
+
     }
 
     override fun onFreeMeetingNeedToUpgrade(p0: FreeMeetingNeedUpgradeType?, p1: String?) {
@@ -241,6 +268,10 @@ class ZoomMeetHandler(
     override fun onMeetingCoHostChanged(p0: Long) {
     }
 
+    override fun onMeetingCoHostChange(p0: Long, p1: Boolean) {
+
+    }
+
     override fun onLowOrRaiseHandStatusChanged(p0: Long, p1: Boolean) {
     }
 
@@ -259,9 +290,18 @@ class ZoomMeetHandler(
     override fun onSinkAllowAttendeeChatNotification(p0: Int) {
     }
 
+    override fun onSinkPanelistChatPrivilegeChanged(p0: InMeetingChatController.MobileRTCWebinarPanelistChatPrivilege?) {
+
+    }
+
 
     override fun onSpotlightVideoChanged(p0: Boolean) {
     }
+
+    override fun onSpotlightVideoChanged(p0: MutableList<Long>?) {
+
+    }
+
 
     override fun onMeetingHostChanged(p0: Long) {
     }
@@ -277,6 +317,10 @@ class ZoomMeetHandler(
     }
 
     override fun onUserNameChanged(p0: Long, p1: String?) {
+    }
+
+    override fun onUserNamesChanged(p0: MutableList<Long>?) {
+
     }
 
     override fun onMeetingNeedPasswordOrDisplayName(

--- a/course/src/main/java/in/testpress/course/util/ZoomMeetHandler.kt
+++ b/course/src/main/java/in/testpress/course/util/ZoomMeetHandler.kt
@@ -94,6 +94,7 @@ class ZoomMeetHandler(
     }
 
     override fun onZoomSDKInitializeResult(errorCode: Int, internalErrorCode: Int) {
+        Toast.makeText(context,zoomSDK.getVersion(context),Toast.LENGTH_SHORT).show()
         if (errorCode != ZoomError.ZOOM_ERROR_SUCCESS) {
             Toast.makeText(
                 context,

--- a/mobilertc/build.gradle
+++ b/mobilertc/build.gradle
@@ -3,8 +3,8 @@ artifacts.add("default", file('mobilertc.aar'))
 
 dependencies.add("default","androidx.security:security-crypto:1.1.0-alpha03")
 dependencies.add("default","com.google.crypto.tink:tink-android:1.5.0")
-dependencies.add("default","com.google.android.exoplayer:exoplayer-core:2.13.3")
-dependencies.add("default","com.google.android.exoplayer:exoplayer-ui:2.13.3")
+dependencies.add("default","com.google.android.exoplayer:exoplayer-core:2.16.1")
+dependencies.add("default","com.google.android.exoplayer:exoplayer-ui:2.16.1")
 dependencies.add("default","androidx.swiperefreshlayout:swiperefreshlayout:1.1.0")
 
 dependencies.add("default","androidx.appcompat:appcompat:1.3.1")
@@ -19,12 +19,13 @@ dependencies.add("default","com.github.bumptech.glide:glide:4.11.0")
 dependencies.add("default","androidx.recyclerview:recyclerview:1.2.1")
 dependencies.add("default","com.airbnb.android:lottie:4.0.0")
 
-dependencies.add("default","androidx.window:window:1.0.0-alpha06")
-dependencies.add("default", "com.google.android.material:material:1.4.0")
+dependencies.add("default","androidx.window:window:1.0.0")
 
-dependencies.add("default","androidx.window:window-java:1.0.0-beta03")
+dependencies.add("default","androidx.window:window-java:1.0.0")
 
-dependencies.add("default","org.jetbrains.kotlin:kotlin-stdlib:1.5.21")
-dependencies.add("default","androidx.core:core-ktx:1.6.0")
+dependencies.add("default","org.jetbrains.kotlin:kotlin-stdlib:1.6.0")
+dependencies.add("default","androidx.core:core-ktx:1.7.0")
 dependencies.add("default","androidx.lifecycle:lifecycle-viewmodel-ktx:2.4.0")
 dependencies.add("default","androidx.lifecycle:lifecycle-runtime-ktx:2.4.0")
+
+dependencies.add("default","androidx.fragment:fragment-ktx:1.4.1")


### PR DESCRIPTION
### Changes done
-  update Zoom sdk version to 5.11.0.6883
-  update exoplayer version to 2.16.1
-  replaced deprecate method 

### Reason for the changes
-  Zoom sdk version using exoplayer version 2.16.1 
- Android version 12 need zoom sdk version 5.11.0.6883

Fixes # .
