### PR TITLE
fix: Add skip helpline option in quiz template

### DIFF
--- a/course/src/main/java/in/testpress/course/fragments/QuizQuestionFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/QuizQuestionFragment.kt
@@ -27,7 +27,7 @@ class QuizQuestionFragment : Fragment() {
     private lateinit var webViewUtils: WebViewUtils
     lateinit var viewModel: QuizViewModel
     private lateinit var userSelectedAnswer: DomainUserSelectedAnswer
-    lateinit var quizSkipListener: QuizSkipListener
+    lateinit var quizOperationsCallback: QuizOperationsCallback
     private lateinit var instituteSettings: InstituteSettings
 
     private var examId: Long = -1
@@ -204,11 +204,11 @@ class QuizQuestionFragment : Fragment() {
 
         @JavascriptInterface
         fun onSkip() {
-            quizSkipListener.onSkip()
+            quizOperationsCallback.onSkip()
         }
     }
 }
 
-interface QuizSkipListener {
+interface QuizOperationsCallback {
     fun onSkip()
 }

--- a/course/src/main/java/in/testpress/course/fragments/QuizQuestionFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/QuizQuestionFragment.kt
@@ -142,6 +142,7 @@ class QuizQuestionFragment : Fragment() {
         return """
         <div style="display: flex; flex-direction: row; align-items: center; justify-content: space-around;">
             ${get5050Options(answers)}
+            ${getSkipOptions()}
         </div>
     """
     }
@@ -172,6 +173,26 @@ class QuizQuestionFragment : Fragment() {
             .sortedDescending()
     }
 
+    private fun getSkipOptions(): String {
+        return """
+        <div style="display: flex; flex-direction: column; justify-content: space-between;">
+            <img src="https://static.testpress.in/static/img/skip.svg" alt="Image 1" style="width: 75px !important; height: 75px !important;">
+            <button class='helpline-button' onclick='skipOptions()'>SKIP</button>
+            <script>
+                ${getSkipOptionScript()}
+            </script>
+        </div>
+    """
+    }
+
+    private fun getSkipOptionScript(): String{
+        return """
+        function skipOptions() {
+                OptionsSelectionListener.onSkip()
+        }
+    """.trimMargin()
+    }
+
     inner class OptionsSelectionListener {
         @JavascriptInterface
         fun onCheckedChange(id: String, checked: Boolean, radioOption: Boolean) {
@@ -184,6 +205,11 @@ class QuizQuestionFragment : Fragment() {
                 selectedOptions.remove(id.toInt())
             }
             viewModel.setAnswer(userSelectedAnswer.id!!, selectedOptions)
+        }
+
+        @JavascriptInterface
+        fun onSkip() {
+            quizFragmentHandler.changeFragment()
         }
     }
 }

--- a/course/src/main/java/in/testpress/course/fragments/QuizQuestionFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/QuizQuestionFragment.kt
@@ -11,6 +11,7 @@ import `in`.testpress.exam.ui.view.WebView
 import `in`.testpress.models.InstituteSettings
 import `in`.testpress.util.WebViewUtils
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup

--- a/course/src/main/java/in/testpress/course/fragments/QuizQuestionFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/QuizQuestionFragment.kt
@@ -27,7 +27,7 @@ class QuizQuestionFragment : Fragment() {
     private lateinit var webViewUtils: WebViewUtils
     lateinit var viewModel: QuizViewModel
     private lateinit var userSelectedAnswer: DomainUserSelectedAnswer
-    lateinit var quizSkipHandler: QuizSkipHandler
+    lateinit var quizSkipListener: QuizSkipListener
     private lateinit var instituteSettings: InstituteSettings
 
     private var examId: Long = -1
@@ -204,11 +204,11 @@ class QuizQuestionFragment : Fragment() {
 
         @JavascriptInterface
         fun onSkip() {
-            quizSkipHandler.onSkip()
+            quizSkipListener.onSkip()
         }
     }
 }
 
