### PR TITLE
fix: Add show Resume disabled warning before start exam

### DIFF
--- a/core/src/main/java/in/testpress/models/greendao/Exam.java
+++ b/core/src/main/java/in/testpress/models/greendao/Exam.java
@@ -827,6 +827,9 @@ public class Exam implements android.os.Parcelable {
         return enableQuizMode != null && enableQuizMode;
     }
 
+    public boolean isAttemptResumeDisabled() {
+        return disableAttemptResume != null && disableAttemptResume;
+    }
     // KEEP METHODS END
 
 }

--- a/course/src/main/java/in/testpress/course/fragments/BaseExamWidgetFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/BaseExamWidgetFragment.kt
@@ -173,7 +173,7 @@ open class BaseExamWidgetFragment : Fragment() {
             startButton.setOnClickListener {startExamInWebview(content)}
         } else if (contentAttempts.isEmpty()) {
             MultiLanguagesUtil.supportMultiLanguage(requireActivity(), exam.asGreenDaoModel(), startButton) {
-                showExamModesOrStartExam(exam, discardExamDetails = true, isPartial = false)
+                showExamModesOrStartExam(exam, shouldShowExamDetails(exam), isPartial = false)
             }
         } else {
             startButton.setOnClickListener {
@@ -182,6 +182,12 @@ open class BaseExamWidgetFragment : Fragment() {
                 }
             }
         }
+    }
+
+    private fun shouldShowExamDetails(exam: DomainExamContent): Boolean {
+        // If 'isAttemptResumeDisabled' is true, we return false to display the Exam Detail page.
+        // Otherwise, we return false to start the exam without displaying the Exam Detail page.
+        return !exam.isAttemptResumeDisabled()
     }
 
     private fun showExamModesOrStartExam(

--- a/exam/src/main/java/in/testpress/exam/domain/DomainExamContent.kt
+++ b/exam/src/main/java/in/testpress/exam/domain/DomainExamContent.kt
@@ -4,8 +4,7 @@ import `in`.testpress.models.greendao.Exam
 import java.text.DateFormat
 import java.text.ParseException
 import java.text.SimpleDateFormat
-import java.util.Date
-import java.util.TimeZone
+import java.util.*
 
 data class DomainExamContent(
     val id: Long,
@@ -85,6 +84,8 @@ data class DomainExamContent(
     fun hasMultipleLanguages() = languages.size > 1
 
     fun isQuizModeEnabled() = enableQuizMode != null && enableQuizMode == true
+
+    fun isAttemptResumeDisabled() = disableAttemptResume != null && disableAttemptResume
 }
 
 fun createDomainExamContent(exam: Exam): DomainExamContent {

--- a/exam/src/main/java/in/testpress/exam/ui/TestActivity.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestActivity.java
@@ -2,13 +2,16 @@ package in.testpress.exam.ui;
 
 import android.annotation.SuppressLint;
 import android.app.Activity;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
 import androidx.annotation.NonNull;
 import androidx.annotation.StringRes;
+import androidx.appcompat.app.AlertDialog;
 import androidx.loader.app.LoaderManager;
 import androidx.loader.content.Loader;
 
+import android.util.Log;
 import android.view.View;
 import android.widget.Button;
 import android.widget.LinearLayout;
@@ -396,7 +399,7 @@ public class TestActivity extends BaseToolBarActivity implements LoaderManager.L
                     new MultiLanguagesUtil.LanguageSelectionListener() {
                         @Override
                         public void onLanguageSelected() {
-                            startExam(false);
+                            showDisableResumeAttemptAlert();
                         }});
             examDuration.setText(exam.getDuration());
         } else {
@@ -434,6 +437,21 @@ public class TestActivity extends BaseToolBarActivity implements LoaderManager.L
             marksPerQuestionLayout.setVisibility(View.GONE);
             negativeMarksLayout.setVisibility(View.GONE);
         }
+    }
+
+    private void showDisableResumeAttemptAlert() {
+        AlertDialog.Builder builder = new AlertDialog.Builder(this, R.style.TestpressAppCompatAlertDialogStyle);
+        builder.setTitle(R.string.exam_resume_disable_warning_title);
+        builder.setMessage(R.string.exam_resume_disable_warning_description);
+        builder.setPositiveButton("OK", new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+                startExam(false);
+            }
+        });
+        builder.setNegativeButton("Cancel", null);
+        AlertDialog dialog = builder.create();
+        dialog.show();
     }
 
     private void endExam() {

--- a/exam/src/main/java/in/testpress/exam/ui/TestActivity.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestActivity.java
@@ -11,7 +11,6 @@ import androidx.appcompat.app.AlertDialog;
 import androidx.loader.app.LoaderManager;
 import androidx.loader.content.Loader;
 
-import android.util.Log;
 import android.view.View;
 import android.widget.Button;
 import android.widget.LinearLayout;
@@ -399,7 +398,7 @@ public class TestActivity extends BaseToolBarActivity implements LoaderManager.L
                     new MultiLanguagesUtil.LanguageSelectionListener() {
                         @Override
                         public void onLanguageSelected() {
-                            showDisableResumeAttemptAlert();
+                            showResumeDisabledWarningAlertOrStartExam();
                         }});
             examDuration.setText(exam.getDuration());
         } else {
@@ -439,19 +438,23 @@ public class TestActivity extends BaseToolBarActivity implements LoaderManager.L
         }
     }
 
