### PR TITLE
fix: Remove redirect URL from RazorpayPaymentGateway

### DIFF
--- a/store/src/main/java/in/testpress/store/razorpay/RazorpayPaymentGateway.kt
+++ b/store/src/main/java/in/testpress/store/razorpay/RazorpayPaymentGateway.kt
@@ -38,7 +38,6 @@ class RazorpayPaymentGateway(order: Order, context: Activity): PaymentGateway(or
         payloadHelper.allowRotation = true
         payloadHelper.rememberCustomer = true
         payloadHelper.redirect = true
-        payloadHelper.callbackUrl = redirectURL
         payloadHelper.modalConfirmClose = true
         payloadHelper.backDropColor = "#ffffff"
         payloadHelper.hideTopBar = true


### PR DESCRIPTION
- After users purchase a product we redirect them to the success page because we added a redirect URL to RazorpayPaymentGateway
- By removing this redirect URL we can get a successful callback from RazorpayPaymentGateway and we show the success page from our app.