### PR TITLE
fix: Add exam timer for custom test

### DIFF
--- a/course/src/main/java/in/testpress/course/ui/CustomTestGenerationActivity.kt
+++ b/course/src/main/java/in/testpress/course/ui/CustomTestGenerationActivity.kt
@@ -5,6 +5,8 @@ import `in`.testpress.core.TestpressException
 import `in`.testpress.course.R
 import `in`.testpress.exam.api.TestpressExamApiClient
 import `in`.testpress.exam.ui.TestFragment
+import `in`.testpress.exam.ui.TestFragment.DEFAULT_EXAM_TIME
+import `in`.testpress.exam.ui.TestFragment.INFINITE_EXAM_TIME
 import `in`.testpress.models.greendao.Attempt
 import `in`.testpress.ui.AbstractWebViewActivity
 import `in`.testpress.util.BaseJavaScriptInterface
@@ -27,11 +29,12 @@ class CustomTestGenerationActivity: AbstractWebViewActivity() {
         apiClient.startAttempt("api/v2.2/attempts/$attemptId/start/")
             .enqueue(object : TestpressCallback<Attempt>() {
                 override fun onSuccess(result: Attempt?) {
-                    // Attempt we are receiving here does not contain remaining time because its
-                    // infinite timing exam attempt. As our app doesn't support exams with infinite
-                    // timing, so we are set 24 hours for remainingTime in this attempt.
+                    // Check if the remaining time for the attempt is infinite we reset to default value of 24 hours.
+                    // This is done because our app doesn't support exams with infinite timing.
                     result?.let {
-                        it.remainingTime = "24:00:00"
+                        if (it.remainingTime == INFINITE_EXAM_TIME) {
+                            it.remainingTime = DEFAULT_EXAM_TIME
+                        }
                         startExam(result)
                     }
                 }

--- a/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
@@ -80,6 +80,8 @@ public class TestFragment extends BaseFragment implements LoaderManager.LoaderCa
         PlainSpinnerItemAdapter.SectionInfoClickListener, TestPanelListAdapter.ListItemClickListener {
 
     private static final int APP_BACKGROUND_DELAY = 60000; // 1m
+    public static final String DEFAULT_EXAM_TIME = "24:00:00";
+    public static final String INFINITE_EXAM_TIME = "0:00:00";
 
     static final String PARAM_EXAM = "exam";
     static final String PARAM_ATTEMPT = "attempt";
@@ -215,7 +217,7 @@ public class TestFragment extends BaseFragment implements LoaderManager.LoaderCa
         if (exam != null && exam.hasMultipleLanguages()) {
             initializeLanguageFilter();
         }
-        if (exam == null) {
+        if (exam == null && attempt.getRemainingTime().equals(DEFAULT_EXAM_TIME)) {
             view.findViewById(R.id.timer).setVisibility(View.GONE);
         }
     }


### PR DESCRIPTION
- Initially, The exam timer is not available for custom tests because it has infinite time.
- In this commit, we have introduced an exam time limit for custom tests. If the user selects a specific time, the exam timer will be displayed; otherwise, it remains hidden.