### PR TITLE
fix: App crashes while opening when the device is offline

### DIFF
--- a/course/src/main/java/in/testpress/course/repository/ProductCategoriesRepository.kt
+++ b/course/src/main/java/in/testpress/course/repository/ProductCategoriesRepository.kt
@@ -62,7 +62,7 @@ class ProductCategoriesRepository(val context: Context) {
     }
 
     private fun  getAllProductCategories():MutableList<ProductCategoryEntity>{
-        return runBlocking {
+        return runBlocking(Dispatchers.IO) {
             productCategoryDao.getAll()
         }
     }


### PR DESCRIPTION
### Issue
- Fetching DB should not be done in the main thread. (ref - [link](https://developer.android.com/reference/android/arch/persistence/room/RoomDatabase.Builder#allowmainthreadqueries))
- In getAllProductCategories() we are fetching DB in the main thread which leads to an app crash.
- This happens only when the device is offline. If the device is online we call this getAllProductCategories() inside the CoroutineScope

### Solution
-  Calling this getAllProductCategories() in the background thread using (Dispatchers.IO) will fix this issue 

