### PR TITLE
fix: Add support to take the exam with attempt ID in Quiz template

### DIFF
--- a/course/src/main/java/in/testpress/course/domain/DomainAttempt.kt
+++ b/course/src/main/java/in/testpress/course/domain/DomainAttempt.kt
@@ -1,6 +1,9 @@
 package `in`.testpress.course.domain
 
+import `in`.testpress.core.TestpressSDKDatabase
 import `in`.testpress.models.greendao.Attempt
+import `in`.testpress.models.greendao.AttemptDao
+import android.content.Context
 
 data class DomainAttempt(
     val id : Long,
@@ -61,4 +64,13 @@ fun Attempt.asDomainModel(): DomainAttempt {
         reviewPdf = reviewPdf,
         rankEnabled = rankEnabled
     )
+}
+
+fun DomainAttempt.getGreenDaoAttempt(context: Context): Attempt? {
+    val attemptDao = TestpressSDKDatabase.getAttemptDao(context)
+    val attempts =  attemptDao.queryBuilder().where(AttemptDao.Properties.Id.eq(this.id)).list()
+    if (attempts.isNotEmpty()) {
+        return attempts[0]
+    }
+    return null
 }

--- a/course/src/main/java/in/testpress/course/fragments/LoadingQuestionsFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/LoadingQuestionsFragment.kt
@@ -117,8 +117,6 @@ class LoadingQuestionsFragment : Fragment(),
     }
 
     private fun initUserSelectedAnswers() {
-        //val attempt = contentAttempt.assessment!!
-        //https://lmsdemo.testpress.in/api/v2.5/attempts/53351/questions/?page=1
         val questionsUrl = "/api/v2.5/attempts/${attempt?.id}/questions/"
         viewModel.loadUserSelectedAnswers(examId, attempt?.id!!, questionsUrl).observe(viewLifecycleOwner, Observer { resource ->
             when(resource?.status) {

--- a/course/src/main/java/in/testpress/course/network/CourseService.kt
+++ b/course/src/main/java/in/testpress/course/network/CourseService.kt
@@ -32,6 +32,11 @@ interface CourseService {
     fun getContentAttempts(@Url attemptsUrl: String): RetrofitCall<TestpressApiResponse<NetworkContentAttempt>>
 
     @PUT("{end_exam_url}")
+    fun endAttempt(
+        @Path(value = "end_exam_url", encoded = true) endExamUrlFrag: String?
+    ): RetrofitCall<NetworkAttempt>
+
+    @PUT("{end_exam_url}")
     fun endContentAttempt(
         @Path(value = "end_exam_url", encoded = true) endExamUrlFrag: String?
     ): RetrofitCall<NetworkContentAttempt>
@@ -85,6 +90,10 @@ class CourseNetwork(context: Context) : TestpressApiClient(context, TestpressSdk
 
     fun getContentAttempts(url: String): RetrofitCall<TestpressApiResponse<NetworkContentAttempt>> {
         return getCourseService().getContentAttempts(url)
+    }
+
+    fun endAttempt(url: String):  RetrofitCall<NetworkAttempt> {
+        return getCourseService().endAttempt(url)
     }
 
     fun endContentAttempt(url: String):  RetrofitCall<NetworkContentAttempt> {

--- a/course/src/main/java/in/testpress/course/repository/QuizExamRepository.kt
+++ b/course/src/main/java/in/testpress/course/repository/QuizExamRepository.kt
@@ -25,7 +25,7 @@ open class QuizExamRepository(val context: Context) {
     val courseAttemptDao = TestpressSDKDatabase.getCourseAttemptDao(context)
     val attemptDao = TestpressSDKDatabase.getAttemptDao(context)
 
-    var _resourceAttempt: MutableLiveData<Resource<DomainAttempt>> = MutableLiveData()
+    private var _resourceAttempt: MutableLiveData<Resource<DomainAttempt>> = MutableLiveData()
     val resourceAttempt: LiveData<Resource<DomainAttempt>>
         get() = _resourceAttempt
 

--- a/course/src/main/java/in/testpress/course/repository/QuizExamRepository.kt
+++ b/course/src/main/java/in/testpress/course/repository/QuizExamRepository.kt
@@ -8,6 +8,7 @@ import `in`.testpress.course.network.CourseNetwork
 import `in`.testpress.course.network.NetworkContentAttempt
 import `in`.testpress.network.Resource
 import `in`.testpress.course.network.asGreenDaoModel
+import `in`.testpress.exam.api.TestpressExamApiClient
 import `in`.testpress.exam.network.NetworkAttempt
 import `in`.testpress.exam.network.asGreenDaoModel
 import `in`.testpress.models.greendao.Attempt
@@ -24,13 +25,41 @@ open class QuizExamRepository(val context: Context) {
     val courseAttemptDao = TestpressSDKDatabase.getCourseAttemptDao(context)
     val attemptDao = TestpressSDKDatabase.getAttemptDao(context)
 
+    var _resourceAttempt: MutableLiveData<Resource<DomainAttempt>> = MutableLiveData()
+    val resourceAttempt: LiveData<Resource<DomainAttempt>>
+        get() = _resourceAttempt
+
     var _resourceContentAttempt: MutableLiveData<Resource<DomainContentAttempt>> = MutableLiveData()
     val resourceContentAttempt: LiveData<Resource<DomainContentAttempt>>
         get() = _resourceContentAttempt
 
+    private var _endAttemptState: MutableLiveData<Resource<DomainAttempt>> = MutableLiveData()
+    val endAttemptState: LiveData<Resource<DomainAttempt>>
+        get() = _endAttemptState
+
     private var _endContentAttemptState: MutableLiveData<Resource<DomainContentAttempt>> = MutableLiveData()
     val endContentAttemptState: LiveData<Resource<DomainContentAttempt>>
         get() = _endContentAttemptState
+
+    fun createAttempt(attemptId: Long): LiveData<Resource<DomainAttempt>> {
+        val apiClient = TestpressExamApiClient(context)
+        apiClient.startAttempt("api/v2.2/attempts/$attemptId/start/")
+            .enqueue(object: TestpressCallback<Attempt>() {
+                override fun onSuccess(result: Attempt?) {
+                    attemptDao.insertOrReplaceInTx(result)
+                    loadAttempt(result!!.id)
+                }
+
+                override fun onException(exception: TestpressException?) {
+                    if (exception?.isNetworkError == true) {
+                        loadAttemptFromDB(attemptId)
+                    } else {
+                        _resourceAttempt.postValue(Resource.error(exception!!, null))
+                    }
+                }
+            })
+        return resourceAttempt
+    }
 
     fun createContentAttempt(contentId: Long): LiveData<Resource<DomainContentAttempt>> {
         courseNetwork.createContentAttempt(contentId)
@@ -51,9 +80,21 @@ open class QuizExamRepository(val context: Context) {
         return resourceContentAttempt
     }
 
+    fun loadAttemptFromDB(attemptId: Long) {
+        val attempt = getRunningAttemptFromDB(attemptId)
+        _resourceAttempt.postValue(Resource.success(attempt?.asDomainModel()))
+    }
+
     fun loadContentAttemptFromDB(contentId: Long) {
         val contentAttempt = getRunningContentAttemptFromDB(contentId) ?: createLocalContentAttempt(contentId)
         _resourceContentAttempt.postValue(Resource.success(contentAttempt.asDomainContentAttempt()))
+    }
+
+    private fun getRunningAttemptFromDB(attemptId: Long): Attempt? {
+        val attempts = attemptDao.queryBuilder()
+            .where(AttemptDao.Properties.State.eq("Running"), AttemptDao.Properties.Id.`in`(attemptId))
+            .orderDesc(AttemptDao.Properties.Id).list()
+        return attempts.first()
     }
 
     private fun getRunningContentAttemptFromDB(contentId: Long): CourseAttempt? {
@@ -89,6 +130,15 @@ open class QuizExamRepository(val context: Context) {
         courseAttemptDao.insertOrReplaceInTx(contentAttempt?.asGreenDaoModel())
     }
 
+    fun loadAttempt(attemptId: Long): LiveData<Resource<DomainAttempt>> {
+        val attempts = attemptDao.queryBuilder()
+            .where(AttemptDao.Properties.Id.eq(attemptId)).list()
+        if (attempts.isNotEmpty()) {
+            _resourceAttempt.postValue(Resource.success(attempts[0].asDomainModel()))
+        }
+        return resourceAttempt
+    }
+
     fun loadContentAttempt(contentAttemptId: Long): LiveData<Resource<DomainContentAttempt>> {
         val contentAttempts = courseAttemptDao.queryBuilder()
             .where(CourseAttemptDao.Properties.Id.eq(contentAttemptId)).list()
@@ -99,7 +149,27 @@ open class QuizExamRepository(val context: Context) {
         return resourceContentAttempt
     }
 
-    fun endExam(url: String, attemptId: Long) {
+    fun endAttempt(url: String, attemptId: Long) {
+        courseNetwork.endAttempt(url)
+            .enqueue(object : TestpressCallback<NetworkAttempt>() {
+                override fun onSuccess(result: NetworkAttempt?) {
+                    attemptDao.insertOrReplaceInTx(result?.asGreenDaoModel())
+                    val attempts = attemptDao.queryBuilder()
+                        .where(AttemptDao.Properties.Id.eq(result!!.id)).list()
+                    _endAttemptState.postValue(Resource.success(attempts[0].asDomainModel()))
+                }
+
+                override fun onException(exception: TestpressException?) {
+                    val attempt = attemptDao.queryBuilder()
+                        .where(AttemptDao.Properties.Id.eq(attemptId)).list()[0]
+                    attempt.state = "COMPLETED"
+                    attemptDao.insertOrReplaceInTx(attempt)
+                    _endAttemptState.postValue(Resource.success(attempt.asDomainModel()))
+                }
+            })
+    }
+
+    fun endContentAttempt(url: String, attemptId: Long) {
         courseNetwork.endContentAttempt(url)
             .enqueue(object : TestpressCallback<NetworkContentAttempt>() {
                 override fun onSuccess(result: NetworkContentAttempt?) {

--- a/course/src/main/java/in/testpress/course/ui/CustomTestGenerationActivity.kt
+++ b/course/src/main/java/in/testpress/course/ui/CustomTestGenerationActivity.kt
@@ -8,9 +8,7 @@ import `in`.testpress.exam.ui.TestFragment
 import `in`.testpress.models.greendao.Attempt
 import `in`.testpress.ui.AbstractWebViewActivity
 import `in`.testpress.util.BaseJavaScriptInterface
-import android.content.Intent
 import android.os.Bundle
-import android.util.Log
 import android.webkit.JavascriptInterface
 import android.widget.Toast
 import android.widget.Toolbar
@@ -74,14 +72,7 @@ class JavaScriptInterface(val activity: CustomTestGenerationActivity):BaseJavaSc
 
     @JavascriptInterface
     fun startCustomTest(attemptId: String) {
-        val intent = Intent(activity, QuizActivity::class.java).apply {
-            //putExtra(ContentActivity.CONTENT_ID, content.id)
-            //putExtra("EXAM_ID", exam.id)
-            putExtra("ATTEMPT_ID", attemptId.toLong())
-        }
-        Log.d("TAG", "startCustomTest: $attemptId")
-        activity.startActivity(intent)
-        activity.finish()
+        activity.getAttempt(attemptId)
     }
 
 }

--- a/course/src/main/java/in/testpress/course/ui/CustomTestGenerationActivity.kt
+++ b/course/src/main/java/in/testpress/course/ui/CustomTestGenerationActivity.kt
@@ -8,7 +8,9 @@ import `in`.testpress.exam.ui.TestFragment
 import `in`.testpress.models.greendao.Attempt
 import `in`.testpress.ui.AbstractWebViewActivity
 import `in`.testpress.util.BaseJavaScriptInterface
+import android.content.Intent
 import android.os.Bundle
+import android.util.Log
 import android.webkit.JavascriptInterface
 import android.widget.Toast
 import android.widget.Toolbar
@@ -72,7 +74,14 @@ class JavaScriptInterface(val activity: CustomTestGenerationActivity):BaseJavaSc
 
     @JavascriptInterface
     fun startCustomTest(attemptId: String) {
-        activity.getAttempt(attemptId)
+        val intent = Intent(activity, QuizActivity::class.java).apply {
+            //putExtra(ContentActivity.CONTENT_ID, content.id)
+            //putExtra("EXAM_ID", exam.id)
+            putExtra("ATTEMPT_ID", attemptId.toLong())
+        }
+        Log.d("TAG", "startCustomTest: $attemptId")
+        activity.startActivity(intent)
+        activity.finish()
     }
 
 }

--- a/course/src/main/java/in/testpress/course/ui/QuizActivity.kt
+++ b/course/src/main/java/in/testpress/course/ui/QuizActivity.kt
@@ -4,6 +4,7 @@ import `in`.testpress.core.TestpressException
 import `in`.testpress.core.TestpressSdk
 import `in`.testpress.course.R
 import `in`.testpress.course.domain.getEndAttemptUrl
+import `in`.testpress.course.domain.getGreenDaoAttempt
 import `in`.testpress.enums.Status
 import `in`.testpress.course.fragments.ExamEndHanlder
 import `in`.testpress.course.fragments.LoadingQuestionsFragment
@@ -68,6 +69,20 @@ class QuizActivity : BaseToolBarActivity(), ShowQuizHandler, ExamEndHanlder, Que
         toolbar.setNavigationIcon(R.drawable.ic_close_white_24dp)
         toolbar.setNavigationOnClickListener {
             showEndExamAlert()
+        }
+
+        viewModel.endAttemptState.observe(this) {
+            dialog.hide()
+            when(it.status) {
+                Status.SUCCESS -> {
+                    val intent = ReviewStatsActivity.createIntent(this, it.data?.getGreenDaoAttempt(this))
+                    finish()
+                    startActivity(intent)
+                }
+                Status.ERROR -> {
+                    handleExamEndError(it.exception!!)
+                }
+            }
         }
 
         viewModel.endContentAttemptState.observe(this, Observer {
@@ -139,24 +154,49 @@ class QuizActivity : BaseToolBarActivity(), ShowQuizHandler, ExamEndHanlder, Que
         alertDialog = alertDialogBuilder.show()
     }
 
-    override fun showQuiz(contentAttempt: Long, totalNoOfQuestions:Int, index: Int) {
-        viewModel.loadContentAttempt(contentAttempt).observe(this, Observer {
-            contentAttemptId = it?.data!!.id
-            this.attemptId = it.data!!.assessment?.id!!
-            examEndUrl = it?.data?.getEndAttemptUrl(this)
-            val examId = intent.getLongExtra("EXAM_ID", -1)
-            val bundle = Bundle().apply {
-                putLong("EXAM_ID", examId)
-                putLong("ATTEMPT_ID", it.data!!.assessment!!.id)
-                putInt("NO_OF_QUESTIONS", totalNoOfQuestions)
-                putInt("START_INDEX", index)
-            }
-            val quizSlideFragment = QuizSlideFragment().apply { arguments=bundle }
-            quizSlideFragment.endHanlder = this
-            quizSlideFragment.questionNumberHandler = this
-            supportFragmentManager.beginTransaction()
-                .replace(R.id.fragment_container, quizSlideFragment).commitAllowingStateLoss()
-        })
+    override fun showQuiz(
+        ContentAttemptId: Long?,
+        attemptId: Long?,
+        totalNoOfQuestions: Int,
+        index: Int
+    ) {
+        if (examId == -1L) {
+            viewModel.loadAttempt(attemptId!!).observe(this, Observer {
+                contentAttemptId = -1
+                this.attemptId = it.data!!.id
+                examEndUrl = it?.data?.endUrl
+                val examId = intent.getLongExtra("EXAM_ID", -1)
+                val bundle = Bundle().apply {
+                    putLong("EXAM_ID", examId)
+                    putLong("ATTEMPT_ID", it.data!!.id)
+                    putInt("NO_OF_QUESTIONS", totalNoOfQuestions)
+                    putInt("START_INDEX", index)
+                }
+                val quizSlideFragment = QuizSlideFragment().apply { arguments=bundle }
+                quizSlideFragment.endHanlder = this
+                quizSlideFragment.questionNumberHandler = this
+                supportFragmentManager.beginTransaction()
+                    .replace(R.id.fragment_container, quizSlideFragment).commitAllowingStateLoss()
+            })
+        } else {
+            viewModel.loadContentAttempt(ContentAttemptId!!).observe(this, Observer {
+                contentAttemptId = it?.data!!.id
+                this.attemptId = it.data!!.assessment?.id!!
+                examEndUrl = it?.data?.getEndAttemptUrl(this)
+                val examId = intent.getLongExtra("EXAM_ID", -1)
+                val bundle = Bundle().apply {
+                    putLong("EXAM_ID", examId)
+                    putLong("ATTEMPT_ID", it.data!!.assessment!!.id)
+                    putInt("NO_OF_QUESTIONS", totalNoOfQuestions)
+                    putInt("START_INDEX", index)
+                }
+                val quizSlideFragment = QuizSlideFragment().apply { arguments=bundle }
+                quizSlideFragment.endHanlder = this
+                quizSlideFragment.questionNumberHandler = this
+                supportFragmentManager.beginTransaction()
+                    .replace(R.id.fragment_container, quizSlideFragment).commitAllowingStateLoss()
+            })
+        }
     }
 
     override fun endExam() {
@@ -165,7 +205,7 @@ class QuizActivity : BaseToolBarActivity(), ShowQuizHandler, ExamEndHanlder, Que
             dialog.hide()
             finish()
         } else {
-            viewModel.endExam(examEndUrl!!, attemptId)
+            viewModel.endExam(examId, examEndUrl!!, attemptId)
         }
     }
 

--- a/course/src/main/java/in/testpress/course/ui/QuizActivity.kt
+++ b/course/src/main/java/in/testpress/course/ui/QuizActivity.kt
@@ -155,48 +155,64 @@ class QuizActivity : BaseToolBarActivity(), ShowQuizHandler, ExamEndHanlder, Que
     }
 
     override fun showQuiz(
-        ContentAttemptId: Long?,
+        contentAttemptId: Long?,
         attemptId: Long?,
         totalNoOfQuestions: Int,
         index: Int
     ) {
         if (examId == -1L) {
-            viewModel.loadAttempt(attemptId!!).observe(this, Observer {
-                contentAttemptId = -1
-                this.attemptId = it.data!!.id
-                examEndUrl = it?.data?.endUrl
-                val examId = intent.getLongExtra("EXAM_ID", -1)
-                val bundle = Bundle().apply {
-                    putLong("EXAM_ID", examId)
-                    putLong("ATTEMPT_ID", it.data!!.id)
-                    putInt("NO_OF_QUESTIONS", totalNoOfQuestions)
-                    putInt("START_INDEX", index)
-                }
-                val quizSlideFragment = QuizSlideFragment().apply { arguments=bundle }
-                quizSlideFragment.endHanlder = this
-                quizSlideFragment.questionNumberHandler = this
-                supportFragmentManager.beginTransaction()
-                    .replace(R.id.fragment_container, quizSlideFragment).commitAllowingStateLoss()
-            })
+            loadAttempt(attemptId, totalNoOfQuestions, index)
         } else {
-            viewModel.loadContentAttempt(ContentAttemptId!!).observe(this, Observer {
-                contentAttemptId = it?.data!!.id
-                this.attemptId = it.data!!.assessment?.id!!
-                examEndUrl = it?.data?.getEndAttemptUrl(this)
-                val examId = intent.getLongExtra("EXAM_ID", -1)
-                val bundle = Bundle().apply {
-                    putLong("EXAM_ID", examId)
-                    putLong("ATTEMPT_ID", it.data!!.assessment!!.id)
-                    putInt("NO_OF_QUESTIONS", totalNoOfQuestions)
-                    putInt("START_INDEX", index)
-                }
-                val quizSlideFragment = QuizSlideFragment().apply { arguments=bundle }
-                quizSlideFragment.endHanlder = this
-                quizSlideFragment.questionNumberHandler = this
-                supportFragmentManager.beginTransaction()
-                    .replace(R.id.fragment_container, quizSlideFragment).commitAllowingStateLoss()
-            })
+            loadContentAttempt(contentAttemptId, totalNoOfQuestions, index)
         }
+    }
+
+    private fun loadAttempt(
+        attemptId: Long?,
+        totalNoOfQuestions: Int,
+        index: Int
+    ) {
+        viewModel.loadAttempt(attemptId!!).observe(this, Observer {
+            this.contentAttemptId = -1
+            this.attemptId = it.data!!.id
+            examEndUrl = it?.data?.endUrl
+            val examId = intent.getLongExtra("EXAM_ID", -1)
+            val bundle = Bundle().apply {
+                putLong("EXAM_ID", examId)
+                putLong("ATTEMPT_ID", it.data!!.id)
+                putInt("NO_OF_QUESTIONS", totalNoOfQuestions)
+                putInt("START_INDEX", index)
+            }
+            showQuizSlideFragment(bundle)
+        })
+    }
+
+    private fun loadContentAttempt(
+        contentAttemptId: Long?,
+        totalNoOfQuestions: Int,
+        index: Int
+    ) {
+        viewModel.loadContentAttempt(contentAttemptId!!).observe(this, Observer {
+            this.contentAttemptId = it?.data!!.id
+            this.attemptId = it.data!!.assessment?.id!!
+            examEndUrl = it.data?.getEndAttemptUrl(this)
+            val examId = intent.getLongExtra("EXAM_ID", -1)
+            val bundle = Bundle().apply {
+                putLong("EXAM_ID", examId)
+                putLong("ATTEMPT_ID", it.data!!.assessment!!.id)
+                putInt("NO_OF_QUESTIONS", totalNoOfQuestions)
+                putInt("START_INDEX", index)
+            }
+            showQuizSlideFragment(bundle)
+        })
+    }
+
+    private fun showQuizSlideFragment(bundle: Bundle) {
+        val quizSlideFragment = QuizSlideFragment().apply { arguments = bundle }
+        quizSlideFragment.endHanlder = this
+        quizSlideFragment.questionNumberHandler = this
+        supportFragmentManager.beginTransaction()
+            .replace(R.id.fragment_container, quizSlideFragment).commitAllowingStateLoss()
     }
 
     override fun endExam() {

--- a/course/src/main/java/in/testpress/course/viewmodels/QuizExamViewModel.kt
+++ b/course/src/main/java/in/testpress/course/viewmodels/QuizExamViewModel.kt
@@ -1,5 +1,6 @@
 package `in`.testpress.course.viewmodels
 
+import `in`.testpress.course.domain.DomainAttempt
 import `in`.testpress.course.domain.DomainContentAttempt
 import `in`.testpress.network.Resource
 import `in`.testpress.course.repository.QuizExamRepository
@@ -8,13 +9,31 @@ import androidx.lifecycle.ViewModel
 
 class QuizExamViewModel(val repository: QuizExamRepository): ViewModel() {
 
+    val endAttemptState = repository.endAttemptState
+
     val endContentAttemptState = repository.endContentAttemptState
 
     fun loadContentAttempt(id: Long): LiveData<Resource<DomainContentAttempt>> {
         return repository.loadContentAttempt(id)
     }
 
-    fun endExam(url: String, attemptId: Long) {
-        repository.endExam(url, attemptId)
+    fun loadAttempt(id: Long): LiveData<Resource<DomainAttempt>> {
+        return repository.loadAttempt(id)
+    }
+
+    fun endExam(examId: Long, url: String, attemptId: Long) {
+        if (examId == -1L) {
+            endAttempt(url, attemptId)
+        } else {
+            endContentAttempt(url, attemptId)
+        }
+    }
+
+    private fun endContentAttempt(url: String, attemptId: Long) {
+        repository.endContentAttempt(url, attemptId)
+    }
+
+    private fun endAttempt(url: String, attemptId: Long) {
+        repository.endAttempt(url, attemptId)
     }
 }

--- a/course/src/main/java/in/testpress/course/viewmodels/QuizViewModel.kt
+++ b/course/src/main/java/in/testpress/course/viewmodels/QuizViewModel.kt
@@ -1,5 +1,6 @@
 package `in`.testpress.course.viewmodels
 
+import `in`.testpress.course.domain.DomainAttempt
 import `in`.testpress.course.domain.DomainContentAttempt
 import `in`.testpress.network.Resource
 import `in`.testpress.course.repository.QuizQuestionsRepository
@@ -9,6 +10,11 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 
 class QuizViewModel(val repository: QuizQuestionsRepository): ViewModel() {
+
+    fun loadAttempt(contentId: Long): LiveData<Resource<DomainAttempt>> {
+        return repository.createAttempt(contentId)
+    }
+
     fun loadContentAttempt(contentId: Long): LiveData<Resource<DomainContentAttempt>> {
         return repository.createContentAttempt(contentId)
     }


### PR DESCRIPTION
- For the custom test generation feature we don't have exam or content objects we only have attempt ID.
- In this commit, we added support to take the exam with attempt ID in the Quiz Template.
- After obtaining the attempt ID for the webview, we initiate a user exam attempt, retrieve the exam questions, and commence the exam. Once the user completes the exam, we conclude the attempt and display the review page.
