### PR TITLE
fix: update exoplayer dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ ext {
     minSdkVersionForUITest = 21
     buildToolsVersion = '30.0.2'
     supportLib = '27.1.1'
-    exoPlayer = '2.16.1'
+    exoPlayer = '2.17.1'
     powermock = '2.0.5'
     paging_version = "3.1.1"
     constraint_layout_version = '2.0.4'

--- a/course/src/main/java/in/testpress/course/util/ExoPlayerUtil.java
+++ b/course/src/main/java/in/testpress/course/util/ExoPlayerUtil.java
@@ -709,12 +709,12 @@ public class ExoPlayerUtil implements VideoTimeRangeListener, DrmSessionManagerP
         return new DefaultDrmSessionManager.Builder().build(new CustomHttpDrmMediaCallback(activity, content.getId()));
     }
 
-    private class PlayerEventListener implements Player.EventListener, DRMLicenseFetchCallback {
+    private class PlayerEventListener implements Player.Listener, DRMLicenseFetchCallback {
 
         @Override
         public void onIsPlayingChanged(boolean isPlaying) {
             updateVideoAttempt();
-            Player.EventListener.super.onIsPlayingChanged(isPlaying);
+            Player.Listener.super.onIsPlayingChanged(isPlaying);
         }
 
         @Override


### PR DESCRIPTION
### Changes done
-  Update exoplayer library version to 2.17.1
- Updated Deprecated symbols EventListener -> Listener

