### PR TITLE
fix: Add support to open ReviewQuestionPage Without Exam object

### DIFF
--- a/exam/src/main/java/in/testpress/exam/ui/ReviewQuestionsActivity.java
+++ b/exam/src/main/java/in/testpress/exam/ui/ReviewQuestionsActivity.java
@@ -151,11 +151,7 @@ public class ReviewQuestionsActivity extends BaseToolBarActivity  {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.testpress_activity_review_question);
         parseArguments();
-        if (exam == null){
-            setTitle("Solutions");
-        } else {
-            setTitle(exam.getTitle() + " Solutions");
-        }
+        setExamTitle();
         apiClient = new TestpressExamApiClient(this);
         bindViews();
         initializeQuestionsListSidebar();
@@ -174,6 +170,14 @@ public class ReviewQuestionsActivity extends BaseToolBarActivity  {
         InstituteSettings instituteSettings = TestpressSdk.getTestpressSession(this).getInstituteSettings();
         if (instituteSettings.isGrowthHackEnabled()) {
             customiseToolbar();
+        }
+    }
+
+    private void setExamTitle() {
+        if (exam == null){
+            setTitle("Solutions");
+        } else {
+            setTitle(exam.getTitle() + " Solutions");
         }
     }
 
@@ -201,11 +205,7 @@ public class ReviewQuestionsActivity extends BaseToolBarActivity  {
     }
 
     private void initializeQuestionPager() {
-        if (exam == null){
-            pagerAdapter = new ReviewQuestionsPagerAdapter(getSupportFragmentManager(), reviewItems, -1L);
-        } else {
-            pagerAdapter = new ReviewQuestionsPagerAdapter(getSupportFragmentManager(), reviewItems, exam.getId());
-        }
+        pagerAdapter = getReviewQuestionsPagerAdapter();
         pager.setAdapter(pagerAdapter);
         slidingPaneLayout.setPanelSlideListener(new SlidingPaneLayout.PanelSlideListener() {
             @Override
@@ -237,6 +237,15 @@ public class ReviewQuestionsActivity extends BaseToolBarActivity  {
             public void onPageScrollStateChanged(int state) {
             }
         });
+    }
+
+    private ReviewQuestionsPagerAdapter getReviewQuestionsPagerAdapter() {
+        if (exam == null){
+            // If Exam null we set Exam ID As -1
+            return new ReviewQuestionsPagerAdapter(getSupportFragmentManager(), reviewItems, -1L);
+        } else {
+            return new ReviewQuestionsPagerAdapter(getSupportFragmentManager(), reviewItems, exam.getId());
+        }
     }
 
 

--- a/exam/src/main/java/in/testpress/exam/ui/ReviewQuestionsActivity.java
+++ b/exam/src/main/java/in/testpress/exam/ui/ReviewQuestionsActivity.java
@@ -140,22 +140,12 @@ public class ReviewQuestionsActivity extends BaseToolBarActivity  {
         return intent;
     }
 
-    public static Intent createIntent(Activity activity, Attempt attempt) {
-        Intent intent = new Intent(activity, ReviewQuestionsActivity.class);
-        intent.putExtra(ReviewQuestionsActivity.PARAM_ATTEMPT, attempt);
-        return intent;
-    }
-
     @Override
     public void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.testpress_activity_review_question);
         parseArguments();
-        if (exam == null){
-            setTitle("Solutions");
-        } else {
-            setTitle(exam.getTitle() + " Solutions");
-        }
+        setTitle(exam.getTitle() + " Solutions");
         apiClient = new TestpressExamApiClient(this);
         bindViews();
         initializeQuestionsListSidebar();
