### PR TITLE
refactor: Plural strings in DateUtil

### DIFF
--- a/course/src/main/java/in/testpress/course/util/DateUtils.kt
+++ b/course/src/main/java/in/testpress/course/util/DateUtils.kt
@@ -10,6 +10,13 @@ import java.util.*
 import java.util.concurrent.TimeUnit
 
 object DateUtils {
+
+    const val YEAR = "Year"
+    const val MONTH = "month"
+    const val DAY = "day"
+    const val HOUR = "hour"
+    const val MINUTE = "minute"
+
     const val ONE_DAY_IN_MILLI_SECONDS = 1000 * 60 * 60 * 24
 
     private val CURRENT_MONTH_IN_MILLS get() = getCurrentMonthMills()
@@ -60,23 +67,23 @@ object DateUtils {
         return when {
             timeDifferenceInMills > CURRENT_YEAR_IN_MILLS -> {  // output -> in 1 year
                 val yearCount = (timeDifferenceInMills / CURRENT_YEAR_IN_MILLS).toInt()
-                resource.getQuantityString(R.plurals.years, yearCount, yearCount)
+                resource.getQuantityString(R.plurals.time_duration, yearCount, yearCount, YEAR)
             }
             timeDifferenceInMills > CURRENT_MONTH_IN_MILLS -> {  // output -> in 2 months
                 val monthCount = (timeDifferenceInMills / CURRENT_MONTH_IN_MILLS).toInt()
-                resource.getQuantityString(R.plurals.months, monthCount, monthCount)
+                resource.getQuantityString(R.plurals.time_duration, monthCount, monthCount, MONTH)
             }
             timeDifferenceInMills > DAY_IN_MILLIS -> {  // output -> in 5 days
                 val daysCount = TimeUnit.MILLISECONDS.toDays(timeDifferenceInMills).toInt()
-                resource.getQuantityString(R.plurals.days, daysCount, daysCount)
+                resource.getQuantityString(R.plurals.time_duration, daysCount, daysCount, DAY)
             }
             timeDifferenceInMills > HOUR_IN_MILLIS -> {  // output -> in 10 hours
                 val hoursCount = TimeUnit.MILLISECONDS.toHours(timeDifferenceInMills).toInt()
-                resource.getQuantityString(R.plurals.hours, hoursCount, hoursCount)
+                resource.getQuantityString(R.plurals.time_duration, hoursCount, hoursCount, HOUR)
             }
             else -> {  // output -> in 10 minutes
                 val minutesCount = TimeUnit.MILLISECONDS.toMinutes(timeDifferenceInMills).toInt()
-                resource.getQuantityString(R.plurals.minutes, minutesCount, minutesCount)
+                resource.getQuantityString(R.plurals.time_duration, minutesCount, minutesCount, MINUTE)
             }
         }
     }

--- a/course/src/main/res/values/strings.xml
+++ b/course/src/main/res/values/strings.xml
@@ -103,7 +103,7 @@
     </style>
 
     <plurals name="time_duration">
-        <item quantity="one">in 1 %s</item>
+        <item quantity="one">in %d %s</item>
         <item quantity="other">in %d %ss</item>
     </plurals>
 

--- a/course/src/main/res/values/strings.xml
+++ b/course/src/main/res/values/strings.xml
@@ -102,30 +102,9 @@
         <item name="android:textColor">@color/testpress_black</item>
     </style>
 
-
-    <plurals name="minutes">
-        <item quantity="one">in %d minute</item>
-        <item quantity="other">in %d minutes</item>
-    </plurals>
-
-    <plurals name="hours">
-        <item quantity="one">in %d hour</item>
-        <item quantity="other">in %d hours</item>
-    </plurals>
-
-    <plurals name="days">
-        <item quantity="one">in %d day</item>
-        <item quantity="other">in %d days</item>
-    </plurals>
-
-    <plurals name="months">
-        <item quantity="one">in %d month</item>
-        <item quantity="other">in %d months</item>
-    </plurals>
-
-    <plurals name="years">
-        <item quantity="one">in %d year</item>
-        <item quantity="other">in %d years</item>
+    <plurals name="time_duration">
+        <item quantity="one">in 1 %s</item>
+        <item quantity="other">in %d %ss</item>
     </plurals>
 
 </resources>


### PR DESCRIPTION
In order to simplify and generalize the plurals resource strings used for a time duration, the existing resource strings for minutes, hours, days, months, and years were refactored into a single plurals resource string with a placeholder for the time unit. The new resource string is named "time_duration" and includes two placeholders for the quantity and the time unit. This change simplifies the code and makes it easier to add new time units in the future.
