### PR TITLE
fix: Custom test icon is showing in product preview page

### DIFF
--- a/course/src/main/java/in/testpress/course/ui/ChaptersListFragment.java
+++ b/course/src/main/java/in/testpress/course/ui/ChaptersListFragment.java
@@ -110,7 +110,7 @@ public class ChaptersListFragment extends BaseDataBaseFragment<Chapter, Long> {
         if (getCourse() != null && isItemsEmpty()) {
             showLoadingPlaceholder();
         }
-        setHasOptionsMenu(isCustomTestGenerationEnabled());
+        setHasOptionsMenu(productSlug == null && isCustomTestGenerationEnabled());
     }
 
     private void fetchCourseAndShowChapters(String courseId) {


### PR DESCRIPTION
- We are using a chapter list view for the product preview page at the time we don't have the course object but we need the course object to show a custom test icon in the app bar. insufficient course object leads to an app crash.
- Also we don't want to show a custom test icon button on the product preview page.
- In this commit, we hide the custom test icon if the product slug has a value.
