### PR TITLE
fix: Removed fallback question count and duration

### DIFF
--- a/course/src/main/java/in/testpress/course/ui/viewholders/ExamContentListItemViewHolder.kt
+++ b/course/src/main/java/in/testpress/course/ui/viewholders/ExamContentListItemViewHolder.kt
@@ -18,6 +18,7 @@ class ExamContentListItemViewHolder(view: View) : BaseContentListItemViewHolder(
     private val duration: TextView = view.findViewById(R.id.duration)
     private val durationContainer: LinearLayout = view.findViewById(R.id.duration_container)
     private val numberOfQuestions: TextView = view.findViewById(R.id.number_of_questions)
+    private val questionContainer: LinearLayout = view.findViewById(R.id.question_container)
     private val description: TextView = view.findViewById(R.id.description)
     private val descriptionContainer: LinearLayout = view.findViewById(R.id.description_container)
 
@@ -32,7 +33,13 @@ class ExamContentListItemViewHolder(view: View) : BaseContentListItemViewHolder(
         content.exam?.let {
             numberOfQuestions.text = it.numberOfQuestions.toString() + " Qs"
             bindDuration(content, it)
-        }
+        }?:isExamNullHideContainers()
+    }
+
+    private fun isExamNullHideContainers(){
+        durationContainer.visibility = View.GONE
+        questionContainer.visibility = View.GONE
+        descriptionContainer.visibility = View.GONE
     }
 
     private fun displayDescription(content: DomainContent) {

--- a/course/src/main/java/in/testpress/course/ui/viewholders/ExamContentListItemViewHolder.kt
+++ b/course/src/main/java/in/testpress/course/ui/viewholders/ExamContentListItemViewHolder.kt
@@ -33,7 +33,9 @@ class ExamContentListItemViewHolder(view: View) : BaseContentListItemViewHolder(
         content.exam?.let {
             numberOfQuestions.text = it.numberOfQuestions.toString() + " Qs"
             bindDuration(content, it)
-        }?:hideExamDetails()
+        }?: run {
+            hideExamDetails()
+        }
     }
 
     private fun hideExamDetails(){

--- a/course/src/main/java/in/testpress/course/ui/viewholders/ExamContentListItemViewHolder.kt
+++ b/course/src/main/java/in/testpress/course/ui/viewholders/ExamContentListItemViewHolder.kt
@@ -33,10 +33,10 @@ class ExamContentListItemViewHolder(view: View) : BaseContentListItemViewHolder(
         content.exam?.let {
             numberOfQuestions.text = it.numberOfQuestions.toString() + " Qs"
             bindDuration(content, it)
-        }?:isExamNullHideContainers()
+        }?:hideExamDetails()
     }
 
-    private fun isExamNullHideContainers(){
+    private fun hideExamDetails(){
         durationContainer.visibility = View.GONE
         questionContainer.visibility = View.GONE
         descriptionContainer.visibility = View.GONE

--- a/course/src/main/java/in/testpress/course/ui/viewholders/VideoContentListItemViewHolder.kt
+++ b/course/src/main/java/in/testpress/course/ui/viewholders/VideoContentListItemViewHolder.kt
@@ -26,7 +26,9 @@ class VideoContentListItemViewHolder(view: View) : BaseContentListItemViewHolder
         content.video?.let {
             bindDuration(it)
             bindVideoProgress(content)
-        }?:hideVideoDuration()
+        }?: run {
+            hideVideoDuration()
+        }
         contentTypeIcon.visibility = View.VISIBLE
     }
 

--- a/course/src/main/java/in/testpress/course/ui/viewholders/VideoContentListItemViewHolder.kt
+++ b/course/src/main/java/in/testpress/course/ui/viewholders/VideoContentListItemViewHolder.kt
@@ -26,11 +26,11 @@ class VideoContentListItemViewHolder(view: View) : BaseContentListItemViewHolder
         content.video?.let {
             bindDuration(it)
             bindVideoProgress(content)
-        }?:isVideoNullHideContainer()
+        }?:hideVideoDuration()
         contentTypeIcon.visibility = View.VISIBLE
     }
 
-    private fun isVideoNullHideContainer(){
+    private fun hideVideoDuration(){
         durationContainer.visibility = View.GONE
     }
 

--- a/course/src/main/java/in/testpress/course/ui/viewholders/VideoContentListItemViewHolder.kt
+++ b/course/src/main/java/in/testpress/course/ui/viewholders/VideoContentListItemViewHolder.kt
@@ -26,8 +26,12 @@ class VideoContentListItemViewHolder(view: View) : BaseContentListItemViewHolder
         content.video?.let {
             bindDuration(it)
             bindVideoProgress(content)
-        }
+        }?:isVideoNullHideContainer()
         contentTypeIcon.visibility = View.VISIBLE
+    }
+
+    private fun isVideoNullHideContainer(){
+        durationContainer.visibility = View.GONE
     }
 
     private fun bindVideoProgress(content: DomainContent) {

--- a/exam/src/main/res/layout/exam_content_list_item.xml
+++ b/exam/src/main/res/layout/exam_content_list_item.xml
@@ -180,23 +180,31 @@
                     android:textSize="12sp" />
             </LinearLayout>
 
-            <ImageView
-                android:layout_width="16dp"
-                android:layout_height="16dp"
-                android:layout_marginRight="5dp"
-                android:src="@drawable/testpress_question_tag" />
-
-            <TextView
-                android:id="@+id/number_of_questions"
-                android:layout_width="40dp"
+            <LinearLayout
+                android:id="@+id/question_container"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:ellipsize="end"
-                android:lineSpacingExtra="4dp"
-                android:maxLines="1"
-                android:text="50 Qs"
-                android:textColor="@color/testpress_text_gray_medium"
-                android:textSize="12sp" />
+                android:layout_gravity="center_vertical"
+                android:layout_marginRight="25dp"
+                android:orientation="horizontal">
 
+                <ImageView
+                    android:layout_width="16dp"
+                    android:layout_height="16dp"
+                    android:layout_marginRight="5dp"
+                    android:src="@drawable/testpress_question_tag" />
+
+                <TextView
+                    android:id="@+id/number_of_questions"
+                    android:layout_width="40dp"
+                    android:layout_height="wrap_content"
+                    android:ellipsize="end"
+                    android:lineSpacingExtra="4dp"
+                    android:maxLines="1"
+                    android:text="50 Qs"
+                    android:textColor="@color/testpress_text_gray_medium"
+                    android:textSize="12sp" />
+            </LinearLayout>
 
         </LinearLayout>
 


### PR DESCRIPTION
### Changes done
-  Hide exam duration and question count if the exam null
-  Hide video duration if video null

### Reason for the changes
-  Previously question count and duration for non preview content were shown as placeholder

Fixes # .
