### PR TITLE
fix: Margin spacing in productCategories listView

### DIFF
--- a/course/src/main/res/layout/available_course_fragment.xml
+++ b/course/src/main/res/layout/available_course_fragment.xml
@@ -87,7 +87,8 @@
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/product_categories_list"
-            android:layout_marginStart="20dp"
+            android:paddingStart="20dp"
+            android:clipToPadding="false"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"/>
 


### PR DESCRIPTION
### Changes done
- Used marginPadding and clipToPadding attributes to hide margin while scrolling the recyclerView

### Reason for the changes
- Previously we used margin for spacing

Fixes #.
