### PR TITLE
fix: Customer key not received properly in zoom report API

### DIFF
--- a/core/src/main/java/in/testpress/core/TestpressUserDetails.java
+++ b/core/src/main/java/in/testpress/core/TestpressUserDetails.java
@@ -2,6 +2,8 @@ package in.testpress.core;
 
 import android.content.Context;
 
+import java.io.IOException;
+
 import in.testpress.models.ProfileDetails;
 import in.testpress.network.RetrofitCall;
 import in.testpress.network.TestpressApiClient;
@@ -61,6 +63,11 @@ public class TestpressUserDetails {
                     }
                 });
         return retrofitCall;
+    }
+
+    public ProfileDetails loadSync(Context context) throws IOException {
+        return new TestpressApiClient(context, TestpressSdk.getTestpressSession(context))
+                .getProfileDetails().execute().body();
     }
 
 }


### PR DESCRIPTION
### Changes done
- Added Synchronous call to fetch user profile details
- Handled start button visibility after fetching profile details in VideoConferenceFragment

### Reason for the changes
-  Issue in fetching user profile details so profile details are null while attending the zoom meeting
-  Due to this not able to assign a user_name to Zoom customer_key

Fixes #.
