### PR TITLE
fix: Incorrect thumbnail showing in Content list view

### DIFF
--- a/course/src/main/java/in/testpress/course/ui/viewholders/BaseContentListItemViewHolder.kt
+++ b/course/src/main/java/in/testpress/course/ui/viewholders/BaseContentListItemViewHolder.kt
@@ -50,6 +50,8 @@ abstract class BaseContentListItemViewHolder(view: View) : RecyclerView.ViewHold
     private fun updateThumbnail(content: DomainContent) {
         if (!content.coverImageMedium.isNullOrEmpty()) {
             imageLoader.displayImage(content.coverImageMedium, thumbnail, imageOptions)
+        } else {
+            thumbnail.setImageDrawable(null)
         }
     }
 


### PR DESCRIPTION
- In this commit, we assign a null value to the thumbnail ImageView if the thumbnail URL is null in the content.
