### PR TITLE
fix: Unable to finish the quiz exam when the back button is pressed

### DIFF
--- a/course/src/main/java/in/testpress/course/ui/QuizActivity.kt
+++ b/course/src/main/java/in/testpress/course/ui/QuizActivity.kt
@@ -173,4 +173,8 @@ class QuizActivity : BaseToolBarActivity(), ShowQuizHandler, ExamEndHanlder, Que
         questionNumberView.visibility = View.VISIBLE
         questionNumberView.text = "$number of $total"
     }
+
+    override fun onBackPressed() {
+        showEndExamAlert()
+    }
 }


### PR DESCRIPTION
- Previously we did not handle the onBackPress event.
- In this commit, we handled onBackPress() when the user pressed the back button we showed the exam end alert dialog.