### PR TITLE
fix: Attachment not download when file name contain illegal characters

### DIFF
--- a/core/src/main/java/in/testpress/util/FileDownloader.kt
+++ b/core/src/main/java/in/testpress/util/FileDownloader.kt
@@ -9,7 +9,7 @@ import androidx.core.content.getSystemService
 class FileDownloader(private val context: Context) {
 
     fun downloadFile(fileUrl: String, fileName: String) {
-        val request = getDownloadManagerRequest(fileUrl,fileName)
+        val request = getDownloadManagerRequest(fileUrl,fileName.sanitizeFileName())
         val downloadManager = context.getSystemService<DownloadManager>()
         downloadManager?.enqueue(request) ?: return
         ViewUtils.toast(context,"Download Started...")

--- a/core/src/main/java/in/testpress/util/StringUtils.kt
+++ b/core/src/main/java/in/testpress/util/StringUtils.kt
@@ -19,6 +19,6 @@ fun String.isEmailValid(): Boolean {
  * @return The sanitized file name.
  */
 fun String.sanitizeFileName(): String {
-    val illegalCharactersRegex = Regex("[<>:|/?*]")
+    val illegalCharactersRegex = Regex("[/`?*<>|\":\\\\]")
     return this.replace(illegalCharactersRegex, "_")
 }

--- a/core/src/main/java/in/testpress/util/StringUtils.kt
+++ b/core/src/main/java/in/testpress/util/StringUtils.kt
@@ -12,3 +12,13 @@ object StringUtils{
 fun String.isEmailValid(): Boolean {
     return !TextUtils.isEmpty(this) && android.util.Patterns.EMAIL_ADDRESS.matcher(this).matches()
 }
+
+/**
+ * Sanitizes the file name by replacing illegal characters with an underscore.
+ *
+ * @return The sanitized file name.
+ */
+fun String.sanitizeFileName(): String {
+    val illegalCharactersRegex = Regex("[<>:|/?*]")
+    return this.replace(illegalCharactersRegex, "_")
+}


### PR DESCRIPTION
- We are not able to create a file with the following characters (<, >, :, ", /, \\, |, ?, *) because these are the reserved characters by OS
- In our case, Some Attachment titles may contain these characters for we are not able to download 
- In this commit replacing these characters with underscore