### PR TITLE
fix: Payment reconciliation is not taking place in the backend

### DIFF
--- a/store/src/main/java/in/testpress/store/network/ProductService.java
+++ b/store/src/main/java/in/testpress/store/network/ProductService.java
@@ -51,7 +51,7 @@ public interface ProductService {
     @POST(ORDER_API_PATH + "{order_id}" + ORDER_STATE_REFRESH_PATH)
     RetrofitCall<NetworkOrderStatus> refreshOrderStatus(
             @Path(value = "order_id", encoded = true) String orderId,
-            @Body HashMap<String, String> arguments);
+            @Body HashMap<String, Boolean> arguments);
 }
 
 

--- a/store/src/main/java/in/testpress/store/network/StoreApiClient.java
+++ b/store/src/main/java/in/testpress/store/network/StoreApiClient.java
@@ -76,8 +76,9 @@ public class StoreApiClient extends TestpressApiClient {
         return getProductService().getProductsList();
     }
 
-    public RetrofitCall<NetworkOrderStatus> refreshOrderStatus(String orderId) {
-        HashMap<String, String> parameters = new HashMap<>();
+    public RetrofitCall<NetworkOrderStatus> refreshOrderStatus(String orderId, Boolean reconciliation) {
+        HashMap<String, Boolean> parameters = new HashMap<>();
+        parameters.put("trigger_payment_reconciliation", reconciliation);
         return getProductService().refreshOrderStatus(orderId, parameters);
     }
 

--- a/store/src/main/java/in/testpress/store/ui/OrderConfirmActivity.java
+++ b/store/src/main/java/in/testpress/store/ui/OrderConfirmActivity.java
@@ -288,7 +288,7 @@ public class OrderConfirmActivity extends BaseToolBarActivity implements Payment
 
     @Override
     public void onBackPressed() {
-        refreshOrderStatus();
+        refreshOrderStatus(false);
         new AlertDialog.Builder(this, R.style.TestpressAppCompatAlertDialogStyle)
                 .setTitle(R.string.testpress_are_you_sure)
                 .setMessage(R.string.testpress_want_to_cancel_order)
@@ -323,9 +323,9 @@ public class OrderConfirmActivity extends BaseToolBarActivity implements Payment
         retryButton.setVisibility(View.GONE);
     }
 
-    private void refreshOrderStatus() {
+    private void refreshOrderStatus(Boolean reconciliation) {
         progressBar.setVisibility(View.VISIBLE);
-        apiClient.refreshOrderStatus(order.getOrderId()).enqueue(new TestpressCallback<NetworkOrderStatus>() {
+        apiClient.refreshOrderStatus(order.getOrderId(), reconciliation).enqueue(new TestpressCallback<NetworkOrderStatus>() {
             @Override
             public void onSuccess(NetworkOrderStatus result) {
                 if (result.getStatus().equals("Completed")) {
@@ -344,12 +344,12 @@ public class OrderConfirmActivity extends BaseToolBarActivity implements Payment
 
     @Override
     public void onPaymentSuccess() {
-        refreshOrderStatus();
+        refreshOrderStatus(false);
     }
 
     @Override
     public void onPaymentSuccess(String razorpayPaymentID) {
-        refreshOrderStatus();
+        refreshOrderStatus(false);
     }
 
     void showPaymentFailedScreen() {
@@ -361,7 +361,7 @@ public class OrderConfirmActivity extends BaseToolBarActivity implements Payment
     @Override
     public void onPaymentFailure() {
         progressBar.setVisibility(View.VISIBLE);
-        refreshOrderStatus();
+        refreshOrderStatus(false);
     }
 
     @Override
@@ -373,7 +373,7 @@ public class OrderConfirmActivity extends BaseToolBarActivity implements Payment
     @Override
     public void onPaymentError(int razorpayErrorCode, String razorpayErrorResponse) {
         progressBar.setVisibility(View.VISIBLE);
-        refreshOrderStatus();
+        refreshOrderStatus(true);
     }
 
     @Override


### PR DESCRIPTION
- In this commit a159622 we removed the payment redirect URL.
- The issue of failed payment reconciliation not being triggered arises due to the removal of this URL.
- In this commit, we pass the `trigger_payment_reconciliation` field in the Order refresh API to trigger payment reconciliation for filed payments.