### PR TITLE
fix: Add error code in Alert dialog box

### DIFF
--- a/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
@@ -1304,7 +1304,7 @@ public class TestFragment extends BaseFragment implements LoaderManager.LoaderCa
                                 });
             } else {
                 setTitle(R.string.testpress_loading_failed)
-                        .setMessage(getResources().getString(R.string.testpress_some_thing_went_wrong_try_again)+" "+"(Code: "+exception.getResponse().code()+")")
+                        .setMessage(getResources().getString(R.string.testpress_some_thing_went_wrong_try_again)+" "+"(Error code: "+exception.getResponse().code()+")")
                         .setPositiveButton(R.string.testpress_ok,
                                 new DialogInterface.OnClickListener() {
                                     @Override

--- a/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
@@ -1304,7 +1304,7 @@ public class TestFragment extends BaseFragment implements LoaderManager.LoaderCa
                                 });
             } else {
                 setTitle(R.string.testpress_loading_failed)
-                        .setMessage(R.string.testpress_some_thing_went_wrong_try_again)
+                        .setMessage(getResources().getString(R.string.testpress_some_thing_went_wrong_try_again)+" "+"(Code: "+exception.getResponse().code()+")")
                         .setPositiveButton(R.string.testpress_ok,
                                 new DialogInterface.OnClickListener() {
                                     @Override


### PR DESCRIPTION
### Issue
- Students facing API failure while attending the exam but we can't able find the type of failure. 

### Solution
- Right now, we are showing an alert box whenever an API failure occurs, so adding the API error code to the alert message will allow us to find the type of failure.

