### PR TITLE
fix: Auto resolution option not working in video

### DIFF
--- a/course/src/main/java/in/testpress/course/util/ExoPlayerUtil.java
+++ b/course/src/main/java/in/testpress/course/util/ExoPlayerUtil.java
@@ -398,7 +398,10 @@ public class ExoPlayerUtil implements VideoTimeRangeListener, DrmSessionManagerP
                     MappingTrackSelector.MappedTrackInfo mappedTrackInfo = trackSelector.getCurrentMappedTrackInfo();
                     int rendererIndex = getRendererIndex(C.TRACK_TYPE_VIDEO, mappedTrackInfo);
                     DefaultTrackSelector.ParametersBuilder parametersBuilder = trackSelector.buildUponParameters();
-                    if (!trackSelectionDialog.getOverrides().isEmpty()) {
+                    if (trackSelectionDialog.getOverrides().isEmpty()) {
+                        parametersBuilder.clearSelectionOverrides(rendererIndex);
+                        trackSelector.setParameters(parametersBuilder.build());
+                    } else {
                         parametersBuilder.clearSelectionOverrides(rendererIndex)
                                 .setSelectionOverride(rendererIndex, mappedTrackInfo.getTrackGroups(rendererIndex), trackSelectionDialog.getOverrides().get(0));
                         trackSelector.setParameters(parametersBuilder.build());
@@ -798,6 +801,8 @@ public class ExoPlayerUtil implements VideoTimeRangeListener, DrmSessionManagerP
             displayError(R.string.license_error);
         }
     }
+
+    DefaultTrackSelector.SelectionOverride override;
 
     private void playLowBitrateTrack() {
         MappingTrackSelector.MappedTrackInfo mappedTrackInfo = trackSelector.getCurrentMappedTrackInfo();

--- a/course/src/main/java/in/testpress/course/util/ExoPlayerUtil.java
+++ b/course/src/main/java/in/testpress/course/util/ExoPlayerUtil.java
@@ -802,8 +802,6 @@ public class ExoPlayerUtil implements VideoTimeRangeListener, DrmSessionManagerP
         }
     }
 
-    DefaultTrackSelector.SelectionOverride override;
-
     private void playLowBitrateTrack() {
         MappingTrackSelector.MappedTrackInfo mappedTrackInfo = trackSelector.getCurrentMappedTrackInfo();
         if (mappedTrackInfo != null) {


### PR DESCRIPTION
- Each time the user changes the resolution, we reset the previously chosen track and assign the newly selected track.
- But we are not doing this process when the user selects the Auto resolution option.
- In this commit, we clear the previously chosen track when the user selects Auto resolution.
