### PR TITLE
fix: Replace ImageView with TextView in quiz template

### DIFF
--- a/course/src/main/java/in/testpress/course/ui/QuizActivity.kt
+++ b/course/src/main/java/in/testpress/course/ui/QuizActivity.kt
@@ -21,7 +21,6 @@ import android.app.Dialog
 import android.graphics.Color
 import android.os.Bundle
 import android.view.View
-import android.widget.ImageButton
 import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
 import androidx.lifecycle.Observer
@@ -116,8 +115,9 @@ class QuizActivity : BaseToolBarActivity(), ShowQuizHandler, ExamEndHanlder, Que
         toolbar.setTitleTextColor(resources.getColor(R.color.testpress_color_primary))
         supportActionBar!!.setDisplayHomeAsUpEnabled(false)
         showLogoInToolbar()
-        val closeButton = findViewById<ImageButton>(R.id.close)
+        val closeButton = findViewById<TextView>(R.id.close)
         closeButton.visibility = View.VISIBLE
+        closeButton.typeface = TestpressSdk.getRubikMediumFont(this)
         closeButton.setOnClickListener {
             showEndExamAlert()
         }

--- a/course/src/main/res/layout/quiz_container_layout.xml
+++ b/course/src/main/res/layout/quiz_container_layout.xml
@@ -39,16 +39,17 @@
                 android:layout_gravity="center"
                 android:id="@+id/question_number" />
 
-            <ImageButton
+            <TextView
+                android:id="@+id/close"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:id="@+id/close"
-                android:layout_gravity="right|end"
-                android:background="@drawable/testpress_transparent"
-                android:tint="@color/testpress_color_primary"
-                android:paddingRight="10dp"
+                android:text="END"
+                android:textSize="16sp"
+                android:layout_marginEnd="16dp"
+                android:layout_gravity="end|right"
+                android:textColor="@color/testpress_color_primary"
                 android:visibility="gone"
-                android:src="@drawable/ic_close_black_24dp"/>
+                android:layout_centerVertical="true" />
         </androidx.appcompat.widget.Toolbar>
 
     </com.google.android.material.appbar.AppBarLayout>


### PR DESCRIPTION
- Previously we used an "Exit" image within the quiz template to conclude the exam. However, in this latest commit, we have substituted it with a "END" text displayed using a TextView.