### PR TITLE
fix: Audio not available for downloaded DRM content

### DIFF
--- a/course/src/main/java/in/testpress/course/helpers/VideoDownloadRequestCreationHandler.kt
+++ b/course/src/main/java/in/testpress/course/helpers/VideoDownloadRequestCreationHandler.kt
@@ -26,9 +26,6 @@ import java.io.IOException
 
 import com.google.android.exoplayer2.source.TrackGroupArray
 
-
-
-
 class VideoDownloadRequestCreationHandler(
     val context: Context,
     val content: DomainContent

--- a/course/src/main/java/in/testpress/course/helpers/VideoDownloadRequestCreationHandler.kt
+++ b/course/src/main/java/in/testpress/course/helpers/VideoDownloadRequestCreationHandler.kt
@@ -8,9 +8,11 @@ import `in`.testpress.course.util.OfflineDRMLicenseHelper
 import `in`.testpress.course.util.VideoUtils.getAudioOrVideoInfoWithDrmInitData
 import `in`.testpress.course.util.VideoUtils.getLowBitrateTrackIndex
 import android.content.Context
+import android.util.Log
 import android.widget.Toast
 import com.google.android.exoplayer2.C
 import com.google.android.exoplayer2.DefaultRenderersFactory
+import com.google.android.exoplayer2.Format
 import com.google.android.exoplayer2.MediaItem
 import com.google.android.exoplayer2.drm.DefaultDrmSessionManager
 import com.google.android.exoplayer2.drm.DrmInitData
@@ -23,6 +25,13 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import java.io.IOException
+import com.google.android.exoplayer2.source.dash.manifest.Representation
+
+import com.google.android.exoplayer2.source.TrackGroup
+
+import com.google.android.exoplayer2.source.TrackGroupArray
+import com.google.android.exoplayer2.trackselection.DefaultTrackSelector.ParametersBuilder
+
 
 class VideoDownloadRequestCreationHandler(
     val context: Context,
@@ -119,13 +128,13 @@ class VideoDownloadRequestCreationHandler(
         val mappedTrackInfo = downloadHelper.getMappedTrackInfo(0)
         for (index in 0 until downloadHelper.periodCount) {
             downloadHelper.clearTrackSelections(index)
-            val rendererIndex = ExoPlayerUtil.getRendererIndex(C.TRACK_TYPE_VIDEO, mappedTrackInfo)
-            downloadHelper.addTrackSelectionForSingleRenderer(
-                index,
-                rendererIndex,
-                DownloadHelper.DEFAULT_TRACK_SELECTOR_PARAMETERS_WITHOUT_CONTEXT,
-                overrides
-            )
+            var builder = DownloadHelper.DEFAULT_TRACK_SELECTOR_PARAMETERS_WITHOUT_CONTEXT.buildUpon()
+            val videoRendererIndex = ExoPlayerUtil.getRendererIndex(C.TRACK_TYPE_VIDEO, mappedTrackInfo)
+            val trackGroupArray: TrackGroupArray = mappedTrackInfo.getTrackGroups(videoRendererIndex)
+            for (i in overrides.indices) {
+                builder.setSelectionOverride(videoRendererIndex, trackGroupArray, overrides[i])
+                downloadHelper.addTrackSelection(index, builder.build())
+            }
         }
     }
 

--- a/course/src/main/java/in/testpress/course/helpers/VideoDownloadRequestCreationHandler.kt
+++ b/course/src/main/java/in/testpress/course/helpers/VideoDownloadRequestCreationHandler.kt
@@ -8,11 +8,9 @@ import `in`.testpress.course.util.OfflineDRMLicenseHelper
 import `in`.testpress.course.util.VideoUtils.getAudioOrVideoInfoWithDrmInitData
 import `in`.testpress.course.util.VideoUtils.getLowBitrateTrackIndex
 import android.content.Context
-import android.util.Log
 import android.widget.Toast
 import com.google.android.exoplayer2.C
 import com.google.android.exoplayer2.DefaultRenderersFactory
-import com.google.android.exoplayer2.Format
 import com.google.android.exoplayer2.MediaItem
 import com.google.android.exoplayer2.drm.DefaultDrmSessionManager
 import com.google.android.exoplayer2.drm.DrmInitData
@@ -25,12 +23,10 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import java.io.IOException
-import com.google.android.exoplayer2.source.dash.manifest.Representation
-
-import com.google.android.exoplayer2.source.TrackGroup
 
 import com.google.android.exoplayer2.source.TrackGroupArray
-import com.google.android.exoplayer2.trackselection.DefaultTrackSelector.ParametersBuilder
+
+
 
 
 class VideoDownloadRequestCreationHandler(


### PR DESCRIPTION
- We used the addTrackSelectionForSingleRenderer to select user-selected resolution tracks while downloading, but in that method, renderers were disabled except the video renderers. so the DRM contents were downloaded without audio tracks.
- This is fixed by selecting tracks to download without using that method.

