### PR TITLE
refactor: Removed generic type parameter in CourseContentList

### DIFF
--- a/course/src/main/java/in/testpress/course/adapter/CourseContentListAdapter .kt
+++ b/course/src/main/java/in/testpress/course/adapter/CourseContentListAdapter .kt
@@ -15,8 +15,8 @@ import `in`.testpress.course.domain.asDomainContent
 import `in`.testpress.database.entities.ContentEntityLite
 import `in`.testpress.database.entities.CourseContentType
 
-class CourseContentListAdapter <T : Any>(COMPARATOR: DiffUtil.ItemCallback<T>):
-    PagingDataAdapter<T, BaseCourseContentItemViewHolder>(COMPARATOR){
+class CourseContentListAdapter (COMPARATOR: DiffUtil.ItemCallback<ContentEntityLite>):
+    PagingDataAdapter<ContentEntityLite, BaseCourseContentItemViewHolder>(COMPARATOR){
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): BaseCourseContentItemViewHolder {
         val binding = RunningUpcomingListItemBinding.inflate(
@@ -40,11 +40,10 @@ class CourseContentListAdapter <T : Any>(COMPARATOR: DiffUtil.ItemCallback<T>):
     }
 
     override fun getItemViewType(position: Int): Int {
-        val content = getItem(position) as ContentEntityLite
-        return if (content.type == CourseContentType.RUNNING_CONTENT.ordinal){
-            CourseContentType.RUNNING_CONTENT.ordinal
-        } else {
-            CourseContentType.UPCOMING_CONTENT.ordinal
+        val content = getItem(position)
+        return when(content?.type){
+            CourseContentType.UPCOMING_CONTENT.ordinal -> CourseContentType.UPCOMING_CONTENT.ordinal
+            else -> CourseContentType.RUNNING_CONTENT.ordinal
         }
     }
 }

--- a/course/src/main/java/in/testpress/course/adapter/CourseContentListAdapter .kt
+++ b/course/src/main/java/in/testpress/course/adapter/CourseContentListAdapter .kt
@@ -15,8 +15,8 @@ import `in`.testpress.course.domain.asDomainContent
 import `in`.testpress.database.entities.ContentEntityLite
 import `in`.testpress.database.entities.CourseContentType
 
-class CourseContentListAdapter (COMPARATOR: DiffUtil.ItemCallback<ContentEntityLite>):
-    PagingDataAdapter<ContentEntityLite, BaseCourseContentItemViewHolder>(COMPARATOR){
+class CourseContentListAdapter :
+    PagingDataAdapter<ContentEntityLite, BaseCourseContentItemViewHolder>(COMPARATOR) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): BaseCourseContentItemViewHolder {
         val binding = RunningUpcomingListItemBinding.inflate(
@@ -46,6 +46,24 @@ class CourseContentListAdapter (COMPARATOR: DiffUtil.ItemCallback<ContentEntityL
             else -> CourseContentType.RUNNING_CONTENT.ordinal
         }
     }
+
+    companion object {
+        private val COMPARATOR =
+            object : DiffUtil.ItemCallback<ContentEntityLite>() {
+                override fun areContentsTheSame(
+                    oldItem: ContentEntityLite,
+                    newItem: ContentEntityLite
+                ): Boolean =
+                    oldItem == newItem
+
+                override fun areItemsTheSame(
+                    oldItem: ContentEntityLite,
+                    newItem: ContentEntityLite
+                ): Boolean =
+                    oldItem.id == newItem.id
+            }
+    }
+
 }
 
 open class BaseCourseContentItemViewHolder(binding: RunningUpcomingListItemBinding) :

--- a/course/src/main/java/in/testpress/course/domain/DomainContent.kt
+++ b/course/src/main/java/in/testpress/course/domain/DomainContent.kt
@@ -203,34 +203,30 @@ fun createDomainContent(content: Content): DomainContent {
     )
 }
 
-fun createDomainContent(content: ContentEntityLite): DomainContent {
+fun ContentEntityLite.asDomainContent(): DomainContent {
     return DomainContent(
-        id = content.id,
-        order = content.order,
-        chapterId = content.chapterId,
-        freePreview = content.freePreview,
-        title = content.title,
-        courseId = content.courseId,
-        examId = content.examId,
-        videoId = content.videoId,
-        attachmentId = content.attachmentId,
-        contentType = content.contentType,
-        start = content.start,
-        end = content.end,
-        treePath = content.treePath,
-        icon = content.icon,
+        id = this.id,
+        order = this.order,
+        chapterId = this.chapterId,
+        freePreview = this.freePreview,
+        title = this.title,
+        courseId = this.courseId,
+        examId = this.examId,
+        videoId = this.videoId,
+        attachmentId = this.attachmentId,
+        contentType = this.contentType,
+        start = this.start,
+        end = this.end,
+        treePath = this.treePath,
+        icon = this.icon,
         isLocked = null,
         isScheduled = null,
         active = null,
         hasEnded = null,
         isCourseAvailable = null,
         hasStarted = null,
-        type = content.type
+        type = this.type
     )
-}
-
-fun <T>T.asDomainContent(): DomainContent {
-    return createDomainContent(this as ContentEntityLite)
 }
 
 fun ContentEntity.asDomainContent(): DomainContent {

--- a/course/src/main/java/in/testpress/course/fragments/CourseContentListFragment .kt
+++ b/course/src/main/java/in/testpress/course/fragments/CourseContentListFragment .kt
@@ -85,7 +85,7 @@ class CourseContentListFragment(val type: Int): Fragment() {
     }
 
     private fun getAdapter(): CourseContentListAdapter {
-        adapter = CourseContentListAdapter (COMPARATOR)
+        adapter = CourseContentListAdapter()
         lifecycleScope.launchWhenCreated {
             viewModel.courseContentList.collect {
                 adapter.submitData(it)
@@ -165,23 +165,6 @@ class CourseContentListFragment(val type: Int): Fragment() {
                 resources.getString(`in`.testpress.R.string.testpress_content_not_available_description)
             retryButton.isVisible = true
         }
-    }
-
-    companion object {
-        private val COMPARATOR =
-            object : DiffUtil.ItemCallback<ContentEntityLite>() {
-                override fun areContentsTheSame(
-                    oldItem: ContentEntityLite,
-                    newItem: ContentEntityLite
-                ): Boolean =
-                    oldItem == newItem
-
-                override fun areItemsTheSame(
-                    oldItem: ContentEntityLite,
-                    newItem: ContentEntityLite
-                ): Boolean =
-                    oldItem.id == newItem.id
-            }
     }
 
 }

--- a/course/src/main/java/in/testpress/course/fragments/CourseContentListFragment .kt
+++ b/course/src/main/java/in/testpress/course/fragments/CourseContentListFragment .kt
@@ -28,7 +28,7 @@ class CourseContentListFragment(val type: Int): Fragment() {
 
     private var courseId: Long = -1
     private lateinit var binding: BaseContentListLayoutBinding
-    private lateinit var adapter: CourseContentListAdapter<ContentEntityLite>
+    private lateinit var adapter: CourseContentListAdapter
     private lateinit var viewModel: CourseContentListViewModel
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -84,7 +84,7 @@ class CourseContentListFragment(val type: Int): Fragment() {
         )
     }
 
-    private fun getAdapter(): CourseContentListAdapter <ContentEntityLite> {
+    private fun getAdapter(): CourseContentListAdapter {
         adapter = CourseContentListAdapter (COMPARATOR)
         lifecycleScope.launchWhenCreated {
             viewModel.courseContentList.collect {


### PR DESCRIPTION
In the past, we had separate models for running content and upcoming content, which necessitated the use of a generic type. However, now that we have a single model for both running and upcoming content, we no longer require a generic type.