### PR TITLE
fix: App crash when user clicks the timer view

### DIFF
--- a/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
@@ -536,7 +536,11 @@ public class TestFragment extends BaseFragment implements LoaderManager.LoaderCa
         timer.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                showPauseExamAlert();
+                if (exam == null){
+                    endExamAlert();
+                } else {
+                    showPauseExamAlert();
+                }
             }
         });
     }


### PR DESCRIPTION
- In this bcc2c5c we added support to show a timer for custom tests we are accessing the exam in timer click listener
- While clicking the timer view it accesses the exam object but the exam object is null for the custom test.
- In this commit, we handled to show pause exam alert dialog or end exam alter dialog according to the exam object.