### PR TITLE
fix: Attempts not showing in attempt list for Quiz exams

### DIFF
--- a/course/src/main/java/in/testpress/course/domain/DomainContentAttempt.kt
+++ b/course/src/main/java/in/testpress/course/domain/DomainContentAttempt.kt
@@ -18,6 +18,10 @@ data class DomainContentAttempt(
     val assessment: DomainAttempt? = null
 )
 
+fun DomainContentAttempt.getEndAttemptUrl(context: Context):String? {
+    return this.getGreenDaoContentAttempt(context)?.endAttemptUrl
+}
+
 fun createDomainContentAttempt(contentAttempt: CourseAttempt): DomainContentAttempt {
     return DomainContentAttempt(
         id = contentAttempt.id,

--- a/course/src/main/java/in/testpress/course/ui/QuizActivity.kt
+++ b/course/src/main/java/in/testpress/course/ui/QuizActivity.kt
@@ -3,6 +3,7 @@ package `in`.testpress.course.ui
 import `in`.testpress.core.TestpressException
 import `in`.testpress.core.TestpressSdk
 import `in`.testpress.course.R
+import `in`.testpress.course.domain.getEndAttemptUrl
 import `in`.testpress.enums.Status
 import `in`.testpress.course.fragments.ExamEndHanlder
 import `in`.testpress.course.fragments.LoadingQuestionsFragment
@@ -142,7 +143,7 @@ class QuizActivity : BaseToolBarActivity(), ShowQuizHandler, ExamEndHanlder, Que
         viewModel.loadAttempt(attemptId).observe(this, Observer {
             contentAttemptId = it?.data!!.id
             this.attemptId = it.data!!.assessment?.id!!
-            examEndUrl = it?.data?.assessment?.endUrl
+            examEndUrl = it?.data?.getEndAttemptUrl(this)
             val examId = intent.getLongExtra("EXAM_ID", -1)
             val bundle = Bundle().apply {
                 putLong("EXAM_ID", examId)


### PR DESCRIPTION
- Previously while ending the quiz exam we only ended the user exam attempt, not the chapter content attempt.
- In this commit, we end the chapter content attempt when the exam ends.