-    private void showDisableResumeAttemptAlert() {
-        AlertDialog.Builder builder = new AlertDialog.Builder(this, R.style.TestpressAppCompatAlertDialogStyle);
-        builder.setTitle(R.string.exam_resume_disable_warning_title);
-        builder.setMessage(R.string.exam_resume_disable_warning_description);
-        builder.setPositiveButton("OK", new DialogInterface.OnClickListener() {
-            @Override
-            public void onClick(DialogInterface dialog, int which) {
-                startExam(false);
-            }
-        });
-        builder.setNegativeButton("Cancel", null);
-        AlertDialog dialog = builder.create();
-        dialog.show();
+    private void showResumeDisabledWarningAlertOrStartExam() {
+        if (exam.isAttemptResumeDisabled()) {
+            AlertDialog.Builder builder = new AlertDialog.Builder(this, R.style.TestpressAppCompatAlertDialogStyle);
+            builder.setTitle(R.string.exam_resume_disable_warning_title);
+            builder.setMessage(R.string.exam_resume_disable_warning_description);
+            builder.setPositiveButton("OK", new DialogInterface.OnClickListener() {
+                @Override
+                public void onClick(DialogInterface dialog, int which) {
+                    startExam(false);
+                }
+            });
+            builder.setNegativeButton("Cancel", null);
+            AlertDialog dialog = builder.create();
+            dialog.show();
+        } else {
+            startExam(false);
+        }
     }
 
     private void endExam() {

--- a/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
@@ -23,7 +23,6 @@ import androidx.slidingpanelayout.widget.SlidingPaneLayout;
 import androidx.appcompat.app.AlertDialog;
 
 import android.text.Html;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -713,9 +712,7 @@ public class TestFragment extends BaseFragment implements LoaderManager.LoaderCa
         }
         if (progressDialog.isShowing()) {
             progressDialog.dismiss();
-            Log.d("TAG", "progressDialog: 1");
         }
-
         getLoaderManager().destroyLoader(loader.getId());
         //noinspection ThrowableResultOfMethodCallIgnored
         TestpressException exception = ((ThrowableLoader<List<AttemptItem>>) loader).clearException();
@@ -919,7 +916,6 @@ public class TestFragment extends BaseFragment implements LoaderManager.LoaderCa
 
                             if (action.equals(Action.PAUSE)) {
                                 progressDialog.dismiss();
-                                Log.d("TAG", "progressDialog: 2");
                                 returnToHistory();
                             } else if (action.equals(Action.END)) {
                                 endExam();
@@ -929,7 +925,6 @@ public class TestFragment extends BaseFragment implements LoaderManager.LoaderCa
                                 if (progressDialog.isShowing()) {
                                     startCountDownTimer(millisRemaining);
                                     progressDialog.dismiss();
-                                    Log.d("TAG", "progressDialog: 3");
                                 }
                                 updatePanel();
                             }
@@ -942,7 +937,6 @@ public class TestFragment extends BaseFragment implements LoaderManager.LoaderCa
                             }
                             if (action.equals(Action.PAUSE)) {
                                 progressDialog.dismiss();
-                                Log.d("TAG", "progressDialog: 4");
                                 returnToHistory();
                                 return;
                             }
