### PR TITLE
refactor: Rename RunningContent to ContentEntityLite

### DIFF
--- a/core/src/main/java/in/testpress/database/Room.kt
+++ b/core/src/main/java/in/testpress/database/Room.kt
@@ -39,8 +39,8 @@ import androidx.room.TypeConverters
             CategoryEntity::class,
             DiscussionThreadAnswerEntity::class,
             ProductCategoryEntity::class,
-            RunningContentEntity::class,
-            RunningContentRemoteKeys::class,
+            ContentEntityLite::class,
+            ContentEntityLiteRemoteKey::class,
             UpcomingContentEntity::class,
             UpcomingContentRemoteKeys::class
         ], exportSchema = true)
@@ -55,8 +55,8 @@ abstract class TestpressDatabase : RoomDatabase() {
     abstract fun categoryDao(): CategoryDao
     abstract fun discussionAnswerDao(): DiscussionAnswerDao
     abstract fun productCategoryDao(): ProductCategoryDao
-    abstract fun runningContentDao(): RunningContentDao
-    abstract fun runningContentRemoteKeysDao():RunningContentRemoteKeysDao
+    abstract fun contentLiteDao(): ContentLiteDao
+    abstract fun contentLiteRemoteKeyDao():ContentLiteRemoteKeyDao
 
     companion object {
         private lateinit var INSTANCE: TestpressDatabase

--- a/core/src/main/java/in/testpress/database/dao/ContentLiteDao.kt
+++ b/core/src/main/java/in/testpress/database/dao/ContentLiteDao.kt
@@ -1,15 +1,16 @@
 package `in`.testpress.database.dao
 
 import `in`.testpress.database.BaseDao
-import `in`.testpress.database.entities.RunningContentEntity
+import `in`.testpress.database.entities.ContentEntityLite
 import androidx.paging.PagingSource
 import androidx.room.Dao
 import androidx.room.Query
 
 @Dao
-interface RunningContentDao: BaseDao<RunningContentEntity> {
+interface ContentLiteDao: BaseDao<ContentEntityLite> {
+
     @Query("SELECT * FROM runningcontententity WHERE courseId = :courseId ORDER BY start DESC")
-    fun getAll(courseId: Long): PagingSource<Int, RunningContentEntity>
+    fun getAll(courseId: Long): PagingSource<Int, ContentEntityLite>
 
     @Query("delete from runningcontententity where courseId = :courseId")
     fun deleteAll(courseId: Long)

--- a/core/src/main/java/in/testpress/database/dao/ContentLiteRemoteKeyDao.kt
+++ b/core/src/main/java/in/testpress/database/dao/ContentLiteRemoteKeyDao.kt
@@ -1,19 +1,19 @@
 package `in`.testpress.database.dao
 
-import `in`.testpress.database.entities.RunningContentRemoteKeys
+import `in`.testpress.database.entities.ContentEntityLiteRemoteKey
 import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 
 @Dao
-interface RunningContentRemoteKeysDao {
+interface ContentLiteRemoteKeyDao {
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insertAll(remoteKey: List<RunningContentRemoteKeys>)
+    suspend fun insertAll(remoteKey: List<ContentEntityLiteRemoteKey>)
 
     @Query("SELECT * FROM runningcontentremotekeys WHERE contentId = :contentId")
-    suspend fun remoteKeysContentId(contentId: Long): RunningContentRemoteKeys?
+    suspend fun remoteKeysContentId(contentId: Long): ContentEntityLiteRemoteKey?
 
     @Query("DELETE FROM runningcontentremotekeys WHERE courseId =:courseId")
     suspend fun clearRemoteKeysByCourseIdAndClassName(courseId: Long)

--- a/core/src/main/java/in/testpress/database/entities/ContentEntityLite.kt
+++ b/core/src/main/java/in/testpress/database/entities/ContentEntityLite.kt
@@ -1,0 +1,7 @@
+package `in`.testpress.database.entities
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity (tableName = "RunningContentEntity")
+data class ContentEntityLite(@PrimaryKey val id: Long) : BaseContentEntity()

--- a/core/src/main/java/in/testpress/database/entities/ContentEntityLiteRemoteKey.kt
+++ b/core/src/main/java/in/testpress/database/entities/ContentEntityLiteRemoteKey.kt
@@ -3,8 +3,8 @@ package `in`.testpress.database.entities
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 
-@Entity
-data class RunningContentRemoteKeys(
+@Entity (tableName = "RunningContentRemoteKeys")
+data class ContentEntityLiteRemoteKey(
     @PrimaryKey val contentId: Long,
     val prevKey: Int?,
     val nextKey: Int?,

--- a/core/src/main/java/in/testpress/database/entities/RunningContentEntity.kt
+++ b/core/src/main/java/in/testpress/database/entities/RunningContentEntity.kt
@@ -1,7 +1,0 @@
-package `in`.testpress.database.entities
-
-import androidx.room.Entity
-import androidx.room.PrimaryKey
-
-@Entity
-data class RunningContentEntity(@PrimaryKey val id: Long) : BaseContentEntity()

--- a/course/src/main/java/in/testpress/course/domain/DomainContent.kt
+++ b/course/src/main/java/in/testpress/course/domain/DomainContent.kt
@@ -2,7 +2,7 @@ package `in`.testpress.course.domain
 
 import `in`.testpress.core.TestpressSDKDatabase
 import `in`.testpress.database.ContentEntity
-import `in`.testpress.database.entities.RunningContentEntity
+import `in`.testpress.database.entities.ContentEntityLite
 import `in`.testpress.models.greendao.Attachment
 import `in`.testpress.models.greendao.Content
 import `in`.testpress.models.greendao.ContentDao
@@ -201,7 +201,7 @@ fun createDomainContent(content: Content): DomainContent {
     )
 }
 
-fun createDomainContent(content: RunningContentEntity): DomainContent {
+fun createDomainContent(content: ContentEntityLite): DomainContent {
     return DomainContent(
         id = content.id,
         order = content.order,
@@ -227,7 +227,7 @@ fun createDomainContent(content: RunningContentEntity): DomainContent {
 }
 
 fun <T>T.asDomainContent(): DomainContent {
-    return createDomainContent(this as RunningContentEntity)
+    return createDomainContent(this as ContentEntityLite)
 }
 
 fun ContentEntity.asDomainContent(): DomainContent {

--- a/course/src/main/java/in/testpress/course/fragments/RunningContentListFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/RunningContentListFragment.kt
@@ -20,14 +20,14 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import `in`.testpress.course.adapter.BaseContentListAdapter
-import `in`.testpress.database.entities.RunningContentEntity
+import `in`.testpress.database.entities.ContentEntityLite
 import kotlinx.coroutines.flow.collect
 
 class RunningContentListFragment : Fragment() {
 
     private var courseId: Long = -1
     private lateinit var binding: BaseContentListLayoutBinding
-    private lateinit var adapter: BaseContentListAdapter<RunningContentEntity>
+    private lateinit var adapter: BaseContentListAdapter<ContentEntityLite>
     private lateinit var viewModel: RunningContentsListViewModel
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -82,7 +82,7 @@ class RunningContentListFragment : Fragment() {
         )
     }
 
-    private fun getAdapter(): BaseContentListAdapter<RunningContentEntity> {
+    private fun getAdapter(): BaseContentListAdapter<ContentEntityLite> {
         adapter = BaseContentListAdapter(COMPARATOR)
         lifecycleScope.launchWhenCreated {
             viewModel.runningContentList.collect {
@@ -159,16 +159,16 @@ class RunningContentListFragment : Fragment() {
 
     companion object {
         private val COMPARATOR =
-            object : DiffUtil.ItemCallback<RunningContentEntity>() {
+            object : DiffUtil.ItemCallback<ContentEntityLite>() {
                 override fun areContentsTheSame(
-                    oldItem: RunningContentEntity,
-                    newItem: RunningContentEntity
+                    oldItem: ContentEntityLite,
+                    newItem: ContentEntityLite
                 ): Boolean =
                     oldItem == newItem
 
                 override fun areItemsTheSame(
-                    oldItem: RunningContentEntity,
-                    newItem: RunningContentEntity
+                    oldItem: ContentEntityLite,
+                    newItem: ContentEntityLite
                 ): Boolean =
                     oldItem.id == newItem.id
             }

--- a/course/src/main/java/in/testpress/course/network/CourseService.kt
+++ b/course/src/main/java/in/testpress/course/network/CourseService.kt
@@ -9,7 +9,7 @@ import `in`.testpress.models.greendao.Course
 import `in`.testpress.network.RetrofitCall
 import `in`.testpress.network.TestpressApiClient
 import `in`.testpress.database.entities.ProductCategoryEntity
-import `in`.testpress.database.entities.RunningContentEntity
+import `in`.testpress.database.entities.ContentEntityLite
 import `in`.testpress.v2_4.models.ApiResponse
 import `in`.testpress.v2_4.models.ContentsListResponse
 import android.content.Context
@@ -62,7 +62,7 @@ interface CourseService {
     suspend fun getRunningContents(
         @Path(value = "course_id", encoded = true) courseId: Long,
         @QueryMap queryParams: HashMap<String, Any>
-    ): ApiResponse<List<RunningContentEntity>>
+    ): ApiResponse<List<ContentEntityLite>>
 }
 
 
@@ -106,7 +106,7 @@ class CourseNetwork(context: Context) : TestpressApiClient(context, TestpressSdk
         return getCourseService().getProductsCategories(arguments)
     }
 
-    suspend fun getRunningContents(courseId: Long, arguments: HashMap<String, Any>): ApiResponse<List<RunningContentEntity>> {
+    suspend fun getRunningContents(courseId: Long, arguments: HashMap<String, Any>): ApiResponse<List<ContentEntityLite>> {
         return getCourseService().getRunningContents(courseId, arguments)
     }
 }

--- a/course/src/main/java/in/testpress/course/repository/RunningContentsRepository.kt
+++ b/course/src/main/java/in/testpress/course/repository/RunningContentsRepository.kt
@@ -18,6 +18,6 @@ class RunningContentsRepository(val context: Context, val courseId: Long = -1) {
         config = PagingConfig(pageSize = 15),
         remoteMediator = RunningContentRemoteMediator(courseNetwork,database,courseId)
     ) {
-        database.runningContentDao().getAll(courseId)
+        database.contentLiteDao().getAll(courseId)
     }.flow
 }


### PR DESCRIPTION
### Changes done
- Previously we have separate model classes for running and upcoming
- Running and upcoming are the same response so we use a common class for both
