### PR TITLE
fix: App crash when the ChapterDetailActivity re-instantiated

### DIFF
--- a/course/src/main/java/in/testpress/course/fragments/CourseContentListFragment .kt
+++ b/course/src/main/java/in/testpress/course/fragments/CourseContentListFragment .kt
@@ -3,9 +3,11 @@ package `in`.testpress.course.fragments
 import `in`.testpress.course.R
 import `in`.testpress.course.TestpressCourse
 import `in`.testpress.course.adapter.BaseListFooterAdapter
+import `in`.testpress.course.adapter.CourseContentListAdapter
 import `in`.testpress.course.databinding.BaseContentListLayoutBinding
 import `in`.testpress.course.repository.CourseContentsRepository
 import `in`.testpress.course.viewmodels.CourseContentListViewModel
+import `in`.testpress.database.entities.CourseContentType
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -16,16 +18,13 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
 import androidx.paging.LoadState
-import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
-import `in`.testpress.course.adapter.CourseContentListAdapter
-import `in`.testpress.database.entities.ContentEntityLite
-import `in`.testpress.database.entities.CourseContentType
 import kotlinx.coroutines.flow.collect
 
-class CourseContentListFragment(val type: Int): Fragment() {
+class CourseContentListFragment: Fragment() {
 
+    private var type: Int = 0
     private var courseId: Long = -1
     private lateinit var binding: BaseContentListLayoutBinding
     private lateinit var adapter: CourseContentListAdapter
@@ -47,6 +46,7 @@ class CourseContentListFragment(val type: Int): Fragment() {
     }
 
     private fun parseArguments() {
+        type = arguments!!.getInt(COURSE_CONTENT_TYPE)
         courseId = arguments!!.getString(TestpressCourse.COURSE_ID)?.toLong()!!
     }
 
@@ -165,6 +165,10 @@ class CourseContentListFragment(val type: Int): Fragment() {
                 resources.getString(`in`.testpress.R.string.testpress_content_not_available_description)
             retryButton.isVisible = true
         }
+    }
+
+    companion object {
+        const val COURSE_CONTENT_TYPE = "CourseContentType"
     }
 
 }

--- a/course/src/main/java/in/testpress/course/ui/ChapterDetailActivity.java
+++ b/course/src/main/java/in/testpress/course/ui/ChapterDetailActivity.java
@@ -39,6 +39,7 @@ import static in.testpress.course.TestpressCourse.CHAPTER_URL;
 import static in.testpress.course.TestpressCourse.COURSE_ID;
 import static in.testpress.course.TestpressCourse.PARENT_ID;
 import static in.testpress.course.TestpressCourse.PRODUCT_SLUG;
+import static in.testpress.course.fragments.CourseContentListFragment.COURSE_CONTENT_TYPE;
 import static in.testpress.course.ui.ContentActivity.FORCE_REFRESH;
 import static in.testpress.course.ui.ContentActivity.GO_TO_MENU;
 import static in.testpress.course.ui.ContentActivity.TESTPRESS_CONTENT_SHARED_PREFS;
@@ -277,17 +278,21 @@ public class ChapterDetailActivity extends BaseToolBarActivity {
                         getString(R.string.testpress_learn)
                 )
         );
+        Bundle runningContentBundle = getIntent().getExtras();
+        runningContentBundle.putInt(COURSE_CONTENT_TYPE,CourseContentType.RUNNING_CONTENT.ordinal());
         fragments.add(
                 createFragment(
-                        new CourseContentListFragment(CourseContentType.RUNNING_CONTENT.ordinal()),
-                        getIntent().getExtras(),
+                        new CourseContentListFragment(),
+                        runningContentBundle,
                         getString(R.string.testpress_running_contents)
                 )
         );
