### PR TITLE
fix: Disable onClick event for helpline images in quiz exam

### DIFF
--- a/core/src/main/assets/TestpressImageTagHandler.js
+++ b/core/src/main/assets/TestpressImageTagHandler.js
@@ -2,5 +2,8 @@
 var images = document.getElementsByTagName("img");
 for (i = 0; i < images.length; i++) {
     var src = images[i].src;
-    images[i].setAttribute('onclick','ImageHandler.onClickImage(src)');
+        // Check if the image has the "no-click-listener" class
+        if (!images[i].classList.contains("no-click-listener")) {
+            images[i].setAttribute('onclick', 'ImageHandler.onClickImage(src)');
+        }
 }

--- a/course/src/main/java/in/testpress/course/fragments/QuizQuestionFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/QuizQuestionFragment.kt
@@ -173,7 +173,7 @@ class QuizQuestionFragment : Fragment() {
         val incorrectAnswers= getIncorrectAnswerIndices(answers)
         return """
         <div style="display: flex; flex-direction: column; justify-content: space-between;">
-            <img src="https://static.testpress.in/static/img/5050.svg" alt="Image 1" style="width: 75px !important; height: 75px !important;">
+            <img class="no-click-listener" src="https://static.testpress.in/static/img/5050.svg" alt="Image 1" style="width: 75px !important; height: 75px !important;">
             <button class='helpline-button' onclick='hideHalfOptions()'>50/50</button>
             <script>
                 function hideHalfOptions() {
@@ -198,7 +198,7 @@ class QuizQuestionFragment : Fragment() {
     private fun getSkipOptions(): String {
         return """
         <div style="display: flex; flex-direction: column; justify-content: space-between;">
-            <img src="https://static.testpress.in/static/img/skip.svg" alt="Image 1" style="width: 75px !important; height: 75px !important;">
+            <img class="no-click-listener" src="https://static.testpress.in/static/img/skip.svg" alt="Image 1" style="width: 75px !important; height: 75px !important;">
             <button class='helpline-button' onclick='skipOptions()'>SKIP</button>
             <script>
                 function skipOptions() {
@@ -212,7 +212,7 @@ class QuizQuestionFragment : Fragment() {
     private fun getAudienceOption(): String {
         return """
         <div style="display: flex; flex-direction: column; justify-content: space-between;">
-            <img src="https://static.testpress.in/static/img/bar-chart.svg" alt="Image 1" style="width: 75px !important; height: 75px !important;">
+            <img class="no-click-listener" src="https://static.testpress.in/static/img/bar-chart.svg" alt="Image 1" style="width: 75px !important; height: 75px !important;">
             <button class='helpline-button' onclick='audienceOptions()'>AUDIENCE</button>
             <script>
                 function audienceOptions() {


### PR DESCRIPTION
- In the context of exam templates, we employ a Webview. We create HTML data and feed it to the Webview. If the Webview includes any image tags, we attach a shared listener to open images in a new window. However, for helpline images within the quiz template, we wish to avoid displaying them in a new window, so we exclude the process of adding the onclick event for these specific images.