### PR TITLE
fix: Sections are getting duplicated

### DIFF
--- a/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
@@ -673,7 +673,7 @@ public class TestFragment extends BaseFragment implements LoaderManager.LoaderCa
         } else {
             showProgress(R.string.testpress_loading_questions);
         }
-        boolean fetchSinglePageOnly = attempt.hasSectionalLock() || (attempt.hasNoSectionalLock() && exam.getTemplateType() != 2);
+        boolean fetchSinglePageOnly = attempt.hasSectionalLock();
         return new AttemptItemsLoader(getActivity(), this, fetchSinglePageOnly);
     }
 


### PR DESCRIPTION
### Changes done
-  Allow fetching all questions when the exam has no sectional lock

### Reason for the changes
- previously we are allowing all question fetching for the IBPS template only that is the reason for the section getting duplicates for all other templates.

Fixes #.
