### PR TITLE
refactor: Fetch the instituteSettings only for SSO login

### DIFF
--- a/core/src/main/java/in/testpress/util/webview/CustomWebViewClient.kt
+++ b/core/src/main/java/in/testpress/util/webview/CustomWebViewClient.kt
@@ -23,8 +23,7 @@ class CustomWebViewClient(val fragment: WebViewFragment) : WebViewClient() {
     }
 
     private fun shouldLoadInWebView(url: String?):Boolean {
-        val isInstituteUrl = fragment.instituteSettings.isInstituteUrl(url)
-        return if (isInstituteUrl){
+        return if (fragment.isInstituteUrl(url)){
             true
         } else {
             fragment.allowNonInstituteUrlInWebView


### PR DESCRIPTION
- Previously, we fetched instituteSettings during fragment creation, making it impossible to use the WebView fragment when the user is not authenticated.
- In this commit, we fetch instituteSettings if SSO is required; otherwise, instituteSettings will be null.