### PR TITLE
enhancement: Add a question report button on the custom test solution page

### DIFF
--- a/exam/src/main/java/in/testpress/exam/ui/ReviewQuestionsFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/ReviewQuestionsFragment.java
@@ -372,16 +372,13 @@ public class ReviewQuestionsFragment extends Fragment {
                 reviewItem.getIndex() +
                 "</div>";
 
-        if (examId != -1L){
-            // Add Report button
-            html += "<div class='report-button' style='float:right;' onclick='onClickReportButton()'>" +
-                    "<svg xmlns=\"http://www.w3.org/2000/svg\" fill=\"none\" viewBox=\"0 0 24 24\" stroke-width=\"1.5\" stroke=\"currentColor\" style=\"width:1rem;height:1rem;vertical-align: sub;\">\n" +
-                    "  <path stroke-linecap=\"round\" stroke-linejoin=\"round\" d=\"M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z\" />\n" +
-                    "</svg>\n" +
-                    "Report Question" +
-                    "</div>";
-        }
-
+        // Add Report button
+        html += "<div class='report-button' style='float:right;' onclick='onClickReportButton()'>" +
+                "<svg xmlns=\"http://www.w3.org/2000/svg\" fill=\"none\" viewBox=\"0 0 24 24\" stroke-width=\"1.5\" stroke=\"currentColor\" style=\"width:1rem;height:1rem;vertical-align: sub;\">\n" +
+                "  <path stroke-linecap=\"round\" stroke-linejoin=\"round\" d=\"M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z\" />\n" +
+                "</svg>\n" +
+                "Report Question" +
+                "</div>";
 
         // Add direction/passage
         if (directionHtml != null && !directionHtml.isEmpty()) {

--- a/exam/src/main/java/in/testpress/exam/ui/viewmodel/ReportQuestionViewModel.kt
+++ b/exam/src/main/java/in/testpress/exam/ui/viewmodel/ReportQuestionViewModel.kt
@@ -27,8 +27,10 @@ class ReportQuestionViewModel(
     ) {
         val params = HashMap<String, Any>()
         params["description"] = description
-        params["exam_id"] = examId.toString()
         params["type"] = type.toString()
+        if (examId != -1L) {
+            params["exam_id"] = examId.toString()
+        }
         reportQuestionRepository.submitReportQuestion(questionId.toString(), params)
     }
 }


### PR DESCRIPTION
- In commit 489ee14, we removed the functionality to report questions for the custom test solution. This change was necessary because it required an examId that we don't have for custom tests.
- Recently, we added support for reporting questions on the web, and now we can report questions without needing an examId. As a result, in this commit and onwards, we permanently display the 'Report Question' button on the solution page for both normal exams and custom tests.
- We do not include the `examId` as param when reporting a question for a custom test.