### PR TITLE
fix: App crash while start video content activity in landscape

### DIFF
--- a/course/src/main/java/in/testpress/course/util/ExoPlayerUtil.java
+++ b/course/src/main/java/in/testpress/course/util/ExoPlayerUtil.java
@@ -212,6 +212,7 @@ public class ExoPlayerUtil implements VideoTimeRangeListener, DrmSessionManagerP
         trackSelector =  new DefaultTrackSelector(activity, videoTrackSelectionFactory);
         initFullscreenDialog();
         initResolutionSelector();
+        initializePinchToZoom();
 
         // set activity as portrait mode at first
         activity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
@@ -298,7 +299,6 @@ public class ExoPlayerUtil implements VideoTimeRangeListener, DrmSessionManagerP
             progressBar.setVisibility(View.VISIBLE);
             buildPlayer();
             initializeDoubleClickOverlay();
-            initializePinchToZoom();
         }
         preparePlayer();
         player.seekTo(getStartPositionInMilliSeconds());


### PR DESCRIPTION
- In this commit 4e963de we added pinch-to-zoom support we initialize this functionality when a player is initialized
- we initialize player on onStart() and onResume()
- When the user starts this video content activity in landscape mode this zoom functionality is invoked prior to its initialization. 
- Furthermore, in scenarios where apps transition from the background in landscape mode, this zoom functionality is invoked prior to its initialization. To address this, we have modified the code in this commit to initialize the pinch-to-zoom functionality when creating the activity.
