### PR TITLE
refactor: Move the DateUtil file to the Core library

### DIFF
--- a/core/src/main/java/in/testpress/util/DateUtils.kt
+++ b/core/src/main/java/in/testpress/util/DateUtils.kt
@@ -1,11 +1,11 @@
-package `in`.testpress.course.util
+package `in`.testpress.util
 
+import `in`.testpress.R
 import android.content.Context
 import android.os.Build
 import android.provider.Settings
 import java.text.SimpleDateFormat
 import android.text.format.DateUtils.*
-import `in`.testpress.course.R
 import java.util.*
 import java.util.concurrent.TimeUnit
 

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -66,4 +66,10 @@
         <item>All</item>
         <item>Commented By me</item>
     </string-array>
+
+    <plurals name="time_duration">
+        <item quantity="one">in %d %s</item>
+        <item quantity="other">in %d %ss</item>
+    </plurals>
+
 </resources>

--- a/course/src/main/java/in/testpress/course/adapter/viewholder/RunningContentItemViewHolder.kt
+++ b/course/src/main/java/in/testpress/course/adapter/viewholder/RunningContentItemViewHolder.kt
@@ -4,7 +4,7 @@ import `in`.testpress.course.adapter.BaseCourseContentItemViewHolder
 import `in`.testpress.course.databinding.RunningUpcomingListItemBinding
 import `in`.testpress.course.domain.DomainContent
 import `in`.testpress.course.ui.ContentActivity
-import `in`.testpress.course.util.DateUtils
+import `in`.testpress.util.DateUtils
 import `in`.testpress.util.ViewUtils
 
 class RunningContentItemViewHolder(val binding: RunningUpcomingListItemBinding) :

--- a/course/src/main/java/in/testpress/course/adapter/viewholder/UpcomingContentItemViewHolder.kt
+++ b/course/src/main/java/in/testpress/course/adapter/viewholder/UpcomingContentItemViewHolder.kt
@@ -4,7 +4,7 @@ import android.widget.Toast
 import `in`.testpress.course.adapter.BaseCourseContentItemViewHolder
 import `in`.testpress.course.databinding.RunningUpcomingListItemBinding
 import `in`.testpress.course.domain.DomainContent
-import `in`.testpress.course.util.DateUtils
+import `in`.testpress.util.DateUtils
 import `in`.testpress.util.ViewUtils
 
 class UpcomingContentItemViewHolder(val binding: RunningUpcomingListItemBinding) :

--- a/course/src/main/java/in/testpress/course/fragments/DownloadsFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/DownloadsFragment.kt
@@ -8,7 +8,7 @@ import `in`.testpress.course.repository.OfflineVideoRepository
 import `in`.testpress.course.repository.VideoWatchDataRepository
 import `in`.testpress.course.services.VideoDownloadService
 import `in`.testpress.course.ui.OfflineVideoListAdapter
-import `in`.testpress.course.util.DateUtils
+import `in`.testpress.util.DateUtils
 import `in`.testpress.course.viewmodels.CourseViewModel
 import `in`.testpress.course.viewmodels.OfflineVideoViewModel
 import `in`.testpress.database.TestpressDatabase
@@ -31,8 +31,6 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.facebook.shimmer.ShimmerFrameLayout
 import kotlinx.coroutines.*
-import java.util.*
-import kotlin.concurrent.schedule
 
 
 class DownloadsFragment : Fragment(), EmptyViewListener {

--- a/course/src/main/java/in/testpress/course/fragments/VideoContentFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/VideoContentFragment.kt
@@ -9,7 +9,7 @@ import `in`.testpress.course.repository.OfflineVideoRepository
 import `in`.testpress.course.services.VideoDownloadService
 import `in`.testpress.course.ui.DownloadsActivity
 import `in`.testpress.course.ui.VideoDownloadQualityChooserDialog
-import `in`.testpress.course.util.DateUtils.convertDurationStringToSeconds
+import `in`.testpress.util.DateUtils.convertDurationStringToSeconds
 import `in`.testpress.course.util.PatternEditableBuilder
 import `in`.testpress.course.viewmodels.OfflineVideoViewModel
 import `in`.testpress.models.InstituteSettings
@@ -31,11 +31,6 @@ import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import io.netopen.hotbitmapgg.library.view.RingProgressBar
-import java.text.DateFormat
-import java.text.ParseException
-import java.text.SimpleDateFormat
-import java.util.Date
-import java.util.TimeZone
 import java.util.regex.Pattern
 
 class VideoContentFragment : BaseContentDetailFragment() {

--- a/course/src/main/java/in/testpress/course/helpers/CourseLastSyncedDate.kt
+++ b/course/src/main/java/in/testpress/course/helpers/CourseLastSyncedDate.kt
@@ -1,7 +1,7 @@
 package `in`.testpress.course.helpers
 
 import `in`.testpress.core.TestpressSdk
-import `in`.testpress.course.util.DateUtils
+import `in`.testpress.util.DateUtils
 import android.content.Context
 import java.util.Date
 

--- a/course/src/main/res/values/strings.xml
+++ b/course/src/main/res/values/strings.xml
@@ -102,9 +102,4 @@
         <item name="android:textColor">@color/testpress_black</item>
     </style>
 
-    <plurals name="time_duration">
-        <item quantity="one">in %d %s</item>
-        <item quantity="other">in %d %ss</item>
-    </plurals>
-
 </resources>


### PR DESCRIPTION
- Beforehand, DateUtil was included in the course library which made it unavailable for usage in the exam library due to the lack of dependency.
- By transitioning to the core library, we can benefit from the availability of all libraries since every library relies on the core library.