### PR TITLE
fix: Add Download Option for Attachment Content

### DIFF
--- a/core/src/test/java/in/testpress/util/FileDownloaderTest.kt
+++ b/core/src/test/java/in/testpress/util/FileDownloaderTest.kt
@@ -1,0 +1,40 @@
+package `in`.testpress.util
+
+import android.app.DownloadManager
+import android.content.Context
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentCaptor
+import org.mockito.Captor
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.verify
+import org.mockito.junit.MockitoJUnitRunner
+
+@RunWith(MockitoJUnitRunner::class)
+class FileDownloaderTest {
+
+    @Mock
+    private lateinit var context: Context
+    @Mock
+    private lateinit var downloadManager: DownloadManager
+    private lateinit var fileDownloader: FileDownloader
+    @Captor
+    private lateinit var captor: ArgumentCaptor<DownloadManager.Request>
+
+    @Before
+    fun setUp() {
+        fileDownloader = FileDownloader(context)
+        `when`(context.getSystemService(Context.DOWNLOAD_SERVICE)).thenReturn(downloadManager)
+    }
+
+    @Test
+    fun `test downloadFile`() {
+        val fileUrl = "https://example.com/file.pdf"
+        val fileName = "file.pdf"
+        fileDownloader.downloadFile(fileUrl, fileName)
+        verify(downloadManager).enqueue(captor.capture())
+    }
+
+}

--- a/course/src/main/java/in/testpress/course/fragments/AttachmentContentFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/AttachmentContentFragment.kt
@@ -2,8 +2,9 @@ package `in`.testpress.course.fragments
 
 import `in`.testpress.core.TestpressSdk
 import `in`.testpress.course.R
+import `in`.testpress.course.domain.DomainAttachmentContent
+import `in`.testpress.util.FileDownloader
 import `in`.testpress.util.ViewUtils
-import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import android.view.LayoutInflater
@@ -12,6 +13,8 @@ import android.view.ViewGroup
 import android.widget.Button
 import android.widget.LinearLayout
 import android.widget.TextView
+import android.widget.Toast
+import java.io.File
 
 class AttachmentContentFragment : BaseContentDetailFragment() {
     private lateinit var attachmentContentLayout: LinearLayout
@@ -51,10 +54,33 @@ class AttachmentContentFragment : BaseContentDetailFragment() {
 
         downloadButton.setOnClickListener {
             forceReloadContent {
-                context!!.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(attachment.attachmentUrl)))
+                downloadFile(attachment)
             }
         }
         attachmentContentLayout.visibility = View.VISIBLE
         viewModel.createContentAttempt(contentId)
     }
+
+    private fun downloadFile(attachment: DomainAttachmentContent){
+        if (isDownloadUrlAvailable(attachment.attachmentUrl)){
+            val fileDownloader = FileDownloader(requireContext())
+            fileDownloader.downloadFile(
+                attachment.attachmentUrl!!,
+                "${attachment.title!!}${getFileType(attachment.attachmentUrl)}"
+            )
+            Toast.makeText(requireContext(),"Download Started...",Toast.LENGTH_SHORT).show()
+        } else {
+            Toast.makeText(requireContext(),"File not available, Please try-again later",Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    private fun isDownloadUrlAvailable(url:String?) = !url.isNullOrEmpty()
+
+    private fun getFileType(url: String): String {
+        val uri = Uri.parse(url)
+        val filename = uri.lastPathSegment ?: ""
+        val extension = File(filename).extension
+        return if (extension.isNotBlank()) ".${extension}" else ""
+    }
+
 }


### PR DESCRIPTION
- Before, we only allowed users to view attachment content, which required an internet connection.
- Some users had to use third-party apps to open attachments, but some of these apps did not have Internet permissions, so users could not open them.
- We have added a download option for attachment content so that users can download and open attachments using any third-party app.