@@ -953,11 +947,9 @@ public class TestFragment extends BaseFragment implements LoaderManager.LoaderCa
                                 clearAndLoadSameQuestion(position);
                                 saveAnswerAlertDialog = showMaxQuestionsAttemptedError(errorDetails);
                                 progressDialog.dismiss();
-                                Log.d("TAG", "progressDialog: 5");
                             } else {
                                 stopTimer();
                                 progressDialog.dismiss();
-                                Log.d("TAG", "progressDialog: 6");
                                 TestEngineAlertDialog alertDialog = new TestEngineAlertDialog(exception) {
                                     @Override
                                     protected void onRetry() {
@@ -973,7 +965,6 @@ public class TestFragment extends BaseFragment implements LoaderManager.LoaderCa
                     });
         } else if (action.equals(Action.PAUSE)) {
             progressDialog.dismiss();
-            Log.d("TAG", "progressDialog: 7");
             returnToHistory();
         }
     }
@@ -1115,7 +1106,6 @@ public class TestFragment extends BaseFragment implements LoaderManager.LoaderCa
                             logEvent(EventsTrackerFacade.ENDED_EXAM);
                             if (progressDialog.isShowing()) {
                                 progressDialog.dismiss();
-                                Log.d("TAG", "progressDialog: 8");
                             }
                             courseAttempt.saveInDB(getActivity(), courseContent);
                             showReview(ReviewStatsActivity.createIntent(getActivity(), exam,
@@ -1143,7 +1133,6 @@ public class TestFragment extends BaseFragment implements LoaderManager.LoaderCa
                             logEvent(EventsTrackerFacade.ENDED_EXAM);
                             if (progressDialog.isShowing()) {
                                 progressDialog.dismiss();
-                                Log.d("TAG", "progressDialog: 9");
                             }
                             TestFragment.this.attempt = attempt;
                             showReview(attempt);
@@ -1471,7 +1460,6 @@ public class TestFragment extends BaseFragment implements LoaderManager.LoaderCa
                         TestFragment.this.attempt = attempt;
                         sections = attempt.getSections();
                         progressDialog.dismiss();
-                        Log.d("TAG", "progressDialog: 10");
                         startCountDownTimer();
                     }
 
@@ -1481,7 +1469,6 @@ public class TestFragment extends BaseFragment implements LoaderManager.LoaderCa
                             return;
                         }
                         progressDialog.dismiss();
-                        Log.d("TAG", "progressDialog: 11");
                         TestEngineAlertDialog alertDialogBuilder = new TestEngineAlertDialog(exception) {
                             @Override
                             protected void onRetry() {

--- a/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
@@ -716,10 +716,6 @@ public class TestFragment extends BaseFragment implements LoaderManager.LoaderCa
             Log.d("TAG", "progressDialog: 1");
         }
 
-        if (true) {
-            showDisableResumeAttemptAlert();
-        }
-
         getLoaderManager().destroyLoader(loader.getId());
         //noinspection ThrowableResultOfMethodCallIgnored
         TestpressException exception = ((ThrowableLoader<List<AttemptItem>>) loader).clearException();
@@ -811,16 +807,6 @@ public class TestFragment extends BaseFragment implements LoaderManager.LoaderCa
 
         questionsListProgressBar.setVisibility(View.GONE);
         isNextPageQuestionsBeingFetched = false;
-    }
-
-    private void showDisableResumeAttemptAlert() {
-        AlertDialog.Builder builder = new AlertDialog.Builder(requireContext(), R.style.TestpressAppCompatAlertDialogStyle);
-        builder.setTitle(R.string.exam_resume_disable_warning_title);
-        builder.setMessage(R.string.exam_resume_disable_warning_description);
-        builder.setPositiveButton("OK", null);
-        builder.setNegativeButton("Cancel", null);
-        AlertDialog dialog = builder.create();
-        dialog.show();
     }
 
     private void initializeSectionSpinner() {

--- a/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
@@ -23,6 +23,7 @@ import androidx.slidingpanelayout.widget.SlidingPaneLayout;
 import androidx.appcompat.app.AlertDialog;
 
 import android.text.Html;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -712,7 +713,13 @@ public class TestFragment extends BaseFragment implements LoaderManager.LoaderCa
         }
         if (progressDialog.isShowing()) {
             progressDialog.dismiss();
+            Log.d("TAG", "progressDialog: 1");
         }
