### PR TITLE
fix: Display the scheduled message content instead of the permission denied message for scheduled content.

### DIFF
--- a/core/src/main/java/in/testpress/fragments/EmptyViewFragment.kt
+++ b/core/src/main/java/in/testpress/fragments/EmptyViewFragment.kt
@@ -83,11 +83,25 @@ class EmptyViewFragment : Fragment() {
             }
         }
 
-        if (errorResponse?.has("detail") == true) {
+        if (isScheduledContent(errorResponse)) {
+            showScheduledContentMessage(errorResponse?.getString("message")!!)
+        } else if (errorResponse?.has("detail") == true) {
             showCustomPermissionDeniedMessage(errorResponse.getString("detail"))
         } else {
             showPermissionDeniedMessage()
         }
+    }
+
+    private fun isScheduledContent(errorResponse: JSONObject?) =
+        errorResponse?.has("error_code") == true && errorResponse.getString("error_code")
+            .equals("scheduled")
+
+    private fun showScheduledContentMessage(message: String){
+        setEmptyText(
+            R.string.content_scheduled,
+            message,
+            R.drawable.ic_error_outline_black_18dp
+        )
     }
 
     private fun showCustomPermissionDeniedMessage(message: String){

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -12,6 +12,7 @@
     <string name="testpress_loading_failed">Loading Failed</string>
     <string name="testpress_authentication_failed">Authentication failed</string>
     <string name="permission_denied">Permission Denied</string>
+    <string name="content_scheduled">This content is scheduled!</string>
     <string name="testpress_please_login">Please login to see this exams</string>
     <string name="testpress_no_permission">You do not have permission to view this.</string>
     <string name="testpress_some_thing_went_wrong_try_again">Some thing went wrong, please try again later.</string>


### PR DESCRIPTION
- Previously we used to display permission-denied messages for scheduled content.
- When a user received a notification for scheduled content they couldn't open, we presented a permission-denied message. This message was confusing for users because they would click the notification, only to encounter a permission denied error.
- In this commit, we have improved the user experience by showing the appropriate scheduled message when users attempt to open scheduled content through notifications.