### PR TITLE
fix: Unable to upload a file in file type questions.

### DIFF
--- a/core/src/main/java/in/testpress/util/PermissionHandler.kt
+++ b/core/src/main/java/in/testpress/util/PermissionHandler.kt
@@ -8,7 +8,6 @@ import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Build
 import android.provider.Settings
-import android.util.Log
 import androidx.core.app.ActivityCompat
 import com.google.android.material.snackbar.Snackbar
 
@@ -122,7 +121,7 @@ class PermissionHandler {
             }
 
             if (shouldShowRationale(activity, requiredPermissions)) {
-                showRationaleSnackbar(activity, rationaleMessage)
+                showInsufficientPermissionMessage(activity, rationaleMessage)
             } else {
                 requestPermission(activity, requiredPermissions)
             }
@@ -131,7 +130,7 @@ class PermissionHandler {
         private fun shouldShowRationale(activity: Activity, permissions: List<String>): Boolean =
             permissions.any { ActivityCompat.shouldShowRequestPermissionRationale(activity, it) }
 
-        private fun showRationaleSnackbar(activity: Activity, message: String) {
+        private fun showInsufficientPermissionMessage(activity: Activity, message: String) {
             Snackbar.make(
                 activity.findViewById(android.R.id.content),
                 message,

--- a/exam/src/main/java/in/testpress/exam/ui/TestQuestionFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestQuestionFragment.java
@@ -30,6 +30,7 @@ import com.hbisoft.pickit.PickiTCallbacks;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import in.testpress.core.TestpressCallback;
@@ -45,6 +46,7 @@ import in.testpress.models.FileDetails;
 import in.testpress.models.InstituteSettings;
 import in.testpress.models.greendao.Exam;
 import in.testpress.models.greendao.Language;
+import in.testpress.util.PermissionHandler;
 import in.testpress.util.ProgressDialog;
 import in.testpress.util.WebViewUtils;
 import pub.devrel.easypermissions.AppSettingsDialog;
@@ -339,19 +341,18 @@ public class TestQuestionFragment extends Fragment implements PickiTCallbacks, E
         @JavascriptInterface
         public void onFileUploadClick() {
             Log.d("TAG", "onFileUploadClick: ");
-            if (hasStoragePermission()) {
+            if (PermissionHandler.Companion.hasPermissions(
+                    requireActivity(),
+                    Arrays.asList(READ_EXTERNAL_STORAGE, WRITE_EXTERNAL_STORAGE)
+            )) {
                 pickFile();
             } else {
-                EasyPermissions.requestPermissions(
-                        new PermissionRequest.Builder(requireActivity(), 200, FILE_PERMISSIONS)
-                                .setRationale("This app needs access to your storage to upload files.")
-                                .setPositiveButtonText("Ok")
-                                .setNegativeButtonText("Cancel")
-                                .setTheme(R.style.TestpressAppCompatAlertDialogStyle)
-                                .build()
-                        );
+                PermissionHandler.Companion.requestPermissionWithRationale(
+                        requireActivity(),
+                        Arrays.asList(READ_EXTERNAL_STORAGE, WRITE_EXTERNAL_STORAGE),
+                        "This app needs access to your storage to upload files."
+                );
             }
-
         }
 
         @JavascriptInterface
@@ -368,10 +369,6 @@ public class TestQuestionFragment extends Fragment implements PickiTCallbacks, E
         public void onEssayValueChange(String value) {
             attemptItem.setLocalEssayText(value.trim());
         }
-    }
-
-    private boolean hasStoragePermission() {
-        return EasyPermissions.hasPermissions(requireContext(), FILE_PERMISSIONS);
     }
 
     void pickFile() {


### PR DESCRIPTION
- When a user tries to upload a file in response to a question about file types, we check if the user has given permission for storage access. If permission is granted, we proceed to open the file manager. However, if permission is not granted, we prompt the user to provide the necessary permission.
- If the user has previously denied permission, we cannot request it again. In this commit, we have included the feature to display a message in a snackbar, notifying the user that the required permission is essential if they have previously denied it.