+
+        if (true) {
+            showDisableResumeAttemptAlert();
+        }
+
         getLoaderManager().destroyLoader(loader.getId());
         //noinspection ThrowableResultOfMethodCallIgnored
         TestpressException exception = ((ThrowableLoader<List<AttemptItem>>) loader).clearException();
@@ -804,6 +811,16 @@ public class TestFragment extends BaseFragment implements LoaderManager.LoaderCa
 
         questionsListProgressBar.setVisibility(View.GONE);
         isNextPageQuestionsBeingFetched = false;
+    }
+
+    private void showDisableResumeAttemptAlert() {
+        AlertDialog.Builder builder = new AlertDialog.Builder(requireContext(), R.style.TestpressAppCompatAlertDialogStyle);
+        builder.setTitle(R.string.exam_resume_disable_warning_title);
+        builder.setMessage(R.string.exam_resume_disable_warning_description);
+        builder.setPositiveButton("OK", null);
+        builder.setNegativeButton("Cancel", null);
+        AlertDialog dialog = builder.create();
+        dialog.show();
     }
 
     private void initializeSectionSpinner() {
@@ -916,6 +933,7 @@ public class TestFragment extends BaseFragment implements LoaderManager.LoaderCa
 
                             if (action.equals(Action.PAUSE)) {
                                 progressDialog.dismiss();
+                                Log.d("TAG", "progressDialog: 2");
                                 returnToHistory();
                             } else if (action.equals(Action.END)) {
                                 endExam();
@@ -925,6 +943,7 @@ public class TestFragment extends BaseFragment implements LoaderManager.LoaderCa
                                 if (progressDialog.isShowing()) {
                                     startCountDownTimer(millisRemaining);
                                     progressDialog.dismiss();
+                                    Log.d("TAG", "progressDialog: 3");
                                 }
                                 updatePanel();
                             }
@@ -937,6 +956,7 @@ public class TestFragment extends BaseFragment implements LoaderManager.LoaderCa
                             }
                             if (action.equals(Action.PAUSE)) {
                                 progressDialog.dismiss();
+                                Log.d("TAG", "progressDialog: 4");
                                 returnToHistory();
                                 return;
                             }
@@ -947,9 +967,11 @@ public class TestFragment extends BaseFragment implements LoaderManager.LoaderCa
                                 clearAndLoadSameQuestion(position);
                                 saveAnswerAlertDialog = showMaxQuestionsAttemptedError(errorDetails);
                                 progressDialog.dismiss();
+                                Log.d("TAG", "progressDialog: 5");
                             } else {
                                 stopTimer();
                                 progressDialog.dismiss();
+                                Log.d("TAG", "progressDialog: 6");
                                 TestEngineAlertDialog alertDialog = new TestEngineAlertDialog(exception) {
                                     @Override
                                     protected void onRetry() {
@@ -965,6 +987,7 @@ public class TestFragment extends BaseFragment implements LoaderManager.LoaderCa
                     });
         } else if (action.equals(Action.PAUSE)) {
             progressDialog.dismiss();
+            Log.d("TAG", "progressDialog: 7");
             returnToHistory();
         }
     }
