### PR TITLE
fix: Add support to open Download activity

### DIFF
--- a/core/src/main/java/in/testpress/util/FileDownloadBroadcastReceiver.kt
+++ b/core/src/main/java/in/testpress/util/FileDownloadBroadcastReceiver.kt
@@ -10,7 +10,6 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Build
-import android.util.Log
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.content.FileProvider

--- a/core/src/main/java/in/testpress/util/FileDownloadBroadcastReceiver.kt
+++ b/core/src/main/java/in/testpress/util/FileDownloadBroadcastReceiver.kt
@@ -61,15 +61,11 @@ class FileDownloaderBroadcastReceiver: BroadcastReceiver() {
     }
 
     private fun createPendingIntent(localFilePath: String): PendingIntent {
-        val intent = Intent(Intent.ACTION_VIEW)
-        val pdfFile  = File(Uri.parse(localFilePath).path.toString())
-        val uri = FileProvider.getUriForFile(
-            context,
-            context.packageName + ".provider",
-            pdfFile
-        )
-        intent.setDataAndType(uri, "application/pdf")
-        intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        val intent = if (localFilePath.isPDF()) {
+            createIntentToOpenPDF(localFilePath)
+        } else {
+            createIntentToOpenDownloadActivity()
+        }
 
         return PendingIntent.getActivity(
             context,
@@ -77,6 +73,23 @@ class FileDownloaderBroadcastReceiver: BroadcastReceiver() {
             intent,
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
         )
+    }
+
+    private fun createIntentToOpenPDF(localFilePath: String): Intent {
+        val pdfFile = File(Uri.parse(localFilePath).path.toString())
+        val uri = FileProvider.getUriForFile(
+            context,
+            context.packageName + ".provider",
+            pdfFile
+        )
+        return Intent(Intent.ACTION_VIEW)
+            .setDataAndType(uri, "application/pdf")
+            .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+    }
+
+    private fun createIntentToOpenDownloadActivity(): Intent {
+        return Intent(DownloadManager.ACTION_VIEW_DOWNLOADS)
+            .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
     }
 
     private fun showCompletedNotification(pdfFilename: String, pendingIntent: PendingIntent) {

--- a/core/src/main/java/in/testpress/util/StringUtils.kt
+++ b/core/src/main/java/in/testpress/util/StringUtils.kt
@@ -27,6 +27,10 @@ internal fun String?.isValidUrl():Boolean{
     return this != null && android.util.Patterns.WEB_URL.matcher(this).matches()
 }
 
-internal fun String?.isPDF():Boolean {
-    return this != null && this.contains(".pdf")
+fun String.isPDF():Boolean {
+    return this.contains(".pdf")
+}
+
+fun String.isImageFile():Boolean {
+    return this.contains(".pgn") || this.contains(".jpg") || this.contains(".gif")
 }

--- a/core/src/main/java/in/testpress/util/StringUtils.kt
+++ b/core/src/main/java/in/testpress/util/StringUtils.kt
@@ -26,3 +26,7 @@ fun String.sanitizeFileName(): String {
 internal fun String?.isValidUrl():Boolean{
     return this != null && android.util.Patterns.WEB_URL.matcher(this).matches()
 }
+
+internal fun String?.isPDF():Boolean {
+    return this != null && this.contains(".pdf")
+}

--- a/core/src/main/java/in/testpress/util/StringUtils.kt
+++ b/core/src/main/java/in/testpress/util/StringUtils.kt
@@ -1,6 +1,7 @@
 package `in`.testpress.util
 
 import android.text.TextUtils
+import android.webkit.MimeTypeMap
 
 object StringUtils{
     @JvmStatic
@@ -27,10 +28,8 @@ internal fun String?.isValidUrl():Boolean{
     return this != null && android.util.Patterns.WEB_URL.matcher(this).matches()
 }
 
-fun String.isPDF():Boolean {
-    return this.contains(".pdf")
-}
+fun String.isPDF():Boolean = this.getFileType() == "pdf"
 
-fun String.isImageFile():Boolean {
-    return this.contains(".png") || this.contains(".jpg") || this.contains(".gif")
-}
+fun String.isImageFile(): Boolean = this.getFileType() == "png" || this.getFileType() == "jpg" || this.getFileType() == "gif"
+
+fun String.getFileType(): String = MimeTypeMap.getFileExtensionFromUrl(this)

--- a/core/src/main/java/in/testpress/util/StringUtils.kt
+++ b/core/src/main/java/in/testpress/util/StringUtils.kt
@@ -32,5 +32,5 @@ fun String.isPDF():Boolean {
 }
 
 fun String.isImageFile():Boolean {
-    return this.contains(".pgn") || this.contains(".jpg") || this.contains(".gif")
+    return this.contains(".png") || this.contains(".jpg") || this.contains(".gif")
 }


### PR DESCRIPTION
- In this commit #512, we implemented download support for attachments, and once the download is complete, a notification is displayed. We also added a pending intent to that notification. However, we encountered an issue where the pending intent only works for opening PDF files, while other file types cannot be opened.
- To address this problem, we made a commit that handles the differentiation between PDF files, image files, and other file types. If the downloaded file is a PDF, we open the PDF activity. If the downloaded file is an image, we open the image viewer activity. Otherwise, if it is any other file type, we open the download activity. This allows for the appropriate handling of different file types in the application.