+        Bundle upcomingContentBundle = getIntent().getExtras();
+        upcomingContentBundle.putInt(COURSE_CONTENT_TYPE,CourseContentType.UPCOMING_CONTENT.ordinal());
         fragments.add(
                 createFragment(
-                        new CourseContentListFragment(CourseContentType.UPCOMING_CONTENT.ordinal()),
-                        getIntent().getExtras(),
+                        new CourseContentListFragment(),
+                        upcomingContentBundle,
                         getString(R.string.testpress_upcoming_contents)
                 )
         );

--- a/samples/src/main/java/in/testpress/samples/core/TestpressCoreSampleActivity.java
+++ b/samples/src/main/java/in/testpress/samples/core/TestpressCoreSampleActivity.java
@@ -119,8 +119,8 @@ public class TestpressCoreSampleActivity extends BaseToolBarActivity {
     }
 
     private void authenticate(String userId, String accessToken, TestpressSdk.Provider provider) {
-        InstituteSettings instituteSettings = new InstituteSettings("https://sandbox.testpress.in");
-        instituteSettings.setWhiteLabeledHostUrl("https://sandbox.testpress.in");
+        InstituteSettings instituteSettings = new InstituteSettings("https://lmsdemo.testpress.in");
+        instituteSettings.setWhiteLabeledHostUrl("https://lmsdemo.testpress.in");
         TestpressSdk.initialize(this, instituteSettings, userId, accessToken, provider,
                 new TestpressCallback<TestpressSession>() {
                     @Override

--- a/samples/src/main/java/in/testpress/samples/core/TestpressCoreSampleActivity.java
+++ b/samples/src/main/java/in/testpress/samples/core/TestpressCoreSampleActivity.java
@@ -119,8 +119,8 @@ public class TestpressCoreSampleActivity extends BaseToolBarActivity {
     }
 
     private void authenticate(String userId, String accessToken, TestpressSdk.Provider provider) {
-        InstituteSettings instituteSettings = new InstituteSettings("https://lmsdemo.testpress.in");
-        instituteSettings.setWhiteLabeledHostUrl("https://lmsdemo.testpress.in");
+        InstituteSettings instituteSettings = new InstituteSettings("https://sandbox.testpress.in");
+        instituteSettings.setWhiteLabeledHostUrl("https://sandbox.testpress.in");
         TestpressSdk.initialize(this, instituteSettings, userId, accessToken, provider,
                 new TestpressCallback<TestpressSession>() {
                     @Override

--- a/samples/src/main/java/in/testpress/samples/course/NavigationDrawerActivity.java
+++ b/samples/src/main/java/in/testpress/samples/course/NavigationDrawerActivity.java
@@ -15,6 +15,7 @@ import in.testpress.samples.R;
 import in.testpress.samples.core.TestpressCoreSampleActivity;
 import in.testpress.util.ViewUtils;
 
+import static in.testpress.course.fragments.CourseContentListFragment.COURSE_CONTENT_TYPE;
 import static in.testpress.samples.core.TestpressCoreSampleActivity.AUTHENTICATE_REQUEST_CODE;
 
 public class NavigationDrawerActivity extends BaseNavigationDrawerActivity {
@@ -79,8 +80,9 @@ public class NavigationDrawerActivity extends BaseNavigationDrawerActivity {
                     @Override
                     public void onInputComplete(String inputText) {
                         Bundle bundle = new Bundle();
+                        bundle.putInt(COURSE_CONTENT_TYPE,type);
                         bundle.putString("courseId",inputText);
-                        CourseContentListFragment fragment = new CourseContentListFragment(type);
+                        CourseContentListFragment fragment = new CourseContentListFragment();
                         fragment.setArguments(bundle);
                         NavigationDrawerActivity.this.getSupportFragmentManager().beginTransaction()
                                 .replace(R.id.fragment_container,fragment)


### PR DESCRIPTION
- We initially initialized the CourseContentListFragment with constructor parameters in the ChapterDetailActivity. However, during activity and fragment recreation, these constructors would not be called, and only the default constructor would be invoked. This prevented us from properly initializing the CourseContentListFragment, leading to the app crash.
- In this commit, we addressed this issue by passing the type value as an argument and removing the constructor parameters in the CourseContentListFragment.