@@ -1106,6 +1129,7 @@ public class TestFragment extends BaseFragment implements LoaderManager.LoaderCa
                             logEvent(EventsTrackerFacade.ENDED_EXAM);
                             if (progressDialog.isShowing()) {
                                 progressDialog.dismiss();
+                                Log.d("TAG", "progressDialog: 8");
                             }
                             courseAttempt.saveInDB(getActivity(), courseContent);
                             showReview(ReviewStatsActivity.createIntent(getActivity(), exam,
@@ -1133,6 +1157,7 @@ public class TestFragment extends BaseFragment implements LoaderManager.LoaderCa
                             logEvent(EventsTrackerFacade.ENDED_EXAM);
                             if (progressDialog.isShowing()) {
                                 progressDialog.dismiss();
+                                Log.d("TAG", "progressDialog: 9");
                             }
                             TestFragment.this.attempt = attempt;
                             showReview(attempt);
@@ -1460,6 +1485,7 @@ public class TestFragment extends BaseFragment implements LoaderManager.LoaderCa
                         TestFragment.this.attempt = attempt;
                         sections = attempt.getSections();
                         progressDialog.dismiss();
+                        Log.d("TAG", "progressDialog: 10");
                         startCountDownTimer();
                     }
 
@@ -1469,6 +1495,7 @@ public class TestFragment extends BaseFragment implements LoaderManager.LoaderCa
                             return;
                         }
                         progressDialog.dismiss();
+                        Log.d("TAG", "progressDialog: 11");
                         TestEngineAlertDialog alertDialogBuilder = new TestEngineAlertDialog(exception) {
                             @Override
                             protected void onRetry() {

--- a/exam/src/main/res/values/strings.xml
+++ b/exam/src/main/res/values/strings.xml
@@ -242,6 +242,10 @@
     <string name="testpress_attempt_sections_in_order">You need to attempt sections in order.</string>
     <string name="testpress_end_section">End current section</string>
 
+    <string name="exam_resume_disable_warning_description">Before you proceed, please be aware:\n\n<b>DO NOT CLOSE THIS APP:</b> Once you begin your exam, if you close or navigate away from this app, you will NOT be able to resume your attempt.\n\n<b>RESUME IS DISABLED:</b> The admin has disabled the resume feature for this exam. Once closed, your attempt will be permanently ended.\n\nEnsure you are ready to take the exam without interruptions. Double-check your internet connection and ensure your device is plugged in or adequately charged.</string>
+
+    <string name="exam_resume_disable_warning_title">"IMPORTANT NOTICE!"</string>
+
     <string name="testpress_retake_with">Retake with?</string>
     <string-array name="testpress_retake_options">
         <item>All Questions</item>

--- a/exam/src/main/res/values/strings.xml
+++ b/exam/src/main/res/values/strings.xml
@@ -242,7 +242,7 @@
     <string name="testpress_attempt_sections_in_order">You need to attempt sections in order.</string>
     <string name="testpress_end_section">End current section</string>
 
-    <string name="exam_resume_disable_warning_description">Before you proceed, please be aware:\n\n<b>DO NOT CLOSE THIS APP:</b> Once you begin your exam, if you close or navigate away from this app, you will NOT be able to resume your attempt.\n\n<b>RESUME IS DISABLED:</b> The admin has disabled the resume feature for this exam. Once closed, your attempt will be permanently ended.\n\nEnsure you are ready to take the exam without interruptions. Double-check your internet connection and ensure your device is plugged in or adequately charged.</string>
+    <string name="exam_resume_disable_warning_description">Before you proceed, please be aware:\n\n<b>DO NOT CLOSE THIS APP:</b> Once you begin your exam, if you close or navigate away from this app, you will NOT be able to resume your attempt.\n\n<b>RESUME IS DISABLED:</b> The admin has disabled the resume feature for this exam. Once closed, your attempt will be permanently ended.\n\nEnsure you are ready to take the exam without interruptions. Double-check your internet connection and make sure your device has sufficient power.</string>
 
     <string name="exam_resume_disable_warning_title">"IMPORTANT NOTICE!"</string>
 


### PR DESCRIPTION
- In this commit, we are added to show a warning alert to the user before starting the exam if the attempt resume is disabled