-interface QuizSkipHandler {
+interface QuizSkipListener {
     fun onSkip()
 }

--- a/course/src/main/java/in/testpress/course/fragments/QuizQuestionFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/QuizQuestionFragment.kt
@@ -179,18 +179,12 @@ class QuizQuestionFragment : Fragment() {
             <img src="https://static.testpress.in/static/img/skip.svg" alt="Image 1" style="width: 75px !important; height: 75px !important;">
             <button class='helpline-button' onclick='skipOptions()'>SKIP</button>
             <script>
-                ${getSkipOptionScript()}
+                function skipOptions() {
+                    OptionsSelectionListener.onSkip()
+                }
             </script>
         </div>
     """
-    }
-
-    private fun getSkipOptionScript(): String{
-        return """
-        function skipOptions() {
-                OptionsSelectionListener.onSkip()
-        }
-    """.trimMargin()
     }
 
     inner class OptionsSelectionListener {

--- a/course/src/main/java/in/testpress/course/fragments/QuizQuestionFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/QuizQuestionFragment.kt
@@ -11,7 +11,6 @@ import `in`.testpress.exam.ui.view.WebView
 import `in`.testpress.models.InstituteSettings
 import `in`.testpress.util.WebViewUtils
 import android.os.Bundle
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup

--- a/course/src/main/java/in/testpress/course/fragments/QuizQuestionFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/QuizQuestionFragment.kt
@@ -27,6 +27,7 @@ class QuizQuestionFragment : Fragment() {
     private lateinit var webViewUtils: WebViewUtils
     lateinit var viewModel: QuizViewModel
     private lateinit var userSelectedAnswer: DomainUserSelectedAnswer
+    lateinit var quizSkipHandler: QuizSkipHandler
     private lateinit var instituteSettings: InstituteSettings
 
     private var examId: Long = -1
@@ -203,7 +204,11 @@ class QuizQuestionFragment : Fragment() {
 
         @JavascriptInterface
         fun onSkip() {
-            quizFragmentHandler.changeFragment()
+            quizSkipHandler.onSkip()
         }
     }
+}
+
+interface QuizSkipHandler {
+    fun onSkip()
 }

--- a/course/src/main/java/in/testpress/course/fragments/QuizSlideFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/QuizSlideFragment.kt
@@ -10,7 +10,7 @@ import androidx.viewpager2.adapter.FragmentStateAdapter
 import androidx.viewpager2.widget.ViewPager2
 import com.google.android.material.button.MaterialButton
 
-class QuizSlideFragment: Fragment(), NextQuizHandler, SubmitButtonListener {
+class QuizSlideFragment: Fragment(), NextQuizHandler, QuizSkipHandler {
     private lateinit var submitButton: MaterialButton
 
     private lateinit var viewPager: ViewPager2
@@ -33,13 +33,20 @@ class QuizSlideFragment: Fragment(), NextQuizHandler, SubmitButtonListener {
         submitButton.visibility = View.VISIBLE
 
         submitButton.setOnClickListener {
-            val fragment = childFragmentManager.findFragmentByTag("f" + viewPager.currentItem) as RootQuizFragment
-            if (fragment.isQuestionFragment) {
-                fragment.submitAnswer()
-                fragment.changeFragment()
-            } else {
-                showNext()
-            }
+            updateSolution()
+        }
+    }
+
+    private fun updateSolution() {
+        val fragment =
+            childFragmentManager.findFragmentByTag("f" + viewPager.currentItem) as RootQuizFragment
+        if (fragment.isQuestionFragment) {
+            fragment.submitAnswer()
+            fragment.changeFragment()
+            submitButton.text = "Continue"
+        } else {
+            showNext()
+            submitButton.text = "Check"
         }
     }
 
@@ -74,7 +81,7 @@ class QuizSlideFragment: Fragment(), NextQuizHandler, SubmitButtonListener {
         override fun createFragment(position: Int): Fragment {
             val questionFragment = RootQuizFragment()
             questionFragment.nextQuizHandler = fragment as NextQuizHandler
-            questionFragment.submitButtonListener = fragment
+            questionFragment.quizSkipHandler = fragment
             val bundle = Bundle().apply {
                 putInt("POSITION", position)
                 putLong("EXAM_ID", fragment.examId)
@@ -85,8 +92,8 @@ class QuizSlideFragment: Fragment(), NextQuizHandler, SubmitButtonListener {
         }
     }
 
-    override fun onSubmitClick(isQuestionFragment: Boolean) {
-        submitButton.text = if (isQuestionFragment) "Check" else "Continue"
+    override fun onSkip() {
+        updateSolution()
     }
 }
 

--- a/course/src/main/java/in/testpress/course/fragments/QuizSlideFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/QuizSlideFragment.kt
@@ -10,7 +10,7 @@ import androidx.viewpager2.adapter.FragmentStateAdapter
 import androidx.viewpager2.widget.ViewPager2
 import com.google.android.material.button.MaterialButton
 
-class QuizSlideFragment: Fragment(), NextQuizHandler {
+class QuizSlideFragment: Fragment(), NextQuizHandler, SubmitButtonListener {
     private lateinit var submitButton: MaterialButton
 
     private lateinit var viewPager: ViewPager2
@@ -37,9 +37,7 @@ class QuizSlideFragment: Fragment(), NextQuizHandler {
             if (fragment.isQuestionFragment) {
                 fragment.submitAnswer()
                 fragment.changeFragment()
-                submitButton.text = "Continue"
             } else {
-                submitButton.text = "Check"
                 showNext()
             }
         }
@@ -76,6 +74,7 @@ class QuizSlideFragment: Fragment(), NextQuizHandler {
         override fun createFragment(position: Int): Fragment {
             val questionFragment = RootQuizFragment()
             questionFragment.nextQuizHandler = fragment as NextQuizHandler
+            questionFragment.submitButtonListener = fragment
             val bundle = Bundle().apply {
                 putInt("POSITION", position)
                 putLong("EXAM_ID", fragment.examId)
@@ -84,6 +83,10 @@ class QuizSlideFragment: Fragment(), NextQuizHandler {
             questionFragment.arguments = bundle
             return questionFragment
         }
+    }
+
+    override fun onSubmitClick(isQuestionFragment: Boolean) {
+        submitButton.text = if (isQuestionFragment) "Check" else "Continue"
     }
 }
 

--- a/course/src/main/java/in/testpress/course/fragments/QuizSlideFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/QuizSlideFragment.kt
@@ -33,11 +33,11 @@ class QuizSlideFragment: Fragment(), NextQuizHandler, QuizSkipListener {
         submitButton.visibility = View.VISIBLE
 
         submitButton.setOnClickListener {
-            updateSolution()
+            changeFragment()
         }
     }
 
-    private fun updateSolution() {
+    private fun changeFragment() {
         val fragment =
             childFragmentManager.findFragmentByTag("f" + viewPager.currentItem) as RootQuizFragment
         if (fragment.isQuestionFragment) {
@@ -93,7 +93,7 @@ class QuizSlideFragment: Fragment(), NextQuizHandler, QuizSkipListener {
     }
 
     override fun onSkip() {
-        updateSolution()
+        changeFragment()
     }
 }
 

--- a/course/src/main/java/in/testpress/course/fragments/QuizSlideFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/QuizSlideFragment.kt
@@ -10,7 +10,7 @@ import androidx.viewpager2.adapter.FragmentStateAdapter
 import androidx.viewpager2.widget.ViewPager2
 import com.google.android.material.button.MaterialButton
 
-class QuizSlideFragment: Fragment(), NextQuizHandler, QuizSkipHandler {
+class QuizSlideFragment: Fragment(), NextQuizHandler, QuizSkipListener {
     private lateinit var submitButton: MaterialButton
 
     private lateinit var viewPager: ViewPager2
@@ -81,7 +81,7 @@ class QuizSlideFragment: Fragment(), NextQuizHandler, QuizSkipHandler {
         override fun createFragment(position: Int): Fragment {
             val questionFragment = RootQuizFragment()
             questionFragment.nextQuizHandler = fragment as NextQuizHandler
-            questionFragment.quizSkipHandler = fragment
+            questionFragment.quizSkipListener = fragment
             val bundle = Bundle().apply {
                 putInt("POSITION", position)
                 putLong("EXAM_ID", fragment.examId)

--- a/course/src/main/java/in/testpress/course/fragments/QuizSlideFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/QuizSlideFragment.kt
@@ -10,7 +10,7 @@ import androidx.viewpager2.adapter.FragmentStateAdapter
 import androidx.viewpager2.widget.ViewPager2
 import com.google.android.material.button.MaterialButton
 
-class QuizSlideFragment: Fragment(), NextQuizHandler, QuizSkipListener {
+class QuizSlideFragment: Fragment(), NextQuizHandler, QuizOperationsCallback {
     private lateinit var submitButton: MaterialButton
 
     private lateinit var viewPager: ViewPager2
@@ -81,7 +81,7 @@ class QuizSlideFragment: Fragment(), NextQuizHandler, QuizSkipListener {
         override fun createFragment(position: Int): Fragment {
             val questionFragment = RootQuizFragment()
             questionFragment.nextQuizHandler = fragment as NextQuizHandler
-            questionFragment.quizSkipListener = fragment
+            questionFragment.quizOperationsCallback = fragment
             val bundle = Bundle().apply {
                 putInt("POSITION", position)
                 putLong("EXAM_ID", fragment.examId)

--- a/course/src/main/java/in/testpress/course/fragments/RootQuizFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/RootQuizFragment.kt
@@ -13,6 +13,7 @@ class RootQuizFragment: Fragment() {
     private lateinit var reviewFragment: QuizReviewFragment
 
     lateinit var nextQuizHandler: NextQuizHandler
+    lateinit var submitButtonListener: SubmitButtonListener
     private var position: Int = 0
     private var examId: Long = -1
     private var attemptId: Long = -1
@@ -40,6 +41,7 @@ class RootQuizFragment: Fragment() {
 
     private fun showQuestion() {
         isQuestionFragment = true
+        submitButtonListener.onSubmitClick(isQuestionFragment)
         questionFragment = QuizQuestionFragment()
         questionFragment.arguments = arguments
 
@@ -50,6 +52,7 @@ class RootQuizFragment: Fragment() {
 
     private fun showReviewFragment() {
         isQuestionFragment = false
+        submitButtonListener.onSubmitClick(isQuestionFragment)
         reviewFragment = QuizReviewFragment()
         reviewFragment.arguments = arguments
         reviewFragment.arguments?.apply {
@@ -66,4 +69,8 @@ class RootQuizFragment: Fragment() {
     fun changeFragment() {
         showReviewFragment()
     }
+}
+
+interface SubmitButtonListener {
+    fun onSubmitClick(isQuestionFragment: Boolean)
 }

--- a/course/src/main/java/in/testpress/course/fragments/RootQuizFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/RootQuizFragment.kt
@@ -13,7 +13,7 @@ class RootQuizFragment: Fragment() {
     private lateinit var reviewFragment: QuizReviewFragment
 
     lateinit var nextQuizHandler: NextQuizHandler
-    lateinit var quizSkipListener: QuizSkipListener
+    lateinit var quizOperationsCallback: QuizOperationsCallback
     private var position: Int = 0
     private var examId: Long = -1
     private var attemptId: Long = -1
@@ -43,7 +43,7 @@ class RootQuizFragment: Fragment() {
         isQuestionFragment = true
         questionFragment = QuizQuestionFragment()
         questionFragment.arguments = arguments
-        questionFragment.quizSkipListener = quizSkipListener
+        questionFragment.quizOperationsCallback = quizOperationsCallback
 
         val transaction = childFragmentManager.beginTransaction()
         transaction.replace(R.id.root_layout, questionFragment)

--- a/course/src/main/java/in/testpress/course/fragments/RootQuizFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/RootQuizFragment.kt
@@ -13,7 +13,7 @@ class RootQuizFragment: Fragment() {
     private lateinit var reviewFragment: QuizReviewFragment
 
     lateinit var nextQuizHandler: NextQuizHandler
-    lateinit var quizSkipHandler: QuizSkipHandler
+    lateinit var quizSkipListener: QuizSkipListener
     private var position: Int = 0
     private var examId: Long = -1
     private var attemptId: Long = -1
@@ -43,7 +43,7 @@ class RootQuizFragment: Fragment() {
         isQuestionFragment = true
         questionFragment = QuizQuestionFragment()
         questionFragment.arguments = arguments
-        questionFragment.quizSkipHandler = quizSkipHandler
+        questionFragment.quizSkipListener = quizSkipListener
 
         val transaction = childFragmentManager.beginTransaction()
         transaction.replace(R.id.root_layout, questionFragment)

--- a/course/src/main/java/in/testpress/course/fragments/RootQuizFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/RootQuizFragment.kt
@@ -13,7 +13,7 @@ class RootQuizFragment: Fragment() {
     private lateinit var reviewFragment: QuizReviewFragment
 
     lateinit var nextQuizHandler: NextQuizHandler
-    lateinit var submitButtonListener: SubmitButtonListener
+    lateinit var quizSkipHandler: QuizSkipHandler
     private var position: Int = 0
     private var examId: Long = -1
     private var attemptId: Long = -1
@@ -41,9 +41,9 @@ class RootQuizFragment: Fragment() {
 
     private fun showQuestion() {
         isQuestionFragment = true
-        submitButtonListener.onSubmitClick(isQuestionFragment)
         questionFragment = QuizQuestionFragment()
         questionFragment.arguments = arguments
+        questionFragment.quizSkipHandler = quizSkipHandler
 
         val transaction = childFragmentManager.beginTransaction()
         transaction.replace(R.id.root_layout, questionFragment)
@@ -52,7 +52,6 @@ class RootQuizFragment: Fragment() {
 
     private fun showReviewFragment() {
         isQuestionFragment = false
-        submitButtonListener.onSubmitClick(isQuestionFragment)
         reviewFragment = QuizReviewFragment()
         reviewFragment.arguments = arguments
         reviewFragment.arguments?.apply {
@@ -69,8 +68,4 @@ class RootQuizFragment: Fragment() {
     fun changeFragment() {
         showReviewFragment()
     }
-}
-
-interface SubmitButtonListener {
-    fun onSubmitClick(isQuestionFragment: Boolean)
 }


### PR DESCRIPTION
 - This commit introduces a skip helpline option to the quiz template. We're incorporating this feature into the Android app to align with its existing availability on the web quiz template.
 - When a user clicks the skip button we show the solution page for the current question