### PR TITLE
fix: App crash while open zoom recorded video

### DIFF
--- a/course/src/main/java/in/testpress/course/fragments/NativeVideoWidgetFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/NativeVideoWidgetFragment.kt
@@ -4,11 +4,13 @@ import `in`.testpress.core.TestpressSdk
 import `in`.testpress.course.R
 import `in`.testpress.course.domain.DomainContent
 import `in`.testpress.course.domain.getGreenDaoContent
+import `in`.testpress.course.network.NetworkContentAttempt
 import `in`.testpress.enums.Status
 import `in`.testpress.course.ui.ContentActivity.CONTENT_ID
 import `in`.testpress.course.util.ExoPlayerUtil
 import `in`.testpress.course.util.ExoplayerFullscreenHelper
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -65,8 +67,9 @@ class NativeVideoWidgetFragment : BaseVideoWidgetFragment() {
                     Status.SUCCESS -> {
                         val contentAttempt = resource.data!!
                         val videoStartPosition = contentAttempt.video?.lastPosition?.toFloat() ?: 0F
+                        val contentAttemptObjectId = contentAttempt.objectId?.toLong()
                         exoPlayerUtil?.setStartPosition(videoStartPosition)
-                        exoPlayerUtil?.setVideoAttemptParameters(contentAttempt.objectId!!.toLong(), greenDaoContent!!)
+                        exoPlayerUtil?.setVideoAttemptParameters(contentAttemptObjectId?:-1, greenDaoContent!!)
                         exoPlayerUtil?.initializePlayer()
                     }
                     else -> {

--- a/course/src/main/java/in/testpress/course/fragments/NativeVideoWidgetFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/NativeVideoWidgetFragment.kt
@@ -4,13 +4,11 @@ import `in`.testpress.core.TestpressSdk
 import `in`.testpress.course.R
 import `in`.testpress.course.domain.DomainContent
 import `in`.testpress.course.domain.getGreenDaoContent
-import `in`.testpress.course.network.NetworkContentAttempt
 import `in`.testpress.enums.Status
 import `in`.testpress.course.ui.ContentActivity.CONTENT_ID
 import `in`.testpress.course.util.ExoPlayerUtil
 import `in`.testpress.course.util.ExoplayerFullscreenHelper
 import android.os.Bundle
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup


### PR DESCRIPTION
### Changes done
-  Added validation for attempt objectId
-  If object id is null assign objectId as -1

### Reason for the changes
-  After attending the zoom meeting user was not able to view the recorded video because of attempt objectId was null
-  In API v2.3/contents/{Content.Id}/attempts/ its return attempt object as null if the content type is video conference

Fixes #.