@@ -201,11 +191,7 @@ public class ReviewQuestionsActivity extends BaseToolBarActivity  {
     }
 
     private void initializeQuestionPager() {
-        if (exam == null){
-            pagerAdapter = new ReviewQuestionsPagerAdapter(getSupportFragmentManager(), reviewItems, -1L);
-        } else {
-            pagerAdapter = new ReviewQuestionsPagerAdapter(getSupportFragmentManager(), reviewItems, exam.getId());
-        }
+        pagerAdapter = new ReviewQuestionsPagerAdapter(getSupportFragmentManager(), reviewItems, exam.getId());
         pager.setAdapter(pagerAdapter);
         slidingPaneLayout.setPanelSlideListener(new SlidingPaneLayout.PanelSlideListener() {
             @Override
@@ -261,6 +247,7 @@ public class ReviewQuestionsActivity extends BaseToolBarActivity  {
 
     private void parseArguments() {
         exam = getIntent().getParcelableExtra(PARAM_EXAM);
+        Assert.assertNotNull("PARAM_EXAM must not be null", exam);
         attempt = getIntent().getParcelableExtra(PARAM_ATTEMPT);
         Assert.assertNotNull("PARAM_ATTEMPT must not be null", attempt);
     }
@@ -340,7 +327,6 @@ public class ReviewQuestionsActivity extends BaseToolBarActivity  {
     }
 
     void setUpLanguageOptionsMenu() {
-        if (exam == null) return;
         final ArrayList<Language> languages = new ArrayList<>(exam.getRawLanguages());
         if (languages.size() > 1 && optionsMenu != null && !reviewItems.isEmpty()) {
             getMenuInflater().inflate(R.menu.testpress_select_language_menu, optionsMenu);
@@ -521,15 +507,12 @@ public class ReviewQuestionsActivity extends BaseToolBarActivity  {
                 uniqueLanguages.put(language.getCode(), language);
             }
         }
-        if (exam != null){
-            exam.setLanguages(new ArrayList<>(uniqueLanguages.values()));
-        }
+        exam.setLanguages(new ArrayList<>(uniqueLanguages.values()));
         setUpLanguageOptionsMenu();
         onSpinnerItemSelected(0);
     }
 
     void fetchLanguages() {
-        if (exam == null) return;
         progressBar.setVisibility(View.VISIBLE);
         languageApiRequest = apiClient.getLanguages(exam.getSlug())
                 .enqueue(new TestpressCallback<TestpressApiResponse<Language>>() {
@@ -743,13 +726,7 @@ public class ReviewQuestionsActivity extends BaseToolBarActivity  {
     }
 
     private void initSelectedLanguage(ArrayList<Language> languages) {
-        String selectedLanguageCode;
-        if (exam == null){
-            selectedLanguageCode = null;
-        } else {
-            selectedLanguageCode = exam.getSelectedLanguage();
-        }
-
+        String selectedLanguageCode = exam.getSelectedLanguage();
         if (selectedLanguageCode == null || selectedLanguageCode.isEmpty()) {
             selectedLanguageCode = reviewItems.get(0).getQuestion().getLanguage();
         }

--- a/exam/src/main/java/in/testpress/exam/ui/ReviewQuestionsActivity.java
+++ b/exam/src/main/java/in/testpress/exam/ui/ReviewQuestionsActivity.java
@@ -22,6 +22,7 @@ import android.widget.ProgressBar;
 import android.widget.Spinner;
 import android.widget.TextView;
 
+import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
 import androidx.core.content.ContextCompat;
 import androidx.recyclerview.widget.GridLayoutManager;
@@ -752,13 +753,7 @@ public class ReviewQuestionsActivity extends BaseToolBarActivity  {
     }
 
     private void initSelectedLanguage(ArrayList<Language> languages) {
-        String selectedLanguageCode;
-        if (exam == null){
-            selectedLanguageCode = null;
-        } else {
-            selectedLanguageCode = exam.getSelectedLanguage();
-        }
-
+        String selectedLanguageCode = getSelectedLanguageCode();
         if (selectedLanguageCode == null || selectedLanguageCode.isEmpty()) {
             selectedLanguageCode = reviewItems.get(0).getQuestion().getLanguage();
         }
@@ -772,6 +767,15 @@ public class ReviewQuestionsActivity extends BaseToolBarActivity  {
         }
         languageSpinner.setSelection(selectedPosition);
         selectLanguageMenu.setVisible(true);
+    }
+
+    @Nullable
+    private String getSelectedLanguageCode() {
+        if (exam == null){
+            return null;
+        } else {
+            return exam.getSelectedLanguage();
+        }
     }
 
     protected void setEmptyText(final int title, final int description) {

--- a/exam/src/main/java/in/testpress/exam/ui/ReviewQuestionsFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/ReviewQuestionsFragment.java
@@ -373,12 +373,14 @@ public class ReviewQuestionsFragment extends Fragment {
                 "</div>";
 
         // Add Report button
-        html += "<div class='report-button' style='float:right;' onclick='onClickReportButton()'>" +
-                "<svg xmlns=\"http://www.w3.org/2000/svg\" fill=\"none\" viewBox=\"0 0 24 24\" stroke-width=\"1.5\" stroke=\"currentColor\" style=\"width:1rem;height:1rem;vertical-align: sub;\">\n" +
-                "  <path stroke-linecap=\"round\" stroke-linejoin=\"round\" d=\"M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z\" />\n" +
-                "</svg>\n" +
-                "Report Question" +
-                "</div>";
+        if (examId != -1L){
+            html += "<div class='report-button' style='float:right;' onclick='onClickReportButton()'>" +
+                    "<svg xmlns=\"http://www.w3.org/2000/svg\" fill=\"none\" viewBox=\"0 0 24 24\" stroke-width=\"1.5\" stroke=\"currentColor\" style=\"width:1rem;height:1rem;vertical-align: sub;\">\n" +
+                    "  <path stroke-linecap=\"round\" stroke-linejoin=\"round\" d=\"M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z\" />\n" +
+                    "</svg>\n" +
+                    "Report Question" +
+                    "</div>";
+        }
 
 
         // Add direction/passage

--- a/exam/src/main/java/in/testpress/exam/ui/ReviewQuestionsFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/ReviewQuestionsFragment.java
@@ -372,8 +372,8 @@ public class ReviewQuestionsFragment extends Fragment {
                 reviewItem.getIndex() +
                 "</div>";
 
-        // Add Report button
         if (examId != -1L){
+            // Add Report button
             html += "<div class='report-button' style='float:right;' onclick='onClickReportButton()'>" +
                     "<svg xmlns=\"http://www.w3.org/2000/svg\" fill=\"none\" viewBox=\"0 0 24 24\" stroke-width=\"1.5\" stroke=\"currentColor\" style=\"width:1rem;height:1rem;vertical-align: sub;\">\n" +
                     "  <path stroke-linecap=\"round\" stroke-linejoin=\"round\" d=\"M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z\" />\n" +

--- a/exam/src/main/java/in/testpress/exam/ui/ReviewQuestionsFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/ReviewQuestionsFragment.java
@@ -373,14 +373,12 @@ public class ReviewQuestionsFragment extends Fragment {
                 "</div>";
 
         // Add Report button
-        if (examId != -1L){
-            html += "<div class='report-button' style='float:right;' onclick='onClickReportButton()'>" +
-                    "<svg xmlns=\"http://www.w3.org/2000/svg\" fill=\"none\" viewBox=\"0 0 24 24\" stroke-width=\"1.5\" stroke=\"currentColor\" style=\"width:1rem;height:1rem;vertical-align: sub;\">\n" +
-                    "  <path stroke-linecap=\"round\" stroke-linejoin=\"round\" d=\"M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z\" />\n" +
-                    "</svg>\n" +
-                    "Report Question" +
-                    "</div>";
-        }
+        html += "<div class='report-button' style='float:right;' onclick='onClickReportButton()'>" +
+                "<svg xmlns=\"http://www.w3.org/2000/svg\" fill=\"none\" viewBox=\"0 0 24 24\" stroke-width=\"1.5\" stroke=\"currentColor\" style=\"width:1rem;height:1rem;vertical-align: sub;\">\n" +
+                "  <path stroke-linecap=\"round\" stroke-linejoin=\"round\" d=\"M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z\" />\n" +
+                "</svg>\n" +
+                "Report Question" +
+                "</div>";
 
 
         // Add direction/passage

--- a/exam/src/main/java/in/testpress/exam/ui/ReviewStatsFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/ReviewStatsFragment.java
@@ -350,7 +350,6 @@ public class ReviewStatsFragment extends BaseFragment {
             reviewQuestionsButton.setOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {
-                    // TODO: 05-06-2023
                     requireActivity().startActivity(
                             ReviewQuestionsActivity.createIntent(getActivity(), attempt)
                     );

--- a/exam/src/main/java/in/testpress/exam/ui/ReviewStatsFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/ReviewStatsFragment.java
@@ -138,7 +138,7 @@ public class ReviewStatsFragment extends BaseFragment {
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        exam = getArguments().getParcelable(PARAM_EXAM);
+        //exam = getArguments().getParcelable(PARAM_EXAM);
         instituteSettings = getInstituteSettings();
         attempt = getArguments().getParcelable(PARAM_ATTEMPT);
         CourseAttempt courseAttempt = getArguments().getParcelable(PARAM_COURSE_ATTEMPT);

--- a/exam/src/main/java/in/testpress/exam/ui/ReviewStatsFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/ReviewStatsFragment.java
@@ -346,6 +346,17 @@ public class ReviewStatsFragment extends BaseFragment {
             reviewQuestionsButton.setVisibility(View.VISIBLE);
         } else if (isExamNotNull() && !exam.showAnalytics()){
             reviewQuestionsButton.setVisibility(View.GONE);
+        } else {
+            reviewQuestionsButton.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    // TODO: 05-06-2023
+                    requireActivity().startActivity(
+                            ReviewQuestionsActivity.createIntent(getActivity(), attempt)
+                    );
+                }
+            });
+            reviewQuestionsButton.setVisibility(View.VISIBLE);
         }
     }
 

--- a/exam/src/main/java/in/testpress/exam/ui/ReviewStatsFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/ReviewStatsFragment.java
@@ -138,7 +138,7 @@ public class ReviewStatsFragment extends BaseFragment {
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        //exam = getArguments().getParcelable(PARAM_EXAM);
+        exam = getArguments().getParcelable(PARAM_EXAM);
         instituteSettings = getInstituteSettings();
         attempt = getArguments().getParcelable(PARAM_ATTEMPT);
         CourseAttempt courseAttempt = getArguments().getParcelable(PARAM_COURSE_ATTEMPT);


### PR DESCRIPTION
- We are adding a new feature called custom test generation int this feature users can able attend exams without an exam object
- We have modified the review questions page to be accessible even without the exam object, ensuring that we have properly handled the exam object in all relevant sections.
