### PR TITLE
fix: Not able to Download Attachments in SDK version 30 above

### DIFF
--- a/core/src/main/java/in/testpress/util/FileDownloadBroadcastReceiver.kt
+++ b/core/src/main/java/in/testpress/util/FileDownloadBroadcastReceiver.kt
@@ -75,7 +75,7 @@ class FileDownloaderBroadcastReceiver: BroadcastReceiver() {
             context,
             0,
             intent,
-            PendingIntent.FLAG_UPDATE_CURRENT
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
         )
     }
 

--- a/core/src/main/java/in/testpress/util/PermissionsUtils.java
+++ b/core/src/main/java/in/testpress/util/PermissionsUtils.java
@@ -49,14 +49,10 @@ public class PermissionsUtils {
     }
 
     public boolean isStoragePermissionGranted(){
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && Build.VERSION.SDK_INT <= Build.VERSION_CODES.Q){
-            return ActivityCompat.checkSelfPermission(
-                    activity,
-                    Manifest.permission.WRITE_EXTERNAL_STORAGE
-            ) == PackageManager.PERMISSION_GRANTED;
-        } else {
-            return true;
-        }
+        return ActivityCompat.checkSelfPermission(
+                activity,
+                Manifest.permission.WRITE_EXTERNAL_STORAGE
+        ) == PackageManager.PERMISSION_GRANTED;
     }
 
     public void requestStoragePermissionWithSnackbar() {

--- a/core/src/main/java/in/testpress/util/PermissionsUtils.java
+++ b/core/src/main/java/in/testpress/util/PermissionsUtils.java
@@ -49,10 +49,14 @@ public class PermissionsUtils {
     }
 
     public boolean isStoragePermissionGranted(){
-        return ActivityCompat.checkSelfPermission(
-                activity,
-                Manifest.permission.WRITE_EXTERNAL_STORAGE
-        ) == PackageManager.PERMISSION_GRANTED;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && Build.VERSION.SDK_INT <= Build.VERSION_CODES.Q){
+            return ActivityCompat.checkSelfPermission(
+                    activity,
+                    Manifest.permission.WRITE_EXTERNAL_STORAGE
+            ) == PackageManager.PERMISSION_GRANTED;
+        } else {
+            return true;
+        }
     }
 
     public void requestStoragePermissionWithSnackbar() {


### PR DESCRIPTION
### Changes done
- For Android S+ (version 31) and above, it is recommended to include the FLAG_IMMUTABLE flag when creating a PendingIntent. 
- Refe - [link](https://developer.android.com/topic/security/risks/pending-intent#flag_immutable)
