### PR TITLE
fix: Add 50-50 helpline option in quiz template

### DIFF
--- a/core/src/main/assets/testpress_questions_typebase.css
+++ b/core/src/main/assets/testpress_questions_typebase.css
@@ -495,3 +495,15 @@ video {
 .upload-button, .clear-upload-button {
     margin-top: 10px;
 }
+
+.helpline-button {
+    display: block;
+    width: 100%;
+    margin-top: 10px;
+    background: #fff;
+    color: #777;
+    border: 1px solid #777;
+    border-radius: 12px;
+    font-size: 12px;
+    padding: 3xp 8xp;
+}

--- a/course/src/main/java/in/testpress/course/fragments/QuizQuestionFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/QuizQuestionFragment.kt
@@ -148,6 +148,7 @@ class QuizQuestionFragment : Fragment() {
     }
 
     private fun get5050Options(answers: List<DomainAnswer>?): String {
+        val incorrectAnswers= getIncorrectAnswerIndices(answers)
         return """
         <div style="display: flex; flex-direction: column; justify-content: space-between;">
             <img src="https://static.testpress.in/static/img/5050.svg" alt="Image 1" style="width: 75px !important; height: 75px !important;">
@@ -156,7 +157,7 @@ class QuizQuestionFragment : Fragment() {
                 function hideHalfOptions() {
                     var optionsTable = document.getElementById('optionsTable');
                     var optionsRows = optionsTable.getElementsByTagName('tr');
-                    ${getIncorrectAnswerIndices(answers).joinToString("\n    ") { "optionsRows[$it].style.display = 'none';" }}
+                    ${incorrectAnswers.joinToString("\n    ") { "optionsRows[$it].style.display = 'none';" }}
                 }
             </script>
         </div>

--- a/course/src/main/java/in/testpress/course/fragments/QuizQuestionFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/QuizQuestionFragment.kt
@@ -5,6 +5,7 @@ import `in`.testpress.course.R
 import `in`.testpress.enums.Status
 import `in`.testpress.course.repository.QuizQuestionsRepository
 import `in`.testpress.course.viewmodels.QuizViewModel
+import `in`.testpress.exam.domain.DomainAnswer
 import `in`.testpress.exam.domain.DomainUserSelectedAnswer
 import `in`.testpress.exam.ui.view.WebView
 import `in`.testpress.models.InstituteSettings
@@ -111,7 +112,7 @@ class QuizQuestionFragment : Fragment() {
         htmlContent += "<div class='question' style='padding-bottom: 10px;'> ${question.questionHtml} </div></div>"
         if (question.type == "R" || question.type == "C") {
             // Add options
-            htmlContent += "<table width='100%' style='margin-top:0px; margin-bottom:20px; font-size:calc(12px + 1.5vw);'>"
+            htmlContent += "<table id='optionsTable' width='100%' style='margin-top:0px; margin-bottom:20px; font-size:calc(12px + 1.5vw);'>"
             for (answer in question.answers ?: listOf()) {
                 htmlContent += if (question.isSingleMCQType) {
                     "\n" + WebViewUtils.getRadioButtonOptionWithTags(
@@ -130,9 +131,60 @@ class QuizQuestionFragment : Fragment() {
             htmlContent += "<input class='edit_box' type='text' onpaste='return false'" +
                 "value='' oninput='onValueChange(this)' placeholder='YOUR ANSWER'>"
         }
+
+        // Add 50-50 helpline button
+        htmlContent += "<button id='changeOptionsButton' onclick='hideExtraOptions()'>Change Options</button>" +
+                "<script>\n" +
+                "    function hideExtraOptions() {\n" +
+                "        var optionsTable = document.getElementById('optionsTable');\n" +
+                "        var optionsRows = optionsTable.getElementsByTagName('tr');\n" +
+                get5050Options(question.answers) +
+                "    }\n" +
+                "</script>"
+
+        htmlContent += "    <table id=\"helplinesTable\" border=\"0\" style=\"width: 100%; height: 100px; border-collapse: collapse;\">\n" +
+                "        <tr>\n" +
+                "            <td>\n" +
+                "                <div style=\"text-align: center;\">\n" +
+                "                    <img src=\"https://static.testpress.in/static/img/5050.svg\" width=\"50\" height=\"50\">\n" +
+                "                    <br>\n" +
+                "                    <button style=\"display: block; margin: 0 auto;\">50/50</button>\n" +
+                "                </div>\n" +
+                "            </td>\n" +
+                "            <td>\n" +
+                "                <div style=\"text-align: center;\">\n" +
+                "                    <img src=\"https://static.testpress.in/static/img/5050.svg\" width=\"50\" height=\"50\">\n" +
+                "                    <br>\n" +
+                "                    <button style=\"display: block; margin: 0 auto;\">50/50</button>\n" +
+                "                </div>\n" +
+                "            </td>\n" +
+                "            <td>\n" +
+                "                <div style=\"text-align: center;\">\n" +
+                "                    <img src=\"https://static.testpress.in/static/img/5050.svg\" width=\"50\" height=\"50\">\n" +
+                "                    <br>\n" +
+                "                    <button style=\"display: block; margin: 0 auto;\">50/50</button>\n" +
+                "                </div>\n" +
+                "            </td>\n" +
+                "        </tr>\n" +
+                "    </table>\n"
+
         htmlContent += "</div>"
 
         return htmlContent
+    }
+
+    private fun get5050Options(answers: List<DomainAnswer>?) :String {
+        val halfOptions = answers?.size!! / 2
+        val incorrectIndices = answers.indices
+            .filter { answers[it].isCorrect == false }
+            .shuffled()
+            .take(halfOptions)
+            .sortedDescending()
+        var hideWrongOptionScript = ""
+        for (index in incorrectIndices){
+            hideWrongOptionScript += "optionsRows[$index].style.display = 'none';"
+        }
+        return hideWrongOptionScript
     }
 
     inner class OptionsSelectionListener {

--- a/course/src/main/java/in/testpress/course/fragments/QuizQuestionFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/QuizQuestionFragment.kt
@@ -135,29 +135,29 @@ class QuizQuestionFragment : Fragment() {
 
         htmlContent += "</div>"
 
-        // Add 50-50 helpline button
-        htmlContent += "<button id='changeOptionsButton' onclick='hideExtraOptions()'>Change Options</button>" +
-                "<script>\n" +
-                "    function hideExtraOptions() {\n" +
-                "        var optionsTable = document.getElementById('optionsTable');\n" +
-                "        var optionsRows = optionsTable.getElementsByTagName('tr');\n" +
-                get5050Options(question.answers) +
-                "    }\n" +
-                "</script>"
+//        // Add 50-50 helpline button
+//        htmlContent += "<button id='changeOptionsButton' onclick='hideExtraOptions()'>Change Options</button>" +
+//                "<script>\n" +
+//                "    function hideExtraOptions() {\n" +
+//                "        var optionsTable = document.getElementById('optionsTable');\n" +
+//                "        var optionsRows = optionsTable.getElementsByTagName('tr');\n" +
+//                get5050Options(question.answers) +
+//                "    }\n" +
+//                "</script>"
 
         // Add Helpline options
         htmlContent += "<div style=\" display: flex; flex-direction: row; align-items: center; justify-content: space-around;\">\n" +
-                "        <div style=\"display: flex; flex-direction: column; justify-content: space-between; padding: 0 20px 0 20px;\">\n" +
+                "        <div style=\"display: flex; flex-direction: column; justify-content: space-between;\">\n" +
                 "            <img src=\"https://static.testpress.in/static/img/5050.svg\" alt=\"Image 1\" style=\"width: 75px !important; height: 75px !important;\">\n" +
-                "            <button>50/50</button>\n" +
+                "            <button class ='helpline-button'>50/50</button>\n" +
                 "        </div>\n" +
-                "        <div style=\"display: flex; flex-direction: column; justify-content: space-between; padding: 0 20px 0 20px;\">\n" +
-                "            <img src=\"https://static.testpress.in/static/img/5050.svg\" alt=\"Image 2\" style=\"width: 75px !important; height: 75px !important;\">\n" +
-                "            <button>AUDIENCE</button>\n" +
+                "        <div style=\"display: flex; flex-direction: column; justify-content: space-between;\">\n" +
+                "            <img src=\"https://static.testpress.in/static/img/bar-chart.svg\" alt=\"Image 2\" style=\"width: 75px !important; height: 75px !important;\">\n" +
+                "            <button class ='helpline-button'>AUDIENCE</button>\n" +
                 "        </div>\n" +
-                "        <div style=\"display: flex; flex-direction: column; justify-content: space-between; padding: 0 20px 0 20px;\">\n" +
-                "            <img src=\"https://static.testpress.in/static/img/5050.svg\" alt=\"Image 3\" style=\"width: 75px !important; height: 75px !important;\">\n" +
-                "            <button>SKIP</button>\n" +
+                "        <div style=\"display: flex; flex-direction: column; justify-content: space-between;\">\n" +
+                "            <img src=\"https://static.testpress.in/static/img/skip.svg\" alt=\"Image 3\" style=\"width: 75px !important; height: 75px !important;\">\n" +
+                "            <button class ='helpline-button'>SKIP</button>\n" +
                 "        </div>\n" +
                 "    </div>\n"
 

--- a/course/src/main/java/in/testpress/course/fragments/QuizQuestionFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/QuizQuestionFragment.kt
@@ -153,24 +153,17 @@ class QuizQuestionFragment : Fragment() {
             <img src="https://static.testpress.in/static/img/5050.svg" alt="Image 1" style="width: 75px !important; height: 75px !important;">
             <button class='helpline-button' onclick='hideHalfOptions()'>50/50</button>
             <script>
-                ${getHideHalfOptionsScript(answers)}
+                function hideHalfOptions() {
+                    var optionsTable = document.getElementById('optionsTable');
+                    var optionsRows = optionsTable.getElementsByTagName('tr');
+                    ${getIncorrectAnswerIndices(answers).joinToString("\n    ") { "optionsRows[$it].style.display = 'none';" }}
+                }
             </script>
         </div>
     """
     }
 
-    private fun getHideHalfOptionsScript(answers: List<DomainAnswer>?): String {
-        val incorrectIndices = getIncorrectIndices(answers)
-        return """
-        |function hideHalfOptions() {
-        |    var optionsTable = document.getElementById('optionsTable');
-        |    var optionsRows = optionsTable.getElementsByTagName('tr');
-        |    ${incorrectIndices.joinToString("\n    ") { "optionsRows[$it].style.display = 'none';" }}
-        |}
-    """.trimMargin()
-    }
-
-    private fun getIncorrectIndices(answers: List<DomainAnswer>?): List<Int> {
+    private fun getIncorrectAnswerIndices(answers: List<DomainAnswer>?): List<Int> {
         val halfOptions = answers?.size!! / 2
         return answers.indices
             .filter { answers[it].isCorrect == false }

--- a/course/src/main/java/in/testpress/course/fragments/QuizQuestionFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/QuizQuestionFragment.kt
@@ -11,6 +11,7 @@ import `in`.testpress.exam.ui.view.WebView
 import `in`.testpress.models.InstituteSettings
 import `in`.testpress.util.WebViewUtils
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -132,6 +133,8 @@ class QuizQuestionFragment : Fragment() {
                 "value='' oninput='onValueChange(this)' placeholder='YOUR ANSWER'>"
         }
 
+        htmlContent += "</div>"
+
         // Add 50-50 helpline button
         htmlContent += "<button id='changeOptionsButton' onclick='hideExtraOptions()'>Change Options</button>" +
                 "<script>\n" +
@@ -142,33 +145,21 @@ class QuizQuestionFragment : Fragment() {
                 "    }\n" +
                 "</script>"
 
-        htmlContent += "    <table id=\"helplinesTable\" border=\"0\" style=\"width: 100%; height: 100px; border-collapse: collapse;\">\n" +
-                "        <tr>\n" +
-                "            <td>\n" +
-                "                <div style=\"text-align: center;\">\n" +
-                "                    <img src=\"https://static.testpress.in/static/img/5050.svg\" width=\"50\" height=\"50\">\n" +
-                "                    <br>\n" +
-                "                    <button style=\"display: block; margin: 0 auto;\">50/50</button>\n" +
-                "                </div>\n" +
-                "            </td>\n" +
-                "            <td>\n" +
-                "                <div style=\"text-align: center;\">\n" +
-                "                    <img src=\"https://static.testpress.in/static/img/5050.svg\" width=\"50\" height=\"50\">\n" +
-                "                    <br>\n" +
-                "                    <button style=\"display: block; margin: 0 auto;\">50/50</button>\n" +
-                "                </div>\n" +
-                "            </td>\n" +
-                "            <td>\n" +
-                "                <div style=\"text-align: center;\">\n" +
-                "                    <img src=\"https://static.testpress.in/static/img/5050.svg\" width=\"50\" height=\"50\">\n" +
-                "                    <br>\n" +
-                "                    <button style=\"display: block; margin: 0 auto;\">50/50</button>\n" +
-                "                </div>\n" +
-                "            </td>\n" +
-                "        </tr>\n" +
-                "    </table>\n"
-
-        htmlContent += "</div>"
+        // Add Helpline options
+        htmlContent += "<div style=\" display: flex; flex-direction: row; align-items: center; justify-content: space-around;\">\n" +
+                "        <div style=\"display: flex; flex-direction: column; justify-content: space-between; padding: 0 20px 0 20px;\">\n" +
+                "            <img src=\"https://static.testpress.in/static/img/5050.svg\" alt=\"Image 1\" style=\"width: 75px !important; height: 75px !important;\">\n" +
+                "            <button>50/50</button>\n" +
+                "        </div>\n" +
+                "        <div style=\"display: flex; flex-direction: column; justify-content: space-between; padding: 0 20px 0 20px;\">\n" +
+                "            <img src=\"https://static.testpress.in/static/img/5050.svg\" alt=\"Image 2\" style=\"width: 75px !important; height: 75px !important;\">\n" +
+                "            <button>AUDIENCE</button>\n" +
+                "        </div>\n" +
+                "        <div style=\"display: flex; flex-direction: column; justify-content: space-between; padding: 0 20px 0 20px;\">\n" +
+                "            <img src=\"https://static.testpress.in/static/img/5050.svg\" alt=\"Image 3\" style=\"width: 75px !important; height: 75px !important;\">\n" +
+                "            <button>SKIP</button>\n" +
+                "        </div>\n" +
+                "    </div>\n"
 
         return htmlContent
     }

--- a/course/src/main/java/in/testpress/course/fragments/QuizQuestionFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/QuizQuestionFragment.kt
@@ -11,7 +11,6 @@ import `in`.testpress.exam.ui.view.WebView
 import `in`.testpress.models.InstituteSettings
 import `in`.testpress.util.WebViewUtils
 import android.os.Bundle
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -132,7 +131,6 @@ class QuizQuestionFragment : Fragment() {
             htmlContent += "<input class='edit_box' type='text' onpaste='return false'" +
                 "value='' oninput='onValueChange(this)' placeholder='YOUR ANSWER'>"
         }
-
         htmlContent += "</div>"
 
         // Add Helpline options

--- a/course/src/main/java/in/testpress/course/fragments/QuizQuestionFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/QuizQuestionFragment.kt
@@ -135,47 +135,50 @@ class QuizQuestionFragment : Fragment() {
 
         htmlContent += "</div>"
 
-//        // Add 50-50 helpline button
-//        htmlContent += "<button id='changeOptionsButton' onclick='hideExtraOptions()'>Change Options</button>" +
-//                "<script>\n" +
-//                "    function hideExtraOptions() {\n" +
-//                "        var optionsTable = document.getElementById('optionsTable');\n" +
-//                "        var optionsRows = optionsTable.getElementsByTagName('tr');\n" +
-//                get5050Options(question.answers) +
-//                "    }\n" +
-//                "</script>"
-
         // Add Helpline options
-        htmlContent += "<div style=\" display: flex; flex-direction: row; align-items: center; justify-content: space-around;\">\n" +
-                "        <div style=\"display: flex; flex-direction: column; justify-content: space-between;\">\n" +
-                "            <img src=\"https://static.testpress.in/static/img/5050.svg\" alt=\"Image 1\" style=\"width: 75px !important; height: 75px !important;\">\n" +
-                "            <button class ='helpline-button'>50/50</button>\n" +
-                "        </div>\n" +
-                "        <div style=\"display: flex; flex-direction: column; justify-content: space-between;\">\n" +
-                "            <img src=\"https://static.testpress.in/static/img/bar-chart.svg\" alt=\"Image 2\" style=\"width: 75px !important; height: 75px !important;\">\n" +
-                "            <button class ='helpline-button'>AUDIENCE</button>\n" +
-                "        </div>\n" +
-                "        <div style=\"display: flex; flex-direction: column; justify-content: space-between;\">\n" +
-                "            <img src=\"https://static.testpress.in/static/img/skip.svg\" alt=\"Image 3\" style=\"width: 75px !important; height: 75px !important;\">\n" +
-                "            <button class ='helpline-button'>SKIP</button>\n" +
-                "        </div>\n" +
-                "    </div>\n"
+        htmlContent += getHelplineOptions(question.answers)
 
         return htmlContent
     }
 
-    private fun get5050Options(answers: List<DomainAnswer>?) :String {
+    private fun getHelplineOptions(answers: List<DomainAnswer>?): String {
+        return """
+        <div style="display: flex; flex-direction: row; align-items: center; justify-content: space-around;">
+            ${get5050Options(answers)}
+        </div>
+    """
+    }
+
+    private fun get5050Options(answers: List<DomainAnswer>?): String {
+        return """
+        <div style="display: flex; flex-direction: column; justify-content: space-between;">
+            <img src="https://static.testpress.in/static/img/5050.svg" alt="Image 1" style="width: 75px !important; height: 75px !important;">
+            <button class='helpline-button' onclick='hideHalfOptions()'>50/50</button>
+            <script>
+                ${getHideHalfOptionsScript(answers)}
+            </script>
+        </div>
+    """
+    }
+
+    private fun getHideHalfOptionsScript(answers: List<DomainAnswer>?): String {
+        val incorrectIndices = getIncorrectIndices(answers)
+        return """
+        |function hideHalfOptions() {
+        |    var optionsTable = document.getElementById('optionsTable');
+        |    var optionsRows = optionsTable.getElementsByTagName('tr');
+        |    ${incorrectIndices.joinToString("\n    ") { "optionsRows[$it].style.display = 'none';" }}
+        |}
+    """.trimMargin()
+    }
+
+    private fun getIncorrectIndices(answers: List<DomainAnswer>?): List<Int> {
         val halfOptions = answers?.size!! / 2
-        val incorrectIndices = answers.indices
+        return answers.indices
             .filter { answers[it].isCorrect == false }
             .shuffled()
             .take(halfOptions)
             .sortedDescending()
-        var hideWrongOptionScript = ""
-        for (index in incorrectIndices){
-            hideWrongOptionScript += "optionsRows[$index].style.display = 'none';"
-        }
-        return hideWrongOptionScript
     }
 
     inner class OptionsSelectionListener {


### PR DESCRIPTION
 - This commit introduces a 50-50 helpline option to the quiz template. We're incorporating this feature into the Android app to align with its existing availability on the web quiz template.
 - When a user clicks the 50-50 button we remove half of the options in the choice list