### PR TITLE
refactor: Migrate from Kotlin synthetics to Jetpack view binding

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 
 android {
@@ -33,6 +32,10 @@ android {
     testOptions {
         unitTests.returnDefaultValues = true
         unitTests.includeAndroidResources = true
+    }
+
+    buildFeatures {
+        viewBinding true
     }
 
     compileOptions {

--- a/core/src/main/java/in/testpress/ui/fragments/DiscussionFragment.kt
+++ b/core/src/main/java/in/testpress/ui/fragments/DiscussionFragment.kt
@@ -1,6 +1,7 @@
 package `in`.testpress.ui.fragments
 
 import `in`.testpress.R
+import `in`.testpress.databinding.DiscussionListBinding
 import `in`.testpress.ui.*
 import android.os.Bundle
 import android.view.*
@@ -16,12 +17,14 @@ import androidx.paging.ExperimentalPagingApi
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.slidingpanelayout.widget.SlidingPaneLayout
 import com.google.android.material.floatingactionbutton.FloatingActionButton
-import kotlinx.android.synthetic.main.discussion_list.*
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 
 
 open class DiscussionFragment: Fragment(), DiscussionFilterListener {
+    private var _binding: DiscussionListBinding? = null
+    private val binding get() = _binding!!
+
     open val adapter = DiscussionsAdapter() { forum ->
     }
     lateinit var slidingPaneLayout: SlidingPaneLayout
@@ -45,8 +48,18 @@ open class DiscussionFragment: Fragment(), DiscussionFilterListener {
         setHasOptionsMenu(true)
     }
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        return inflater.inflate(R.layout.discussion_list, container, false)
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        _binding = DiscussionListBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
@@ -99,11 +112,11 @@ open class DiscussionFragment: Fragment(), DiscussionFilterListener {
     }
 
     private fun setupViews() {
-        discussions.adapter = adapter.withLoadStateHeaderAndFooter(
+        binding.discussions.adapter = adapter.withLoadStateHeaderAndFooter(
                 header = DiscussionsLoadingStateAdapter(adapter, requireContext()),
                 footer = DiscussionsLoadingStateAdapter(adapter, requireContext())
         )
-        discussions.addItemDecoration(DividerItemDecoration(context, DividerItemDecoration.VERTICAL))
+        binding.discussions.addItemDecoration(DividerItemDecoration(context, DividerItemDecoration.VERTICAL))
         initializeFilterFragment()
     }
 

--- a/course/build.gradle
+++ b/course/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdkVersion rootProject.compileSdkVersion

--- a/course/src/main/java/in/testpress/course/fragments/DocumentViewerFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/DocumentViewerFragment.kt
@@ -1,6 +1,7 @@
 package `in`.testpress.course.fragments
 
 import `in`.testpress.course.R
+import `in`.testpress.course.databinding.LayoutDocumentViewerBinding
 import `in`.testpress.course.ui.ContentActivity
 import `in`.testpress.course.ui.PdfViewerActivity
 import `in`.testpress.course.util.PDFViewer
@@ -8,18 +9,18 @@ import `in`.testpress.course.util.DisplayPDFListener
 import `in`.testpress.course.util.PDFDownloadManager
 import `in`.testpress.course.util.PdfDownloadListener
 import `in`.testpress.course.util.SHA256Generator.generateSha256
+import `in`.testpress.databinding.DiscussionListBinding
 import android.content.Intent
 import android.os.Bundle
 import android.view.*
 import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.Observer
-import kotlinx.android.synthetic.main.layout_document_viewer.*
-import kotlinx.android.synthetic.main.layout_document_viewer.pdfView
 import java.net.URI
 
 class DocumentViewerFragment : BaseContentDetailFragment(), PdfDownloadListener,
         DisplayPDFListener {
-
+    private var _binding: LayoutDocumentViewerBinding? = null
+    private val binding get() = _binding!!
     private var pageNumber = 0
 
     private lateinit var fileName: String
@@ -40,8 +41,14 @@ class DocumentViewerFragment : BaseContentDetailFragment(), PdfDownloadListener,
             inflater: LayoutInflater,
             container: ViewGroup?,
             savedInstanceState: Bundle?
-    ): View? {
-        return inflater.inflate(R.layout.layout_document_viewer, container, false)
+    ): View {
+        _binding = LayoutDocumentViewerBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
@@ -104,10 +111,10 @@ class DocumentViewerFragment : BaseContentDetailFragment(), PdfDownloadListener,
     }
 
     private fun displayPDF() {
-        encryptionProgress.visibility = View.VISIBLE
+        binding.encryptionProgress.visibility = View.VISIBLE
         PDFViewer(requireContext(),displayPDFListener = this).display(
                 file = pdfDownloadManager.get(),
-                pdfView = pdfView
+                pdfView = binding.pdfView
         )
     }
 
@@ -117,13 +124,11 @@ class DocumentViewerFragment : BaseContentDetailFragment(), PdfDownloadListener,
     }
 
     override fun downloadProgress(progress: Int) {
-        if (downloadProgress != null) {
-            showDownloadProgress(progress)
-            encryptionProgress.visibility = View.GONE
-        }
+        showDownloadProgress(progress)
+        binding.encryptionProgress.visibility = View.GONE
         if (progress == completeProgress) {
             hideDownloadProgress()
-            encryptionProgress.visibility = View.VISIBLE
+            binding.encryptionProgress.visibility = View.VISIBLE
         }
     }
 
@@ -136,7 +141,7 @@ class DocumentViewerFragment : BaseContentDetailFragment(), PdfDownloadListener,
     }
 
     override fun onPDFLoaded() {
-        encryptionProgress.visibility = View.GONE
+        binding.encryptionProgress.visibility = View.GONE
         if (::fullScreenMenu.isInitialized) {
             fullScreenMenu.isVisible = true
         }
@@ -147,22 +152,20 @@ class DocumentViewerFragment : BaseContentDetailFragment(), PdfDownloadListener,
     }
 
     private fun showDownloadProgress(progress: Int) {
-        downloadProgress.visibility = View.VISIBLE
-        progressPercentage.visibility = View.VISIBLE
-        downloadProgress.progress = progress
-        progressPercentage.text = "$progress%"
+        binding.downloadProgress.visibility = View.VISIBLE
+        binding.progressPercentage.visibility = View.VISIBLE
+        binding.downloadProgress.progress = progress
+        binding.progressPercentage.text = "$progress%"
     }
 
     private fun hideDownloadProgress() {
-        if (downloadProgress != null) {
-            downloadProgress.visibility = View.GONE
-            progressPercentage.visibility = View.GONE
-        }
+        binding.downloadProgress.visibility = View.GONE
+        binding.progressPercentage.visibility = View.GONE
     }
 
     private fun showErrorView() {
-        pdfView.visibility = View.GONE
-        emptyContainer.visibility = View.VISIBLE
+        binding.pdfView.visibility = View.GONE
+        binding.emptyContainer.visibility = View.VISIBLE
     }
 
     override fun onDetach() {

--- a/course/src/main/java/in/testpress/course/ui/PdfViewerActivity.kt
+++ b/course/src/main/java/in/testpress/course/ui/PdfViewerActivity.kt
@@ -1,6 +1,7 @@
 package `in`.testpress.course.ui
 
 import `in`.testpress.course.R
+import `in`.testpress.course.databinding.LayoutPdfViewerBinding
 import `in`.testpress.course.util.PDFViewer
 import `in`.testpress.course.util.DisplayPDFListener
 import `in`.testpress.course.util.PDFDownloadManager
@@ -9,14 +10,9 @@ import android.os.Bundle
 import android.view.View
 import android.view.WindowManager
 import androidx.appcompat.app.AppCompatActivity
-import kotlinx.android.synthetic.main.layout_pdf_viewer.*
-import kotlinx.android.synthetic.main.layout_pdf_viewer.downloadProgress
-import kotlinx.android.synthetic.main.layout_pdf_viewer.emptyContainer
-import kotlinx.android.synthetic.main.layout_pdf_viewer.pdfView
-import kotlinx.android.synthetic.main.layout_pdf_viewer.progressPercentage
 
 class PdfViewerActivity : AppCompatActivity(), PdfDownloadListener, DisplayPDFListener {
-
+    private lateinit var binding: LayoutPdfViewerBinding
     private lateinit var pdfDownloadManager: PDFDownloadManager
 
     private var pageNumber = 0
@@ -30,7 +26,8 @@ class PdfViewerActivity : AppCompatActivity(), PdfDownloadListener, DisplayPDFLi
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         disableScreenShot()
-        setContentView(R.layout.layout_pdf_viewer)
+        binding = LayoutPdfViewerBinding.inflate(layoutInflater)
+        setContentView(binding.root)
         hideStatusBar()
         getDataFromBundle()
         pdfDownloadManager = PDFDownloadManager(this,this,fileName)
@@ -69,11 +66,11 @@ class PdfViewerActivity : AppCompatActivity(), PdfDownloadListener, DisplayPDFLi
     }
 
     private fun displayPDF() {
-        encryptionProgressbar.visibility = View.VISIBLE
+        binding.encryptionProgressbar.visibility = View.VISIBLE
         PDFViewer(this,displayPDFListener = this).display(
                 pageNumber = pageNumber,
                 file = pdfDownloadManager.get(),
-                pdfView = pdfView
+                pdfView = binding.pdfView
         )
     }
 
@@ -83,15 +80,13 @@ class PdfViewerActivity : AppCompatActivity(), PdfDownloadListener, DisplayPDFLi
     }
 
     override fun downloadProgress(progress: Int) {
-        if (progressPercentage != null) {
-            showDownloadProgress(progress)
-        }
+        showDownloadProgress(progress)
     }
 
     override fun onSingleTapOnPDF() {}
 
     override fun onPDFLoaded() {
-        encryptionProgressbar.visibility = View.GONE
+        binding.encryptionProgressbar.visibility = View.GONE
     }
 
     override fun onError() {
@@ -103,21 +98,21 @@ class PdfViewerActivity : AppCompatActivity(), PdfDownloadListener, DisplayPDFLi
     }
 
     private fun showDownloadProgress(progress: Int) {
-        downloadProgress.visibility = View.VISIBLE
-        progressPercentage.visibility = View.VISIBLE
-        downloadProgress.progress = progress
-        progressPercentage.text = "$progress%"
+        binding.downloadProgress.visibility = View.VISIBLE
+        binding.progressPercentage.visibility = View.VISIBLE
+        binding.downloadProgress.progress = progress
+        binding.progressPercentage.text = "$progress%"
     }
 
     private fun hideDownloadProgress() {
-        downloadProgress.visibility = View.GONE
-        progressPercentage.visibility = View.GONE
+        binding.downloadProgress.visibility = View.GONE
+        binding.progressPercentage.visibility = View.GONE
     }
 
     private fun showErrorView() {
-        encryptionProgressbar.visibility = View.GONE
-        pdfView.visibility = View.GONE
-        emptyContainer.visibility = View.VISIBLE
+        binding.encryptionProgressbar.visibility = View.GONE
+        binding.pdfView.visibility = View.GONE
+        binding.emptyContainer.visibility = View.VISIBLE
     }
 
     override fun onDestroy() {

--- a/course/src/main/java/in/testpress/course/ui/VideoDownloadQualityChooserDialog.kt
+++ b/course/src/main/java/in/testpress/course/ui/VideoDownloadQualityChooserDialog.kt
@@ -1,6 +1,8 @@
 package `in`.testpress.course.ui
 
 import `in`.testpress.course.R
+import `in`.testpress.course.databinding.LayoutDocumentViewerBinding
+import `in`.testpress.course.databinding.VideoDownloadDialogBinding
 import `in`.testpress.course.domain.DomainContent
 import `in`.testpress.course.helpers.VideoDownloadRequestCreationHandler
 import `in`.testpress.course.util.ExoPlayerTrackNameProvider
@@ -17,7 +19,6 @@ import com.google.android.exoplayer2.offline.DownloadRequest
 import com.google.android.exoplayer2.trackselection.DefaultTrackSelector
 import com.google.android.exoplayer2.trackselection.MappingTrackSelector
 import com.google.android.exoplayer2.ui.TrackSelectionView
-import kotlinx.android.synthetic.main.video_download_dialog.*
 import java.io.IOException
 
 typealias OnSubmitListener = (DownloadRequest) -> Unit
@@ -25,6 +26,9 @@ typealias OnSubmitListener = (DownloadRequest) -> Unit
 class VideoDownloadQualityChooserDialog(val content: DomainContent) : DialogFragment(),
     TrackSelectionView.TrackSelectionListener,
     VideoDownloadRequestCreationHandler.Listener {
+    private var _binding: VideoDownloadDialogBinding? = null
+    private val binding get() = _binding!!
+
     private lateinit var trackSelectionView: TrackSelectionView
     lateinit var overrides: List<DefaultTrackSelector.SelectionOverride>
     private var onSubmitListener: OnSubmitListener? = null
@@ -45,7 +49,8 @@ class VideoDownloadQualityChooserDialog(val content: DomainContent) : DialogFrag
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        return inflater.inflate(R.layout.video_download_dialog, container, false)
+        _binding = VideoDownloadDialogBinding.inflate(inflater, container, false)
+        return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -65,7 +70,7 @@ class VideoDownloadQualityChooserDialog(val content: DomainContent) : DialogFrag
     }
 
     private fun setOnClickListeners() {
-        okButton.setOnClickListener {
+        binding.okButton.setOnClickListener {
             if (::overrides.isInitialized) {
                 val downloadRequest = videoDownloadRequestCreateHandler.buildDownloadRequest(overrides)
                 onSubmitListener?.invoke(downloadRequest)
@@ -73,13 +78,11 @@ class VideoDownloadQualityChooserDialog(val content: DomainContent) : DialogFrag
             dismiss()
         }
 
-        cancelButton.setOnClickListener { dismiss() }
+        binding.cancelButton.setOnClickListener { dismiss() }
     }
 
     private fun showLoading() {
-        if (loadingProgress != null) {
-            loadingProgress.visibility = View.VISIBLE
-        }
+        binding.loadingProgress.visibility = View.VISIBLE
     }
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
@@ -101,19 +104,17 @@ class VideoDownloadQualityChooserDialog(val content: DomainContent) : DialogFrag
 
     override fun onDownloadRequestHandlerPrepareError(helper: DownloadHelper, e: IOException) {
         hideLoading()
-        errorText.visibility = View.VISIBLE
+        binding.errorText.visibility = View.VISIBLE
         dialog?.setTitle(null)
-        cancelButton.visibility = View.GONE
-        okButton.setOnClickListener {
+        binding.cancelButton.visibility = View.GONE
+        binding.okButton.setOnClickListener {
             dismiss()
         }
         Log.d("VideoDownload", "onDownloadRequestHandlerPrepareError: ${e.localizedMessage}")
     }
 
     private fun hideLoading() {
-        if (loadingProgress != null) {
-            loadingProgress.visibility = View.GONE
-        }
+        binding.loadingProgress.visibility = View.GONE
     }
 
     override fun onTrackSelectionChanged(

--- a/course/src/main/java/in/testpress/course/ui/WebViewWithSSO.kt
+++ b/course/src/main/java/in/testpress/course/ui/WebViewWithSSO.kt
@@ -4,6 +4,8 @@ import `in`.testpress.core.TestpressCallback
 import `in`.testpress.core.TestpressException
 import `in`.testpress.core.TestpressSdk
 import `in`.testpress.course.R
+import `in`.testpress.course.databinding.LayoutPdfViewerBinding
+import `in`.testpress.databinding.TestpressContainerLayoutBinding
 import `in`.testpress.ui.WebViewActivity
 import `in`.testpress.fragments.EmptyViewFragment
 import `in`.testpress.fragments.EmptyViewListener
@@ -15,16 +17,17 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
-import kotlinx.android.synthetic.main.content_detail_activity.*
 import java.io.IOException
 
 class WebViewWithSSO: AppCompatActivity(), EmptyViewListener {
+    private lateinit var binding: TestpressContainerLayoutBinding
     lateinit var emptyViewFragment: EmptyViewFragment
     val instituteSettings: InstituteSettings? = TestpressSdk.getTestpressSession(this)?.instituteSettings;
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.testpress_container_layout)
+        binding = TestpressContainerLayoutBinding.inflate(layoutInflater)
+        setContentView(binding.root)
         initializeEmptyViewFragment()
         showLoading()
         fetchSsoLink()
@@ -67,13 +70,13 @@ class WebViewWithSSO: AppCompatActivity(), EmptyViewListener {
     }
 
     private fun showLoading() {
-        pb_loading.visibility = View.VISIBLE
-        fragment_container.visibility = View.GONE
+        binding.pbLoading.visibility = View.VISIBLE
+        binding.fragmentContainer.visibility = View.GONE
     }
 
     private fun hideLoading() {
-        pb_loading.visibility = View.GONE
-        fragment_container.visibility = View.VISIBLE
+        binding.pbLoading.visibility = View.GONE
+        binding.fragmentContainer.visibility = View.VISIBLE
     }
 
     private fun showErrorView(exception: java.lang.Exception?) {

--- a/course/src/main/java/in/testpress/course/util/TrackSelectionDialog.kt
+++ b/course/src/main/java/in/testpress/course/util/TrackSelectionDialog.kt
@@ -1,6 +1,8 @@
 package `in`.testpress.course.util
 
 import `in`.testpress.course.R
+import `in`.testpress.course.databinding.LayoutDocumentViewerBinding
+import `in`.testpress.course.databinding.TrackSelectionDialogBinding
 import android.app.Dialog
 import android.content.DialogInterface
 import android.os.Bundle
@@ -13,14 +15,14 @@ import com.google.android.exoplayer2.C
 import com.google.android.exoplayer2.trackselection.DefaultTrackSelector
 import com.google.android.exoplayer2.trackselection.MappingTrackSelector
 import com.google.android.exoplayer2.ui.TrackSelectionView
-import kotlinx.android.synthetic.main.track_selection_dialog.*
 
 open class TrackSelectionDialog(
     private val parameters: DefaultTrackSelector.Parameters,
     open val mappedTrackInfo: MappingTrackSelector.MappedTrackInfo
 ) : DialogFragment(),
     TrackSelectionView.TrackSelectionListener {
-
+    private var _binding: TrackSelectionDialogBinding? = null
+    private val binding get() = _binding!!
     private lateinit var trackSelectionView: TrackSelectionView
     private var allowAdaptiveSelections = false
     private val rendererIndex = ExoPlayerUtil.getRendererIndex(C.TRACK_TYPE_VIDEO, mappedTrackInfo)
@@ -43,7 +45,14 @@ open class TrackSelectionDialog(
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        return inflater.inflate(R.layout.track_selection_dialog, container, false)
+        _binding = TrackSelectionDialogBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -68,12 +77,12 @@ open class TrackSelectionDialog(
     }
 
     private fun setOnClickListeners() {
-        okButton.setOnClickListener {
+        binding.okButton.setOnClickListener {
             onClickListener?.onClick(dialog, DialogInterface.BUTTON_POSITIVE)
             dismiss()
         }
 
-        cancelButton.setOnClickListener { dismiss() }
+        binding.cancelButton.setOnClickListener { dismiss() }
     }
 
     fun setAllowAdaptiveSelections(allow: Boolean) {

--- a/exam/build.gradle
+++ b/exam/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdkVersion rootProject.compileSdkVersion
@@ -28,6 +27,10 @@ android {
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    buildFeatures {
+        viewBinding true
     }
 }
 

--- a/exam/src/main/java/in/testpress/exam/ui/ReviewPanelAdapter.kt
+++ b/exam/src/main/java/in/testpress/exam/ui/ReviewPanelAdapter.kt
@@ -1,6 +1,7 @@
 package `in`.testpress.exam.ui
 
 import `in`.testpress.exam.R
+import `in`.testpress.exam.databinding.ReviewPanelItemLayoutBinding
 import `in`.testpress.models.greendao.ReviewItem
 import android.content.Context
 import android.graphics.PorterDuff
@@ -11,7 +12,6 @@ import android.view.ViewGroup
 import android.widget.TextView
 import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.RecyclerView
-import kotlinx.android.synthetic.main.review_panel_item_layout.view.*
 
 class ReviewPanelAdapter(var questions: List<ReviewItem>, val listener: ListItemClickListener): RecyclerView.Adapter<ReviewPanelAdapter.ViewHolder>() {
 
@@ -64,7 +64,8 @@ class ReviewPanelAdapter(var questions: List<ReviewItem>, val listener: ListItem
     override fun getItemCount(): Int = questions.size
 
     inner class ViewHolder(val view: View) : RecyclerView.ViewHolder(view) {
-        val questionIndex: TextView = view.question_index_all
+        private val binding = ReviewPanelItemLayoutBinding.bind(view)
+        val questionIndex: TextView = binding.questionIndexAll
     }
 }
 

--- a/exam/src/main/java/in/testpress/exam/ui/adapters/ShareToUnlockAdapter.kt
+++ b/exam/src/main/java/in/testpress/exam/ui/adapters/ShareToUnlockAdapter.kt
@@ -1,6 +1,7 @@
 package `in`.testpress.exam.ui.adapters
 
 import `in`.testpress.exam.R
+import `in`.testpress.exam.databinding.ShareAppItemBinding
 import `in`.testpress.exam.ui.OnShareAppListener
 import android.content.pm.PackageManager
 import android.content.pm.ResolveInfo
@@ -10,7 +11,6 @@ import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
-import kotlinx.android.synthetic.main.share_app_item.view.*
 
 class ShareToUnlockAdapter(
     val values: List<ResolveInfo>,
@@ -48,7 +48,8 @@ class ShareToUnlockAdapter(
     override fun getItemCount(): Int = values.size
 
     inner class ViewHolder(val view: View) : RecyclerView.ViewHolder(view) {
-        val titleView: TextView = view.title
-        val iconView: ImageView = view.icon
+        private val binding = ShareAppItemBinding.bind(view)
+        val titleView: TextView = binding.title
+        val iconView: ImageView = binding.icon
     }
 }

--- a/store/build.gradle
+++ b/store/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 
 android {


### PR DESCRIPTION
- Kotlin synthetics binding is depreciated. So we are migrating to jetbrains view binding
- Reference: https://developer.android.com/topic/libraries/view-binding/migration#groovy