### PR TITLE
fix: Show Exam end alert when user try to close or submit the exam

### DIFF
--- a/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
@@ -621,7 +621,7 @@ public class TestFragment extends BaseFragment implements LoaderManager.LoaderCa
     }
 
     private void endExamAlert() {
-        if (exam == null){
+        if (exam == null || exam.isAttemptResumeDisabled()){
             showEndExamAlert();
         } else {
             AlertDialog.Builder dialogBuilder =
@@ -654,6 +654,10 @@ public class TestFragment extends BaseFragment implements LoaderManager.LoaderCa
     }
 
     void showPauseExamAlert() {
+        if (exam.isAttemptResumeDisabled()) {
+            showEndExamAlert();
+            return;
+        }
         pauseExamAlertDialog =
                 new AlertDialog.Builder(getActivity(), R.style.TestpressAppCompatAlertDialogStyle)
                         .setMessage(R.string.testpress_pause_message)


### PR DESCRIPTION
- In this commit, we added a show exam end alert box when the user tries to close or submit the exam if the `disableAttemptResume` field is true in the exam.
