### PR TITLE
refactor: Move EmptyViewFragmentTest to core library

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -116,6 +116,7 @@ dependencies {
     kapt "androidx.room:room-compiler:$room_version"
     api "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlin_coroutine_version"
     api "org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlin_coroutine_version"
+    testImplementation "com.github.nimbl3:robolectric.shadows-supportv4:4.1-SNAPSHOT"
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-github-packages.gradle')

--- a/core/src/test/java/in/testpress/ui/EmptyViewFragmentTest.kt
+++ b/core/src/test/java/in/testpress/ui/EmptyViewFragmentTest.kt
@@ -1,7 +1,7 @@
-package `in`.testpress.course.fragments
+package `in`.testpress.ui
 
 import `in`.testpress.core.TestpressException
-import `in`.testpress.course.R
+import `in`.testpress.R
 import `in`.testpress.fragments.EmptyViewFragment
 import `in`.testpress.models.TestpressApiResponse
 import `in`.testpress.models.greendao.Content


### PR DESCRIPTION
- Refactoring EmptyViewFragmentTest to the core library as EmptyViewFragment.kt is located in the same library
