### PR TITLE
fix: Review page showing incorrect data after complete the quiz exam

### DIFF
--- a/course/src/main/java/in/testpress/course/network/CourseService.kt
+++ b/course/src/main/java/in/testpress/course/network/CourseService.kt
@@ -34,7 +34,7 @@ interface CourseService {
     @PUT("{end_exam_url}")
     fun endContentAttempt(
         @Path(value = "end_exam_url", encoded = true) endExamUrlFrag: String?
-    ): RetrofitCall<NetworkAttempt>
+    ): RetrofitCall<NetworkContentAttempt>
 
     @GET("{contents_url}")
     fun getContents(
@@ -87,7 +87,7 @@ class CourseNetwork(context: Context) : TestpressApiClient(context, TestpressSdk
         return getCourseService().getContentAttempts(url)
     }
 
-    fun endContentAttempt(url: String):  RetrofitCall<NetworkAttempt> {
+    fun endContentAttempt(url: String):  RetrofitCall<NetworkContentAttempt> {
         return getCourseService().endContentAttempt(url)
     }
 

--- a/course/src/main/java/in/testpress/course/network/NetworkContentAttempt.kt
+++ b/course/src/main/java/in/testpress/course/network/NetworkContentAttempt.kt
@@ -2,6 +2,7 @@ package `in`.testpress.course.network
 
 import `in`.testpress.course.domain.DomainContentAttempt
 import `in`.testpress.exam.network.NetworkAttempt
+import `in`.testpress.exam.network.asGreenDaoModel
 import `in`.testpress.models.greendao.CourseAttempt
 
 data class NetworkContentAttempt(
@@ -30,6 +31,7 @@ fun createContentAttempt(contentAttempt: NetworkContentAttempt): CourseAttempt {
         contentAttempt.userVideoId
     )
     courseAttempt.chapterContent = contentAttempt.chapterContent?.asGreenDaoModel()
+    courseAttempt.assessment = contentAttempt.assessment?.asGreenDaoModel()
     return courseAttempt
 }
 

--- a/course/src/main/java/in/testpress/course/repository/QuizExamRepository.kt
+++ b/course/src/main/java/in/testpress/course/repository/QuizExamRepository.kt
@@ -28,9 +28,9 @@ open class QuizExamRepository(val context: Context) {
     val resourceContentAttempt: LiveData<Resource<DomainContentAttempt>>
         get() = _resourceContentAttempt
 
-    var _resourceAttempt: MutableLiveData<Resource<DomainAttempt>> = MutableLiveData()
-    val resourceAttempt: LiveData<Resource<DomainAttempt>>
-        get() = _resourceAttempt
+    private var _endContentAttemptState: MutableLiveData<Resource<DomainContentAttempt>> = MutableLiveData()
+    val endContentAttemptState: LiveData<Resource<DomainContentAttempt>>
+        get() = _endContentAttemptState
 
     fun createContentAttempt(contentId: Long): LiveData<Resource<DomainContentAttempt>> {
         courseNetwork.createContentAttempt(contentId)
@@ -101,12 +101,13 @@ open class QuizExamRepository(val context: Context) {
 
     fun endExam(url: String, attemptId: Long) {
         courseNetwork.endContentAttempt(url)
-            .enqueue(object : TestpressCallback<NetworkAttempt>() {
-                override fun onSuccess(result: NetworkAttempt?) {
-                    attemptDao.insertOrReplaceInTx(result?.asGreenDaoModel())
-                    val attempts = attemptDao.queryBuilder()
-                        .where(AttemptDao.Properties.Id.eq(result!!.id)).list()
-                    _resourceAttempt.postValue(Resource.success(attempts[0].asDomainModel()))
+            .enqueue(object : TestpressCallback<NetworkContentAttempt>() {
+                override fun onSuccess(result: NetworkContentAttempt?) {
+                    courseAttemptDao.insertOrReplaceInTx(result?.asGreenDaoModel())
+                    attemptDao.insertOrReplaceInTx(result?.assessment?.asGreenDaoModel())
+                    val contentAttempts = courseAttemptDao.queryBuilder()
+                        .where(CourseAttemptDao.Properties.Id.eq(result?.id)).list()
+                    _endContentAttemptState.postValue(Resource.success(contentAttempts[0].asDomainContentAttempt()))
                 }
 
                 override fun onException(exception: TestpressException?) {
@@ -114,7 +115,9 @@ open class QuizExamRepository(val context: Context) {
                         .where(AttemptDao.Properties.Id.eq(attemptId)).list()[0]
                     attempt.state = "COMPLETED"
                     attemptDao.insertOrReplaceInTx(attempt)
-                    _resourceAttempt.postValue(Resource.success(attempt.asDomainModel()))
+                    val contentAttempts = courseAttemptDao.queryBuilder()
+                        .where(CourseAttemptDao.Properties.AssessmentId.eq(attempt.id)).list()
+                    _endContentAttemptState.postValue(Resource.success(contentAttempts[0].asDomainContentAttempt()))
                 }
             })
     }

--- a/course/src/main/java/in/testpress/course/ui/QuizActivity.kt
+++ b/course/src/main/java/in/testpress/course/ui/QuizActivity.kt
@@ -70,7 +70,7 @@ class QuizActivity : BaseToolBarActivity(), ShowQuizHandler, ExamEndHanlder, Que
             showEndExamAlert()
         }
 
-        viewModel.endExamState.observe(this, Observer {
+        viewModel.endContentAttemptState.observe(this, Observer {
             dialog.hide()
             when(it.status) {
                 Status.SUCCESS -> {

--- a/course/src/main/java/in/testpress/course/viewmodels/QuizExamViewModel.kt
+++ b/course/src/main/java/in/testpress/course/viewmodels/QuizExamViewModel.kt
@@ -7,7 +7,8 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
 
 class QuizExamViewModel(val repository: QuizExamRepository): ViewModel() {
-    val endExamState = repository.resourceAttempt
+
+    val endContentAttemptState = repository.endContentAttemptState
 
     fun loadContentAttempt(id: Long): LiveData<Resource<DomainContentAttempt>> {
         return repository.loadContentAttempt(id)


### PR DESCRIPTION
- In this commit d9a0b41 we end the ContentAttempt while ending the exam.
- After completing the Quiz exam, we conclude the ContentAttempt. During this process, we receive a success response for the ContentAttempt. However, our implementation is designed to handle an Attempt response, which results in our inability to properly parse the response, leading to inaccurate data being displayed on the Review page.
- In this commit we Handled success response for the ContentAttempt