### PR TITLE
fix: Not able end section in resumed exams

### DIFF
--- a/exam/src/main/java/in/testpress/exam/api/ExamService.java
+++ b/exam/src/main/java/in/testpress/exam/api/ExamService.java
@@ -10,6 +10,7 @@ import in.testpress.exam.models.Permission;
 import in.testpress.exam.models.ReportQuestionResponse;
 import in.testpress.exam.models.Subject;
 import in.testpress.exam.models.Vote;
+import in.testpress.exam.network.NetworkAttemptSection;
 import in.testpress.models.TestpressApiResponse;
 import in.testpress.models.greendao.Attempt;
 import in.testpress.models.greendao.AttemptSection;
@@ -91,7 +92,7 @@ public interface ExamService {
             @Path(value = "end_exam_url", encoded = true) String endExamUrlFrag);
 
     @PATCH("/{url_frag}")
-    RetrofitCall<AttemptSection> updateSection(
+    RetrofitCall<NetworkAttemptSection> updateSection(
             @Path(value = "url_frag", encoded = true) String urlFrag);
 
     @PUT("{end_exam_url}")

--- a/exam/src/main/java/in/testpress/exam/api/TestpressExamApiClient.java
+++ b/exam/src/main/java/in/testpress/exam/api/TestpressExamApiClient.java
@@ -15,6 +15,7 @@ import in.testpress.exam.models.Permission;
 import in.testpress.exam.models.ReportQuestionResponse;
 import in.testpress.exam.models.Subject;
 import in.testpress.exam.models.Vote;
+import in.testpress.exam.network.NetworkAttemptSection;
 import in.testpress.models.TestpressApiResponse;
 import in.testpress.models.greendao.Attempt;
 import in.testpress.models.greendao.AttemptSection;
@@ -183,7 +184,7 @@ public class TestpressExamApiClient extends TestpressApiClient {
         return getExamService().heartbeat(heartbeatUrlFrag);
     }
 
-    public RetrofitCall<AttemptSection> updateSection(String urlFrag) {
+    public RetrofitCall<NetworkAttemptSection> updateSection(String urlFrag) {
         return getExamService().updateSection(urlFrag);
     }
 

--- a/exam/src/main/java/in/testpress/exam/network/NetworkAttemptSection.kt
+++ b/exam/src/main/java/in/testpress/exam/network/NetworkAttemptSection.kt
@@ -27,18 +27,18 @@ fun List<NetworkAttemptSection>.asGreenDaoModel(): List<AttemptSection> {
 }
 
 fun createAttemptSection(networkAttemptSection: NetworkAttemptSection): AttemptSection {
-    return AttemptSection(
-            networkAttemptSection.id,
-            networkAttemptSection.attemptSectionId,
-            networkAttemptSection.state,
-            networkAttemptSection.questionsUrl,
-            networkAttemptSection.startUrl,
-            networkAttemptSection.endUrl,
-            networkAttemptSection.remainingTime,
-            networkAttemptSection.info?.name,
-            networkAttemptSection.info?.duration,
-            networkAttemptSection.info?.order,
-            networkAttemptSection.info?.instructions,
-            networkAttemptSection.attemptId
-    )
+        return AttemptSection(
+                networkAttemptSection.id,
+                networkAttemptSection.attemptSectionId,
+                networkAttemptSection.state,
+                networkAttemptSection.questionsUrl,
+                networkAttemptSection.startUrl,
+                networkAttemptSection.endUrl,
+                networkAttemptSection.remainingTime,
+                networkAttemptSection.name ?: networkAttemptSection.info?.name,
+                networkAttemptSection.duration ?: networkAttemptSection.info?.duration,
+                networkAttemptSection.order ?: networkAttemptSection.info?.order,
+                networkAttemptSection.instructions ?: networkAttemptSection.info?.instructions,
+                networkAttemptSection.attemptId
+        )
 }


### PR DESCRIPTION
- When concluding the section, we utilize the AttemptSection model for managing network responses from API v2.2.
- However, in commit 0ed10a2, the network response from API v2.2 was modified to API v2.3, preventing us from concluding the section.
- In this particular commit, we substituted AttemptSection with NetworkAttemptSection to effectively handle responses from both API versions 2.2 and 2.3.
