### PR TITLE
fix: User able to access embed video content after its views limit exhausted

### DIFF
--- a/core/src/main/java/in/testpress/fragments/EmptyViewFragment.kt
+++ b/core/src/main/java/in/testpress/fragments/EmptyViewFragment.kt
@@ -14,6 +14,7 @@ import android.widget.Button
 import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.TextView
+import androidx.core.view.isVisible
 import org.json.JSONException
 import org.json.JSONObject
 
@@ -136,6 +137,15 @@ class EmptyViewFragment : Fragment() {
         setEmptyText(R.string.testpress_error_loading_contents,
                 R.string.testpress_some_thing_went_wrong_try_again,
                 R.drawable.ic_error_outline_black_18dp)
+    }
+
+    fun showViewsExhaustedMessage(){
+        setEmptyText(
+            R.string.video_id_locked,
+            R.string.testpress_views_exhausted,
+            R.drawable.ic_error_outline_black_18dp
+        )
+        retryButton.isVisible = false
     }
 
     fun setEmptyText(title: Int, description : Int, leftDrawable: Int?) {

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -19,6 +19,8 @@
     <string name="testpress_error_loading_contents">Loading contents failed</string>
     <string name="testpress_content_not_available">Content not available</string>
     <string name="testpress_content_not_available_description">Content is no longer available or not published yet.</string>
+    <string name="video_id_locked"> This Video is locked!</string>
+    <string name="testpress_views_exhausted">You\'ve exhausted your views limit for this content. Contact your administrator for further information.</string>
 
     <string name="testpress_ok">OK</string>
     <string name="testpress_cancel">Cancel</string>

--- a/course/src/main/java/in/testpress/course/fragments/ContentLoadingFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/ContentLoadingFragment.kt
@@ -1,5 +1,6 @@
 package `in`.testpress.course.fragments
 
+import `in`.testpress.core.TestpressSDKDatabase
 import `in`.testpress.course.R
 import `in`.testpress.course.TestpressCourse.PRODUCT_SLUG
 import `in`.testpress.course.domain.DomainContent
@@ -9,6 +10,9 @@ import `in`.testpress.course.ui.ContentActivity.CONTENT_ID
 import `in`.testpress.course.viewmodels.ContentViewModel
 import `in`.testpress.fragments.EmptyViewFragment
 import `in`.testpress.fragments.EmptyViewListener
+import `in`.testpress.models.greendao.CourseAttempt
+import `in`.testpress.models.greendao.CourseAttemptDao
+import `in`.testpress.models.greendao.CourseDao
 import android.content.Context
 import android.os.Bundle
 import android.view.LayoutInflater
@@ -92,12 +96,20 @@ class ContentLoadingFragment : Fragment(),
         if(content.isLocked == true) return false
         return when(content.contentType) {
             "Exam" -> (content.exam != null) && (content.attemptsUrl != null)
-            "Video" -> content.video != null
+            "Video" -> content.video != null && !hasCourseVideoViewsLimit(content)
             "Attachment" -> content.attachment != null
             "Html", "Notes" -> content.htmlContent != null
             "Quiz" -> content.exam != null
             else -> true
         }
+    }
+
+    private fun hasCourseVideoViewsLimit(content: DomainContent): Boolean {
+        val courseDao = TestpressSDKDatabase.getCourseDao(requireContext())
+        val course =
+            courseDao.queryBuilder().where(CourseDao.Properties.Id.eq(content.courseId)).list()
+        val maxAllowedViewsPerVideo: Int? = course[0].maxAllowedViewsPerVideo
+        return maxAllowedViewsPerVideo != null && maxAllowedViewsPerVideo > 0
     }
 
     private fun refetchContent(id: Long) {

--- a/course/src/main/java/in/testpress/course/fragments/VideoContentFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/VideoContentFragment.kt
@@ -194,6 +194,11 @@ class VideoContentFragment : BaseContentDetailFragment() {
     }
 
     override fun display() {
+        if (content.video?.isViewsExhausted == true) {
+            emptyViewFragment.showViewsExhaustedMessage()
+            setHasOptionsMenu(false)
+            return
+        }
         titleView.text = content.title
         videoWidgetFragment = VideoWidgetFragmentFactory.getWidget(content.video!!)
         videoWidgetFragment.arguments = arguments


### PR DESCRIPTION
- This problem has been addressed on the web, and we are currently implementing a similar fix in the Android app.
- When a user attempts to access a video content, we first verify whether the course has a video view limit, and if it does, we refresh the content detail view.
- After the content detail view finishes loading, we will use the `isViewsExhausted` field to display an error page indicating that the views limit has been reached.