### PR TITLE
fix: Add static method to TestpressException

### DIFF
--- a/core/src/main/java/in/testpress/core/TestpressException.java
+++ b/core/src/main/java/in/testpress/core/TestpressException.java
@@ -20,6 +20,13 @@ public class TestpressException extends RuntimeException {
         return new TestpressException(message, response, Kind.HTTP, null);
     }
 
+    public static TestpressException httpError(int errorCode, String errorMessage) {
+        String message = errorCode + " " + errorMessage;
+        TestpressException exception = new TestpressException(message, null, Kind.HTTP, null);
+        exception.setStatusCode(errorCode);
+        return exception;
+    }
+
     public static TestpressException networkError(IOException exception) {
         return new TestpressException(exception.getMessage(), null, Kind.NETWORK, exception);
     }
@@ -73,6 +80,10 @@ public class TestpressException extends RuntimeException {
 
     public void setMessage(String message) {
         this.message = message;
+    }
+
+    public void setStatusCode(int statusCode) {
+        this.statusCode = statusCode;
     }
 
     /**

--- a/core/src/main/java/in/testpress/fragments/EmptyViewFragment.kt
+++ b/core/src/main/java/in/testpress/fragments/EmptyViewFragment.kt
@@ -14,6 +14,7 @@ import android.widget.Button
 import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.TextView
+import org.json.JSONException
 import org.json.JSONObject
 
 class EmptyViewFragment : Fragment() {
@@ -74,10 +75,17 @@ class EmptyViewFragment : Fragment() {
     }
 
     private fun handleForbidden(exception: TestpressException) {
-        val errorResponse: JSONObject? = JSONObject(exception.response.errorBody()?.string()!!)
-        if (errorResponse != null && errorResponse.has("detail")) {
+        val errorResponse = exception.response?.errorBody()?.string()?.let {
+            try {
+                JSONObject(it)
+            } catch (e: JSONException) {
+                null
+            }
+        }
+
+        if (errorResponse?.has("detail") == true) {
             showCustomPermissionDeniedMessage(errorResponse.getString("detail"))
-        }else{
+        } else {
             showPermissionDeniedMessage()
         }
     }

--- a/core/src/test/java/in/testpress/ui/EmptyViewFragmentTest.kt
+++ b/core/src/test/java/in/testpress/ui/EmptyViewFragmentTest.kt
@@ -54,8 +54,18 @@ class EmptyViewFragmentTest {
     }
 
     @Test
-    fun testForbiddenError() {
+    fun testForbiddenErrorWithResponse() {
         val exception = TestpressException.httpError(buildErrorResponse(403))
+        fragment.displayError(exception)
+
+        Assert.assertEquals(View.VISIBLE, fragment.emptyContainer.visibility)
+        Assert.assertEquals(context.getString(R.string.permission_denied), fragment.emptyTitleView.text)
+        Assert.assertEquals(context.getString(R.string.testpress_no_permission), fragment.emptyDescView.text)
+    }
+
+    @Test
+    fun testForbiddenErrorWithErrorCodeAndMessage() {
+        val exception = TestpressException.httpError(403,"Forbidden")
         fragment.displayError(exception)
 
         Assert.assertEquals(View.VISIBLE, fragment.emptyContainer.visibility)


### PR DESCRIPTION
### Changes done
- This commit adds a new static method called httpError() in TestpressException class. This method allows creating a TestpressException object specifically for HTTP errors with a custom error code and error message.
- This new method enhances the flexibility of handling HTTP errors in the Testpress library.
