### PR TITLE
refactor: Update runtime storage permission check

### DIFF
--- a/core/src/main/java/in/testpress/util/PermissionsUtils.java
+++ b/core/src/main/java/in/testpress/util/PermissionsUtils.java
@@ -49,10 +49,14 @@ public class PermissionsUtils {
     }
 
     public boolean isStoragePermissionGranted(){
-        return ActivityCompat.checkSelfPermission(
-                activity,
-                Manifest.permission.WRITE_EXTERNAL_STORAGE
-        ) == PackageManager.PERMISSION_GRANTED;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && Build.VERSION.SDK_INT <= Build.VERSION_CODES.Q){
+            return ActivityCompat.checkSelfPermission(
+                    activity,
+                    Manifest.permission.WRITE_EXTERNAL_STORAGE
+            ) == PackageManager.PERMISSION_GRANTED;
+        } else {
+            return true;
+        }
     }
 
     public void requestStoragePermissionWithSnackbar() {


### PR DESCRIPTION
### Changes done
-  We previously implemented runtime permission handling for all SDK versions.
-  However, we have now optimized it to request the runtime storage permission (WRITE_EXTERNAL_STORAGE) only for SDK versions 23 to 29 (Android Marshmallow to Android 10)
- This change ensures that the app follows the appropriate permission model based on the specific SDK version, improving compatibility and enhancing the user experience by requesting permissions only when required.
- Ref [link](https://developer.android.com/reference/android/app/DownloadManager.Request#setDestinationInExternalPublicDir(java.lang.String,%20java.lang.String))
