### PR TITLE
fix: Add field in InstituteSettingsModel

### DIFF
--- a/core/src/main/java/in/testpress/models/InstituteSettings.java
+++ b/core/src/main/java/in/testpress/models/InstituteSettings.java
@@ -358,8 +358,9 @@ public class InstituteSettings {
         return whiteLabeledHostUrl;
     }
 
-    public void setWhiteLabeledHostUrl(String whiteLabeledHostUrl) {
+    public InstituteSettings setWhiteLabeledHostUrl(String whiteLabeledHostUrl) {
         this.whiteLabeledHostUrl = whiteLabeledHostUrl;
+        return this;
     }
 
     public boolean isInstituteUrl(String url) {

--- a/core/src/main/java/in/testpress/models/InstituteSettings.java
+++ b/core/src/main/java/in/testpress/models/InstituteSettings.java
@@ -41,6 +41,7 @@ public class InstituteSettings {
     private String appName;
     private boolean isCustomMeetingUIEnabled;
     private Integer maxAllowedDownloadedVideos;
+    private String whiteLabeledHostUrl;
 
     public InstituteSettings(String baseUrl) {
         setBaseUrl(baseUrl);
@@ -351,5 +352,17 @@ public class InstituteSettings {
     public InstituteSettings setMaxAllowedDownloadedVideos(Integer maxAllowedDownloadedVideos){
         this.maxAllowedDownloadedVideos = maxAllowedDownloadedVideos;
         return this;
+    }
+
+    public String getWhiteLabeledHostUrl() {
+        return whiteLabeledHostUrl;
+    }
+
+    public void setWhiteLabeledHostUrl(String whiteLabeledHostUrl) {
+        this.whiteLabeledHostUrl = whiteLabeledHostUrl;
+    }
+
+    public boolean isInstituteUrl(String url) {
+        return url.contains(baseUrl) || url.contains(whiteLabeledHostUrl);
     }
 }

--- a/samples/src/main/java/in/testpress/samples/course/NavigationDrawerActivity.java
+++ b/samples/src/main/java/in/testpress/samples/course/NavigationDrawerActivity.java
@@ -56,6 +56,7 @@ public class NavigationDrawerActivity extends BaseNavigationDrawerActivity {
                     .setDisplayUserEmailOnVideo(false)
                     .setCoursesGamificationEnabled(false)
                     .setMaxAllowedDownloadedVideos(null)
+                    .setWhiteLabeledHostUrl(session.getInstituteSettings().getBaseUrl())
                     .setAppName(getString(R.string.app_name));
             TestpressSdk.setTestpressSession(this, session);
             if (position == 1) {


### PR DESCRIPTION
- Precisely Android SDK does know white labeled host URL
- In this commit, we add a white-labeled host URL field to the InstituteSetting model
- The purpose of this addition is to prevent the opening of non-institute URLs in our customized webview.