### PR TITLE
fix: App crash when app name contains contain non-ASCII characters

### DIFF
--- a/core/src/main/java/in/testpress/network/TestpressApiClient.java
+++ b/core/src/main/java/in/testpress/network/TestpressApiClient.java
@@ -116,7 +116,7 @@ public class TestpressApiClient {
             @Override
             public okhttp3.Response intercept(Interceptor.Chain chain) throws IOException {
                 Request.Builder header = chain.request().newBuilder()
-                        .addHeader("User-Agent", UserAgentProvider.get(context));
+                        .addHeader("User-Agent", checkHeaderValue(UserAgentProvider.get(context)));
                 if (testpressSession != null) {
                     header.addHeader("Authorization", "JWT " + testpressSession.getToken());
                 }
@@ -257,6 +257,20 @@ public class TestpressApiClient {
         RequestBody reqFile = RequestBody.create(MediaType.parse(mimeType), file);
         MultipartBody.Part body = MultipartBody.Part.createFormData("file", file.getName(), reqFile);
         return getFileUploadService().upload(body);
+    }
+
+    private String checkHeaderValue(String value) {
+        // Header value does not contains illegal characters.
+        // Sanitizes the value by removing illegal characters.
+        // Conditions in this method is refers from okhttp Headers.checkValue().
+        StringBuilder sanitizedValue = new StringBuilder();
+        for (int i = 0, length = value.length(); i < length; i++) {
+            char c = value.charAt(i);
+            if ((c > '\u001f' || c == '\t') && c < '\u007f') {
+                sanitizedValue.append(c);
+            }
+        }
+        return sanitizedValue.toString();
     }
 
 }

--- a/core/src/main/java/in/testpress/network/TestpressApiClient.java
+++ b/core/src/main/java/in/testpress/network/TestpressApiClient.java
@@ -261,10 +261,8 @@ public class TestpressApiClient {
     }
 
     private String sanitizeHeaderValue(String value) {
-        // Header value should not contains non-ASCII values.
+        // Header value should not contains non-ASCII values. Refer - https://github.com/square/okhttp/issues/891
         // Here we are Sanitizing the value by removing non-ASCII values.
-        // Refer - https://github.com/square/okhttp/issues/891
-        // Following code in this method is refers from okhttp Headers.checkValue().
         StringBuilder sanitizedValue = new StringBuilder();
         for (int i = 0, length = value.length(); i < length; i++) {
             char c = value.charAt(i);

--- a/core/src/main/java/in/testpress/network/TestpressApiClient.java
+++ b/core/src/main/java/in/testpress/network/TestpressApiClient.java
@@ -116,7 +116,7 @@ public class TestpressApiClient {
             @Override
             public okhttp3.Response intercept(Interceptor.Chain chain) throws IOException {
                 Request.Builder header = chain.request().newBuilder()
-                        .addHeader("User-Agent", sanitizeHeaderValue(UserAgentProvider.get(context)));
+                        .addHeader("User-Agent", UserAgentProvider.get(context));
                 if (testpressSession != null) {
                     header.addHeader("Authorization", "JWT " + testpressSession.getToken());
                 }
@@ -257,23 +257,6 @@ public class TestpressApiClient {
         RequestBody reqFile = RequestBody.create(MediaType.parse(mimeType), file);
         MultipartBody.Part body = MultipartBody.Part.createFormData("file", file.getName(), reqFile);
         return getFileUploadService().upload(body);
-    }
-
-    private String sanitizeHeaderValue(String value) {
-        // Header value should not contains non-ASCII values. Refer - https://github.com/square/okhttp/issues/891
-        // Here we are Sanitizing the value by removing non-ASCII values.
-        StringBuilder sanitizedValue = new StringBuilder();
-        for (int i = 0, length = value.length(); i < length; i++) {
-            char c = value.charAt(i);
-            if (isASCIICharacter(c)) {
-                sanitizedValue.append(c);
-            }
-        }
-        return sanitizedValue.toString();
-    }
-
-    private boolean isASCIICharacter(char c) {
-        return (c > '\u001f' || c == '\t') && c < '\u007f';
     }
 
 }

--- a/core/src/main/java/in/testpress/network/TestpressApiClient.java
+++ b/core/src/main/java/in/testpress/network/TestpressApiClient.java
@@ -261,8 +261,8 @@ public class TestpressApiClient {
 
     private String checkHeaderValue(String value) {
         // Header value does not contains illegal characters.
-        // Sanitizes the value by removing illegal characters.
-        // Conditions in this method is refers from okhttp Headers.checkValue().
+        // Here we are Sanitizing the value by removing illegal characters.
+        // Following code in this method is refers from okhttp Headers.checkValue().
         StringBuilder sanitizedValue = new StringBuilder();
         for (int i = 0, length = value.length(); i < length; i++) {
             char c = value.charAt(i);

--- a/core/src/main/java/in/testpress/network/TestpressApiClient.java
+++ b/core/src/main/java/in/testpress/network/TestpressApiClient.java
@@ -31,7 +31,6 @@ import in.testpress.ui.UserDevicesActivity;
 import in.testpress.util.Misc;
 import in.testpress.util.UIUtils;
 import in.testpress.util.UserAgentProvider;
-import okhttp3.Headers;
 import okhttp3.Interceptor;
 import okhttp3.MediaType;
 import okhttp3.MultipartBody;

--- a/core/src/main/java/in/testpress/network/TestpressApiClient.java
+++ b/core/src/main/java/in/testpress/network/TestpressApiClient.java
@@ -31,6 +31,7 @@ import in.testpress.ui.UserDevicesActivity;
 import in.testpress.util.Misc;
 import in.testpress.util.UIUtils;
 import in.testpress.util.UserAgentProvider;
+import okhttp3.Headers;
 import okhttp3.Interceptor;
 import okhttp3.MediaType;
 import okhttp3.MultipartBody;
@@ -116,7 +117,7 @@ public class TestpressApiClient {
             @Override
             public okhttp3.Response intercept(Interceptor.Chain chain) throws IOException {
                 Request.Builder header = chain.request().newBuilder()
-                        .addHeader("User-Agent", checkHeaderValue(UserAgentProvider.get(context)));
+                        .addHeader("User-Agent", sanitizeHeaderValue(UserAgentProvider.get(context)));
                 if (testpressSession != null) {
                     header.addHeader("Authorization", "JWT " + testpressSession.getToken());
                 }
@@ -259,9 +260,10 @@ public class TestpressApiClient {
         return getFileUploadService().upload(body);
     }
 
-    private String checkHeaderValue(String value) {
-        // Header value does not contains illegal characters.
-        // Here we are Sanitizing the value by removing illegal characters.
+    private String sanitizeHeaderValue(String value) {
+        // Header value should not contains non-ASCII values.
+        // Here we are Sanitizing the value by removing non-ASCII values.
+        // Refer - https://github.com/square/okhttp/issues/891
         // Following code in this method is refers from okhttp Headers.checkValue().
         StringBuilder sanitizedValue = new StringBuilder();
         for (int i = 0, length = value.length(); i < length; i++) {

--- a/core/src/main/java/in/testpress/network/TestpressApiClient.java
+++ b/core/src/main/java/in/testpress/network/TestpressApiClient.java
@@ -266,11 +266,15 @@ public class TestpressApiClient {
         StringBuilder sanitizedValue = new StringBuilder();
         for (int i = 0, length = value.length(); i < length; i++) {
             char c = value.charAt(i);
-            if ((c > '\u001f' || c == '\t') && c < '\u007f') {
+            if (isASCIICharacter(c)) {
                 sanitizedValue.append(c);
             }
         }
         return sanitizedValue.toString();
+    }
+
+    private boolean isASCIICharacter(char c) {
+        return (c > '\u001f' || c == '\t') && c < '\u007f';
     }
 
 }

--- a/core/src/main/java/in/testpress/util/UserAgentProvider.java
+++ b/core/src/main/java/in/testpress/util/UserAgentProvider.java
@@ -3,7 +3,6 @@ package in.testpress.util;
 import android.content.Context;
 import android.content.pm.PackageManager;
 import android.os.Build;
-import android.util.Log;
 
 /**
  * Class that builds a User-Agent that is set on all HTTP calls.

--- a/core/src/main/java/in/testpress/util/UserAgentProvider.java
+++ b/core/src/main/java/in/testpress/util/UserAgentProvider.java
@@ -3,6 +3,7 @@ package in.testpress.util;
 import android.content.Context;
 import android.content.pm.PackageManager;
 import android.os.Build;
+import android.util.Log;
 
 /**
  * Class that builds a User-Agent that is set on all HTTP calls.
@@ -15,7 +16,7 @@ import android.os.Build;
  *
  * Example
  *
- * testpress/1.1.2 (Dalvik; Android 9; Xiaomi POCO F1 Build/PKQ1.180729.001) okhttp
+ * in.testpress.samples/1.1.2 (Dalvik; Android 9; Xiaomi POCO F1 Build/PKQ1.180729.001) okhttp
  *
  */
 public class UserAgentProvider {
@@ -34,7 +35,7 @@ public class UserAgentProvider {
                         e.printStackTrace();
                     }
                     userAgent = String.format("%s/%s (Dalvik; Android %s; %s %s Build/%s) okhttp",
-                            context.getApplicationInfo().loadLabel(context.getPackageManager()),
+                            context.getApplicationInfo().packageName,
                             appVersion,
                             Build.VERSION.RELEASE,
                             Build.MANUFACTURER,


### PR DESCRIPTION
- We include the application name in the User-Agent request header to identify the app usage. If the app name includes special characters, it leads to a crash because the header value should not contain non-ASCII values. https://github.com/square/okhttp/issues/891
- In this commit, we have passed the package name to the User-Agent instead of the App name because the package name is also unique.