### PR TITLE
fix: Add validation for WebView Http Error

### DIFF
--- a/core/src/main/java/in/testpress/fragments/WebViewFragment.kt
+++ b/core/src/main/java/in/testpress/fragments/WebViewFragment.kt
@@ -158,7 +158,7 @@ class WebViewFragment(
         emptyViewFragment.displayError(exception)
     }
 
-    private fun hideEmptyViewShowWebView() {
+    fun hideEmptyViewShowWebView() {
         layout.emptyViewContainer.isVisible = false
         layout.webView.isVisible = true
     }

--- a/core/src/main/java/in/testpress/util/webview/CustomWebViewClient.kt
+++ b/core/src/main/java/in/testpress/util/webview/CustomWebViewClient.kt
@@ -53,9 +53,8 @@ class CustomWebViewClient(val fragment: WebViewFragment) : WebViewClient() {
         request: WebResourceRequest?,
         errorResponse: WebResourceResponse?
     ) {
-        // Verify if the error is related to the current URL being loaded in the WebView
-        // This is important to display errors only for the specific URL being loaded in the WebView.
-        // Since a WebView might load multiple types of URLs simultaneously, such as static and image URLs.
+        // We are not showing error for other URLs like static and image URLs.
+        // Because WebView can load multiple URLs simultaneously like browser.
         val requestUrl = request?.url.toString()
         if (currentLoadingUrl == requestUrl) {
             val statusCode = errorResponse?.statusCode ?: -1


### PR DESCRIPTION
- We are currently displaying errors for each HTTP error that occurs. Due to the nature of using a WebView, various URLs are loaded, including static image URLs. If any of these static URLs encounter an error, we will also present the error within the WebView.
- However, in this particular commit, we are not addressing the issue of displaying errors for other URL failures such as those related to static image URLs.