### PR TITLE
fix: Hide product list fragment if store is disabled in CourseListFragment

### DIFF
--- a/core/src/main/java/in/testpress/models/InstituteSettings.java
+++ b/core/src/main/java/in/testpress/models/InstituteSettings.java
@@ -44,6 +44,7 @@ public class InstituteSettings {
     private String whiteLabeledHostUrl;
     private String currentPaymentApp;
     private Boolean enableCustomTest;
+    private Boolean storeEnabled;
 
     public InstituteSettings(String baseUrl) {
         setBaseUrl(baseUrl);
@@ -384,5 +385,13 @@ public class InstituteSettings {
 
     public void setEnableCustomTest(Boolean enableCustomTest) {
         this.enableCustomTest = enableCustomTest;
+    }
+
+    public Boolean getStoreEnabled() {
+        return storeEnabled != null && storeEnabled;
+    }
+
+    public void setStoreEnabled(Boolean storeEnabled) {
+        this.storeEnabled = storeEnabled;
     }
 }

--- a/course/src/main/java/in/testpress/course/ui/CourseListFragment.java
+++ b/course/src/main/java/in/testpress/course/ui/CourseListFragment.java
@@ -30,11 +30,13 @@ public class CourseListFragment extends BaseFragment {
     private Adapter adapter;
     private WebViewFragment webViewFragment;
     private boolean isWebViewVisibleToUser = false;
+    private TestpressSession session;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setRetainInstance(true);
+        session = TestpressSdk.getTestpressSession(getContext());
     }
 
     @Override
@@ -54,7 +56,6 @@ public class CourseListFragment extends BaseFragment {
         adapter = new Adapter(getChildFragmentManager());
         adapter.addFragment(new MyCoursesFragment(), getString(R.string.my_course_title));
 
-        TestpressSession session = TestpressSdk.getTestpressSession(getContext());
         String storeLabel = "Available Courses";
         if (session.getInstituteSettings().getStoreLabel() != null && !session.getInstituteSettings().getStoreLabel().isEmpty()) {
             storeLabel = session.getInstituteSettings().getStoreLabel();
@@ -74,6 +75,9 @@ public class CourseListFragment extends BaseFragment {
     }
 
     private void addStoreFragment(String storeLabel) {
+        if (isStoreDisabled()) {
+            return;
+        }
         // Here we are adding Custom store WebView for EPratibha App
         if (isEPratibhaApp()) {
             String[] credentials = CommonUtils.getUserCredentials(requireContext());
@@ -92,6 +96,10 @@ public class CourseListFragment extends BaseFragment {
         } else {
             adapter.addFragment(new AvailableCourseListFragment(), storeLabel);
         }
+    }
+
+    private boolean isStoreDisabled() {
+        return session.getInstituteSettings() != null && !session.getInstituteSettings().getStoreEnabled();
     }
 
     private boolean isEPratibhaApp() {

--- a/samples/src/main/java/in/testpress/samples/course/CourseSampleActivity.java
+++ b/samples/src/main/java/in/testpress/samples/course/CourseSampleActivity.java
@@ -201,6 +201,7 @@ public class CourseSampleActivity extends BaseToolBarActivity {
             session.getInstituteSettings().setDisableStudentAnalytics(false);
             session.getInstituteSettings().setEnableCustomTest(true);
             session.getInstituteSettings().setStoreLabel("Available Courses");
+            session.getInstituteSettings().setStoreEnabled(true);
             session.getInstituteSettings().setAppToolbarLogo("https://media.testpress.in/institute/elixir/institutes/elixir-neet-pg-preparation-app/9571158ee51b4c36b9dd14b9dae17452.png");
 
             TestpressSdk.setTestpressSession(this, session);


### PR DESCRIPTION
- Added the 'storeEnable' field in institute settings.
- In this commit, we handled adding the product list view in the CourseListFragment based on the 'storeEnable' field in institute settings.