### PR TITLE
refactor: Extract fragment initialization in CourseDetailsTabAdapter

### DIFF
--- a/course/src/main/java/in/testpress/course/ui/ChapterDetailActivity.java
+++ b/course/src/main/java/in/testpress/course/ui/ChapterDetailActivity.java
@@ -15,6 +15,7 @@ import android.widget.LinearLayout;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 
 import in.testpress.core.TestpressCallback;
@@ -256,13 +257,28 @@ public class ChapterDetailActivity extends BaseToolBarActivity {
     void loadCourseTabLayout() {
         findViewById(R.id.fragment_carousel).setVisibility(View.VISIBLE);
         findViewById(R.id.fragment_container).setVisibility(View.GONE);
-        CourseDetailsTabAdapter adapter = new CourseDetailsTabAdapter(getResources(),
-                getSupportFragmentManager(), getIntent().getExtras());
+        CourseDetailsTabAdapter adapter =
+                new CourseDetailsTabAdapter(getSupportFragmentManager(), getFragmentListWithTitle());
 
         ViewPager viewPager = (ViewPager) findViewById(R.id.viewpager);
         viewPager.setAdapter(adapter);
         TabLayout tabLayout = (TabLayout) findViewById(R.id.tab_layout);
         tabLayout.setupWithViewPager(viewPager);
+    }
+
+    private LinkedHashMap<Fragment, String> getFragmentListWithTitle() {
+        LinkedHashMap<Fragment, String> fragmentListWithTitle = new LinkedHashMap<>();
+        Bundle extras = getIntent().getExtras();
+
+        ChaptersListFragment chaptersListFragment = new ChaptersListFragment();
+        chaptersListFragment.setArguments(extras);
+        fragmentListWithTitle.put(chaptersListFragment, getString(R.string.testpress_learn));
+
+        RankListFragment rankListFragment = new RankListFragment();
+        rankListFragment.setArguments(extras);
+        fragmentListWithTitle.put(rankListFragment, getString(R.string.testpress_leaderboard));
+
+        return fragmentListWithTitle;
     }
 
     private void loadChildChapters() {

--- a/course/src/main/java/in/testpress/course/ui/CourseDetailsTabAdapter.java
+++ b/course/src/main/java/in/testpress/course/ui/CourseDetailsTabAdapter.java
@@ -1,57 +1,36 @@
 package in.testpress.course.ui;
 
-import android.content.res.Resources;
-import android.os.Bundle;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentPagerAdapter;
 
-import in.testpress.course.R;
+import java.util.LinkedHashMap;
 
 class CourseDetailsTabAdapter extends FragmentPagerAdapter {
 
-    private Resources resources;
-    private Bundle bundle;
+    private LinkedHashMap<Fragment, String> fragmentList;
 
-    CourseDetailsTabAdapter(Resources resources, FragmentManager fragmentManager, Bundle bundle) {
+    CourseDetailsTabAdapter(
+            FragmentManager fragmentManager,
+            LinkedHashMap<Fragment, String> fragmentList
+    ) {
         super(fragmentManager);
-        this.resources = resources;
-        this.bundle = bundle;
+        this.fragmentList = fragmentList;
     }
 
     @Override
     public int getCount() {
-        return 2;
+        return fragmentList.size();
     }
 
     @Override
     public Fragment getItem(int position) {
-        Fragment fragment;
-        switch (position) {
-            case 0:
-                fragment = new ChaptersListFragment();
-                break;
-            case 1:
-                fragment = new RankListFragment();
-                break;
-            default:
-                fragment = new ChaptersListFragment();
-                break;
-        }
-        fragment.setArguments(bundle);
-        return fragment;
+        return (Fragment) fragmentList.keySet().toArray()[position];
     }
 
     @Override
     public CharSequence getPageTitle(final int position) {
-        switch (position) {
-            case 0:
-                return resources.getString(R.string.testpress_learn);
-            case 1:
-                return resources.getString(R.string.testpress_leaderboard);
-            default:
-                return null;
-        }
+        return fragmentList.get(getItem(position));
     }
 
 }


### PR DESCRIPTION
### Changes done
- Fragments are currently initialized directly inside the CourseDetailsTabAdapter.
- To add more fragments, we need to modify the adapter class.
- By passing the fragment list as an argument to the adapter, we can add multiple fragments from outside the adapter.
- We removed an unused argument from the CourseDetailsTabAdapter.
