### PR TITLE
fix: App crash while opening product detail page

### DIFF
--- a/store/src/main/res/layout/testpress_product_details_layout.xml
+++ b/store/src/main/res/layout/testpress_product_details_layout.xml
@@ -5,6 +5,8 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
+    <include layout="@layout/testpress_toolbar" />
+
     <ProgressBar
         android:layout_width="45dp"
         android:layout_height="45dp"
@@ -17,6 +19,7 @@
     <androidx.coordinatorlayout.widget.CoordinatorLayout
         android:visibility="gone"
         android:id="@+id/main_content"
+        android:layout_below="@id/appbar"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 


### PR DESCRIPTION
 - We forgot to add the toolbar layout to the XML file for the Product detail view, For an activity that extends BaseToolBarActivity to work correctly, the corresponding XML file must include a toolbar layout.
 - If the toolbar view is missing, it will cause an exception because it is initialized in BaseToolBarActivity.
 - so included the toolbar layout in the XML layout for the Product detail view, to fix the same.