### PR TITLE
fix: Razorpay payment success/failure message not shown

### DIFF
--- a/store/src/main/java/in/testpress/store/razorpay/RazorpayPaymentGateway.kt
+++ b/store/src/main/java/in/testpress/store/razorpay/RazorpayPaymentGateway.kt
@@ -49,12 +49,4 @@ class RazorpayPaymentGateway(order: Order, context: Activity): PaymentGateway(or
         payloadHelper.sendSmsHash = true
         return payloadHelper.getJson()
     }
-
-    override fun onPaymentSuccess(razorpayPaymentId: String?) {
-        paymentGatewayListener?.onPaymentSuccess()
-    }
-
-    override fun onPaymentError(errorCode: Int, response: String?) {
-        paymentGatewayListener?.onPaymentError(response)
-    }
 }

--- a/store/src/main/java/in/testpress/store/razorpay/RazorpayPaymentGateway.kt
+++ b/store/src/main/java/in/testpress/store/razorpay/RazorpayPaymentGateway.kt
@@ -10,7 +10,7 @@ import org.json.JSONObject
 import `in`.testpress.store.network.StoreApiClient
 
 
-class RazorpayPaymentGateway(order: Order, context: Activity): PaymentGateway(order, context), PaymentResultListener {
+class RazorpayPaymentGateway(order: Order, context: Activity): PaymentGateway(order, context) {
     val instituteSettings: InstituteSettings = TestpressSdk.getTestpressSession(context)!!.instituteSettings
     val redirectURL = instituteSettings.baseUrl + StoreApiClient.RAZORPAY_PAYMENT_RESPONSE_PATH
 

--- a/store/src/main/java/in/testpress/store/ui/OrderConfirmActivity.java
+++ b/store/src/main/java/in/testpress/store/ui/OrderConfirmActivity.java
@@ -352,7 +352,7 @@ public class OrderConfirmActivity extends BaseToolBarActivity implements Payment
         refreshOrderStatus();
     }
 
-    private void showPaymentFailedScreen() {
+    void showPaymentFailedScreen() {
         progressBar.setVisibility(View.GONE);
         Intent intent = new Intent(this, PaymentFailureActivity.class);
         startActivityForResult(intent, STORE_REQUEST_CODE);


### PR DESCRIPTION
### Changes done
- After successful payment, the in-app message was not being shown in razorpay payment.
- The reason was that according to razorpay docs, the success/ failure event handlers 
should be present inside the Activity, not the Fragment.
- Fixed by moving the methods to the activity.

### Reason for the changes
- 
- 

Fixes # .
