### PR TITLE
fix: Prevent users from copying a YouTube video link while in fullscreen.

### DIFF
--- a/core/src/main/java/in/testpress/util/FullScreenChromeClient.java
+++ b/core/src/main/java/in/testpress/util/FullScreenChromeClient.java
@@ -22,6 +22,7 @@ public class FullScreenChromeClient extends WebChromeClient {
     private int mOriginalSystemUiVisibility;
     private Activity activity;
     private ValueCallback<Uri[]> filePathCallback;
+    public boolean disableLongPress = false;
 
     public FullScreenChromeClient(Activity activity) {
         this.activity = activity;
@@ -60,6 +61,20 @@ public class FullScreenChromeClient extends WebChromeClient {
 
         // https://stackoverflow.com/a/38799514/5134215
         activity.getWindow().getDecorView().setSystemUiVisibility(3846);
+
+        disableLongPressForYouTubeEmbeddedContent();
+    }
+
+    private void disableLongPressForYouTubeEmbeddedContent() {
+        if (disableLongPress) {
+            activity.getWindow().getCurrentFocus().setOnLongClickListener(new View.OnLongClickListener() {
+                @Override
+                public boolean onLongClick(View v) {
+                    return true;
+                }
+            });
+            activity.getWindow().getCurrentFocus().setLongClickable(false);
+        }
     }
 
     @Override

--- a/course/src/main/java/in/testpress/course/fragments/WebViewVideoFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/WebViewVideoFragment.kt
@@ -29,6 +29,7 @@ open class WebViewVideoFragment : BaseVideoWidgetFragment() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         fullScreenChromeClient = FullScreenChromeClient(activity)
+        fullScreenChromeClient.disableLongPress = true
     }
 
     override fun onCreateView(


### PR DESCRIPTION
- In commit b48068f, we deactivated the long-press option. However, when the user transitions to fullscreen mode, we alter the view so the disabled long-press option is ineffective. In this particular commit, we addressed this issue by disabling the long-press option when switching to fullscreen mode. This is achieved through the use of the disableLongPress variable, which is set to its default value of false.
