### PR TITLE
fix: Attempt not receiving in domain model

### DIFF
--- a/course/src/main/java/in/testpress/course/network/NetworkContentAttempt.kt
+++ b/course/src/main/java/in/testpress/course/network/NetworkContentAttempt.kt
@@ -2,6 +2,7 @@ package `in`.testpress.course.network
 
 import `in`.testpress.course.domain.DomainContentAttempt
 import `in`.testpress.exam.network.NetworkAttempt
+import `in`.testpress.exam.network.asDomainModel
 import `in`.testpress.exam.network.asGreenDaoModel
 import `in`.testpress.models.greendao.CourseAttempt
 
@@ -44,7 +45,8 @@ fun createDomainContentAttempt(contentAttempt: NetworkContentAttempt): DomainCon
         contentAttempt.trophies,
         contentAttempt.chapterContentId,
         contentAttempt.assessmentId,
-        contentAttempt.userVideoId
+        contentAttempt.userVideoId,
+        contentAttempt.assessment?.asDomainModel()
     )
 }
 

--- a/exam/src/main/java/in/testpress/exam/domain/DomainAttempt.kt
+++ b/exam/src/main/java/in/testpress/exam/domain/DomainAttempt.kt
@@ -28,7 +28,7 @@ data class DomainAttempt(
     val unanswered_count : Int? = null,
     val totalBonus : Int? = null,
     val rankEnabled : Boolean? = null,
-    val sections : List<String>? = null,
+    val sections : List<DomainAttemptSection>? = null,
     val speed : Int? = null,
     val accuracy : Int? = null,
     val lastViewedQuestionId: Int? = null,
@@ -64,7 +64,8 @@ fun Attempt.asDomainModel(): DomainAttempt {
         externalReviewUrl = externalReviewUrl,
         reviewPdf = reviewPdf,
         rankEnabled = rankEnabled,
-        attemptType = attemptType
+        attemptType = attemptType,
+        sections = sections.asDomainModels()
     )
 }
 

--- a/exam/src/main/java/in/testpress/exam/domain/DomainAttemptSection.kt
+++ b/exam/src/main/java/in/testpress/exam/domain/DomainAttemptSection.kt
@@ -1,0 +1,37 @@
+package `in`.testpress.exam.domain
+
+import `in`.testpress.models.greendao.AttemptSection
+
+data class DomainAttemptSection(
+    val id: Long,
+    val attemptSectionId: Long,
+    var state: String? = null,
+    val questionsUrl: String? = null,
+    val startUrl: String? = null,
+    val endUrl: String? = null,
+    val remainingTime: String? = null,
+    val name: String? = null,
+    val duration: String? = null,
+    val order: Int? = null,
+    val instructions: String? = null,
+    val attemptId: Long? = null,
+    var info: DomainSection? = null
+)
+
+fun AttemptSection.asDomainModel() = DomainAttemptSection(
+    id = this.id,
+    attemptSectionId = attemptSectionId,
+    state = this.state,
+    questionsUrl = questionsUrl,
+    startUrl = startUrl,
+    endUrl = endUrl,
+    remainingTime = remainingTime,
+    name = name,
+    duration = duration,
+    order = order,
+    instructions = instructions,
+    attemptId = attemptId
+)
+
+fun List<AttemptSection>.asDomainModels(): List<DomainAttemptSection> =
+    map { it.asDomainModel() }

--- a/exam/src/main/java/in/testpress/exam/network/NetworkAttempt.kt
+++ b/exam/src/main/java/in/testpress/exam/network/NetworkAttempt.kt
@@ -1,5 +1,6 @@
 package `in`.testpress.exam.network
 
+import `in`.testpress.exam.domain.DomainAttempt
 import `in`.testpress.models.greendao.Attempt
 
 data class NetworkAttempt(
@@ -60,6 +61,38 @@ fun createNetworkAttempt(attempt: NetworkAttempt): Attempt {
     greenDaoAttempt.sections = attempt.sections?.asGreenDaoModel()
     return greenDaoAttempt
 }
+
+fun NetworkAttempt.asDomainModel() = DomainAttempt(
+    id = this.id,
+    url = this.url,
+    date = this.date,
+    score = this.score,
+    totalQuestions = this.totalQuestions,
+    reviewPdfUrl = this.reviewPdf,
+    reviewUrl = this.reviewUrl,
+    questionsUrl = this.questionsUrl,
+    percentile = this.percentile,
+    correctCount = this.correctCount,
+    exam = null,
+    incorrectCount = this.incorrectCount,
+    lastStartedTime = this.lastStartedTime,
+    remainingTime = this.remainingTime,
+    timeTaken = this.timeTaken,
+    state = this.state,
+    rank = this.rank,
+    maxRank = this.maxRank,
+    percentage = this.percentage,
+    unanswered_count = null,
+    totalBonus = null,
+    rankEnabled = this.rankEnabled,
+    sections = this.sections?.asDomainModels(),
+    speed = this.speed,
+    accuracy = this.accuracy,
+    lastViewedQuestionId = this.lastViewedQuestionId,
+    externalReviewUrl = this.externalReviewUrl,
+    reviewPdf = this.reviewPdf,
+    attemptType = this.attemptType
+)
 
 fun NetworkAttempt.asGreenDaoModel(): Attempt {
     return createNetworkAttempt(this)

--- a/exam/src/main/java/in/testpress/exam/network/NetworkAttemptSection.kt
+++ b/exam/src/main/java/in/testpress/exam/network/NetworkAttemptSection.kt
@@ -1,5 +1,6 @@
 package `in`.testpress.exam.network
 
+import `in`.testpress.exam.domain.DomainAttemptSection
 import `in`.testpress.models.greendao.AttemptSection
 import `in`.testpress.models.greendao.CourseAttempt
 
@@ -42,3 +43,21 @@ fun createAttemptSection(networkAttemptSection: NetworkAttemptSection): AttemptS
                 networkAttemptSection.attemptId
         )
 }
+
+fun NetworkAttemptSection.asDomainModel() = DomainAttemptSection(
+        id = this.id,
+        attemptSectionId = this.attemptSectionId,
+        state = this.state,
+        questionsUrl = this.questionsUrl,
+        startUrl = this.startUrl,
+        endUrl = this.endUrl,
+        remainingTime = this.remainingTime,
+        name = this.name,
+        duration = this.duration,
+        order = this.order,
+        instructions = this.instructions,
+        this.attemptId
+)
+
+fun List<NetworkAttemptSection>.asDomainModels(): List<DomainAttemptSection> =
+        map { it.asDomainModel() }


### PR DESCRIPTION
- In ExamContentRepository we are parsing Network response to Domain response this process is not done properly 
- During this conversion, attempts are not being retrieved due to improper parsing.
- In this commit, we have included the necessary files that were missing for proper parsing.