### PR TITLE
fix: Green mark is not visible after watching the video completely

### DIFF
--- a/course/src/main/java/in/testpress/course/ui/viewholders/VideoContentListItemViewHolder.kt
+++ b/course/src/main/java/in/testpress/course/ui/viewholders/VideoContentListItemViewHolder.kt
@@ -11,6 +11,7 @@ import android.widget.FrameLayout
 import android.widget.LinearLayout
 import android.widget.ProgressBar
 import android.widget.TextView
+import androidx.core.view.isVisible
 
 class VideoContentListItemViewHolder(view: View) : BaseContentListItemViewHolder(view) {
     private val duration: TextView = view.findViewById(R.id.duration)
@@ -37,12 +38,12 @@ class VideoContentListItemViewHolder(view: View) : BaseContentListItemViewHolder
     }
 
     private fun bindVideoProgress(content: DomainContent) {
-        attemptedTickContainer.visibility = View.GONE
+        attemptedTickContainer.isVisible = content.hasAttempted()
         videoCompletionProgressContainer.visibility = View.GONE
-        when (content.videoWatchedPercentage) {
-            0, null -> {}
-            100 ->  attemptedTickContainer.visibility = View.VISIBLE
-            else -> showVideoProgress(content.videoWatchedPercentage)
+        content.videoWatchedPercentage?.let { watchedPercentage ->
+            if (watchedPercentage > 0) {
+                showVideoProgress(watchedPercentage)
+            }
         }
     }
 


### PR DESCRIPTION
- Previously, the green tick was only shown if the video watch percentage was 100%. 
- Now display the green tick based on the user's attempt count field, which indicates whether they have attempted to watch the video.