### PR TITLE
fix: App crash when the WebViewFragment re-instantiated

### DIFF
--- a/core/src/main/java/in/testpress/ui/AbstractWebViewActivity.kt
+++ b/core/src/main/java/in/testpress/ui/AbstractWebViewActivity.kt
@@ -40,24 +40,24 @@ abstract class AbstractWebViewActivity: BaseToolBarActivity(), WebViewFragment.L
     }
 
     private fun initializeWebViewFragment() {
-        webViewFragment = WebViewFragment(
-            url = urlPath,
-            webViewFragmentSettings = getWebViewFragmentSettings()
-        )
+        webViewFragment = WebViewFragment()
+        webViewFragment.arguments = getWebViewArguments()
         webViewFragment.setListener(this)
         supportFragmentManager.beginTransaction()
             .replace(R.id.fragment_container, webViewFragment)
             .commit()
     }
 
-    private fun getWebViewFragmentSettings():WebViewFragment.Settings {
-        return if (isSSORequired){
-            WebViewFragment.Settings()
-        } else {
-            WebViewFragment.Settings(
-                isSSORequired = false,
-                allowNonInstituteUrlInWebView = true
-            )
+    private fun getWebViewArguments(): Bundle {
+        return Bundle().apply {
+            this.putString(WebViewFragment.URL_TO_OPEN, urlPath)
+            if (isSSORequired) {
+                this.putBoolean(WebViewFragment.IS_SSO_REQUIRED, true)
+                this.putBoolean(WebViewFragment.ALLOW_NON_INSTITUTE_URL_IN_WEB_VIEW, false)
+            } else {
+                this.putBoolean(WebViewFragment.IS_SSO_REQUIRED, false)
+                this.putBoolean(WebViewFragment.ALLOW_NON_INSTITUTE_URL_IN_WEB_VIEW, true)
+            }
         }
     }
 

--- a/core/src/main/java/in/testpress/util/webview/CustomWebViewClient.kt
+++ b/core/src/main/java/in/testpress/util/webview/CustomWebViewClient.kt
@@ -27,12 +27,12 @@ class CustomWebViewClient(val fragment: WebViewFragment) : WebViewClient() {
         return if (isInstituteUrl){
             true
         } else {
-            fragment.webViewFragmentSettings.allowNonInstituteUrlInWebView
+            fragment.allowNonInstituteUrlInWebView
         }
     }
 
     override fun onPageStarted(view: WebView?, url: String?, favicon: Bitmap?) {
-        if (fragment.webViewFragmentSettings.showLoadingBetweenPages) fragment.showLoading()
+        if (fragment.showLoadingBetweenPages) fragment.showLoading()
     }
 
     override fun onPageFinished(view: WebView?, url: String?) {

--- a/course/src/main/java/in/testpress/course/fragments/LiveStreamFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/LiveStreamFragment.kt
@@ -9,6 +9,8 @@ import `in`.testpress.course.domain.getGreenDaoContent
 import `in`.testpress.course.util.ExoPlayerUtil
 import `in`.testpress.course.util.ExoplayerFullscreenHelper
 import `in`.testpress.fragments.WebViewFragment
+import `in`.testpress.fragments.WebViewFragment.Companion.IS_SSO_REQUIRED
+import `in`.testpress.fragments.WebViewFragment.Companion.URL_TO_OPEN
 import android.widget.RelativeLayout
 import android.widget.TextView
 import com.google.android.exoplayer2.ui.AspectRatioFrameLayout
@@ -94,11 +96,12 @@ class LiveStreamFragment : BaseContentDetailFragment() {
             val chatView = view?.findViewById<View>(R.id.chat_view_fragment)
             chatView?.visibility = View.VISIBLE
 
-            val webViewFragment = WebViewFragment(
-                url = embedUrl,
-                webViewFragmentSettings = WebViewFragment.Settings(isSSORequired = false)
-            )
-
+            val webViewFragment = WebViewFragment()
+            val bundle = Bundle().apply {
+                this.putString(URL_TO_OPEN,embedUrl)
+                this.putBoolean(IS_SSO_REQUIRED,false)
+            }
+            webViewFragment.arguments = bundle
             childFragmentManager.beginTransaction()
                 .replace(R.id.chat_view_fragment, webViewFragment)
                 .commit()

--- a/course/src/main/java/in/testpress/course/ui/CourseListFragment.java
+++ b/course/src/main/java/in/testpress/course/ui/CourseListFragment.java
@@ -1,5 +1,11 @@
 package in.testpress.course.ui;
 
+import static in.testpress.fragments.WebViewFragment.ALLOW_NON_INSTITUTE_URL_IN_WEB_VIEW;
+import static in.testpress.fragments.WebViewFragment.ENABLE_SWIPE_REFRESH;
+import static in.testpress.fragments.WebViewFragment.IS_SSO_REQUIRED;
+import static in.testpress.fragments.WebViewFragment.SHOW_LOADING_BETWEEN_PAGES;
+import static in.testpress.fragments.WebViewFragment.URL_TO_OPEN;
+
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 
@@ -80,22 +86,23 @@ public class CourseListFragment extends BaseFragment {
         }
         // Here we are adding Custom store WebView for EPratibha App
         if (isEPratibhaApp()) {
-            String[] credentials = CommonUtils.getUserCredentials(requireContext());
-            webViewFragment = new WebViewFragment(
-                    "https://www.epratibha.net/mobile-login/?email=" + credentials[0] + "&pass=" + credentials[1],
-                    "",
-                    new WebViewFragment.Settings(
-                            true,
-                            false,
-                            true,
-                            false,
-                            true
-                    )
-            );
-            adapter.addFragment(webViewFragment, storeLabel);
+            addEPratibhaWebViewFragment(storeLabel);
         } else {
             adapter.addFragment(new AvailableCourseListFragment(), storeLabel);
         }
+    }
+
+    private void addEPratibhaWebViewFragment(String storeLabel) {
+        String[] credentials = CommonUtils.getUserCredentials(requireContext());
+        WebViewFragment webViewFragment = new WebViewFragment();
+        Bundle bundle = new Bundle();
+        bundle.putString(URL_TO_OPEN, "https://www.epratibha.net/mobile-login/?email=" + credentials[0] + "&pass=" + credentials[1]);
+        bundle.putBoolean(SHOW_LOADING_BETWEEN_PAGES, true);
+        bundle.putBoolean(IS_SSO_REQUIRED, false);
+        bundle.putBoolean(ALLOW_NON_INSTITUTE_URL_IN_WEB_VIEW, true);
+        bundle.putBoolean(ENABLE_SWIPE_REFRESH, true);
+        webViewFragment.setArguments(bundle);
+        adapter.addFragment(webViewFragment, storeLabel);
     }
 
     private boolean isStoreDisabled() {


### PR DESCRIPTION
- We initially initialized the WebViewFragment with constructor parameters. However, during activity and fragment recreation, these constructors would not be called, and only the default constructor would be invoked. This prevented us from properly initializing the WebViewFragment, leading to the app crash.
- In this commit, we addressed this issue by passing all values as an argument and removing the constructor parameters in the WebViewFragment.