### PR TITLE
enhancement: Add support to open review page from custom test webview

### DIFF
--- a/core/src/main/java/in/testpress/util/extension/Activity.kt
+++ b/core/src/main/java/in/testpress/util/extension/Activity.kt
@@ -4,7 +4,6 @@ import `in`.testpress.RequestCode
 import `in`.testpress.util.Permission
 import `in`.testpress.util.PermissionHandler
 import android.app.Activity
-import android.os.Message
 import android.widget.Toast
 import androidx.annotation.StringRes
 import androidx.core.app.ActivityCompat

--- a/core/src/main/java/in/testpress/util/extension/Activity.kt
+++ b/core/src/main/java/in/testpress/util/extension/Activity.kt
@@ -4,6 +4,9 @@ import `in`.testpress.RequestCode
 import `in`.testpress.util.Permission
 import `in`.testpress.util.PermissionHandler
 import android.app.Activity
+import android.os.Message
+import android.widget.Toast
+import androidx.annotation.StringRes
 import androidx.core.app.ActivityCompat
 
 fun Activity.askAllPermissions() {
@@ -17,4 +20,8 @@ fun Activity.performActionIfPermissionsGranted(
     action: () -> Unit
 ) {
     PermissionHandler().performActionIfPermissionsGranted(this,requiredPermissions,action)
+}
+
+fun Activity.toast(@StringRes resId: Int) {
+    Toast.makeText(this, resId, Toast.LENGTH_SHORT).show()
 }

--- a/course/src/main/java/in/testpress/course/ui/CustomTestGenerationActivity.kt
+++ b/course/src/main/java/in/testpress/course/ui/CustomTestGenerationActivity.kt
@@ -4,6 +4,7 @@ import `in`.testpress.core.TestpressCallback
 import `in`.testpress.core.TestpressException
 import `in`.testpress.course.R
 import `in`.testpress.exam.api.TestpressExamApiClient
+import `in`.testpress.exam.ui.ReviewStatsActivity
 import `in`.testpress.exam.ui.TestFragment
 import `in`.testpress.exam.ui.TestFragment.DEFAULT_EXAM_TIME
 import `in`.testpress.exam.ui.TestFragment.INFINITE_EXAM_TIME
@@ -50,6 +51,33 @@ class CustomTestGenerationActivity: AbstractWebViewActivity() {
             })
     }
 
+    fun getAttempt(attemptId: String) {
+        val apiClient = TestpressExamApiClient(this)
+        apiClient.getAttempt("api/v2.2/attempts/$attemptId/")
+            .enqueue(object : TestpressCallback<Attempt>() {
+                override fun onSuccess(result: Attempt?) {
+                    if (result != null){
+                        startActivity(ReviewStatsActivity.createIntent(this@CustomTestGenerationActivity,result))
+                        finish()
+                    } else {
+                        Toast.makeText(
+                            this@CustomTestGenerationActivity,
+                            "Review not found!, Please try again later",
+                            Toast.LENGTH_SHORT
+                        ).show()
+                    }
+                }
+
+                override fun onException(exception: TestpressException) {
+                    Toast.makeText(
+                        this@CustomTestGenerationActivity,
+                        "Review not found!, Please try again later",
+                        Toast.LENGTH_SHORT
+                    ).show()
+                }
+            })
+    }
+
     private fun startExam(attempt: Attempt) {
         findViewById<Toolbar>(R.id.toolbar).isVisible = false
         val testFragment = TestFragment()
@@ -86,6 +114,11 @@ class JavaScriptInterface(val activity: CustomTestGenerationActivity):BaseJavaSc
         }
         activity.startActivity(intent)
         activity.finish()
+    }
+
+    @JavascriptInterface
+    fun showReview(attemptId: String) {
+        activity.getAttempt(attemptId)
     }
 
 }

--- a/course/src/main/java/in/testpress/course/ui/CustomTestGenerationActivity.kt
+++ b/course/src/main/java/in/testpress/course/ui/CustomTestGenerationActivity.kt
@@ -15,9 +15,7 @@ import `in`.testpress.util.extension.toast
 import android.content.Intent
 import android.os.Bundle
 import android.webkit.JavascriptInterface
-import android.widget.Toast
 import android.widget.Toolbar
-import androidx.annotation.StringRes
 import androidx.core.view.isVisible
 
 

--- a/course/src/main/java/in/testpress/course/ui/CustomTestGenerationActivity.kt
+++ b/course/src/main/java/in/testpress/course/ui/CustomTestGenerationActivity.kt
@@ -41,12 +41,7 @@ class CustomTestGenerationActivity: AbstractWebViewActivity() {
                 }
 
                 override fun onException(exception: TestpressException) {
-                    Toast.makeText(
-                        this@CustomTestGenerationActivity,
-                        "Something went wrong, Please try again later",
-                        Toast.LENGTH_SHORT
-                    ).show()
-                    finish()
+                    showToast("Something went wrong, Please try again later")
                 }
             })
     }
@@ -60,22 +55,19 @@ class CustomTestGenerationActivity: AbstractWebViewActivity() {
                         startActivity(ReviewStatsActivity.createIntent(this@CustomTestGenerationActivity,result))
                         finish()
                     } else {
-                        Toast.makeText(
-                            this@CustomTestGenerationActivity,
-                            "Review not found!, Please try again later",
-                            Toast.LENGTH_SHORT
-                        ).show()
+                        showToast("Review not found!, Please try again later")
                     }
                 }
 
                 override fun onException(exception: TestpressException) {
-                    Toast.makeText(
-                        this@CustomTestGenerationActivity,
-                        "Review not found!, Please try again later",
-                        Toast.LENGTH_SHORT
-                    ).show()
+                    showToast("Review not found!, Please try again later")
                 }
             })
+    }
+
+    private fun showToast(message: String) {
+        Toast.makeText(this@CustomTestGenerationActivity, message, Toast.LENGTH_SHORT).show()
+        finish()
     }
 
     private fun startExam(attempt: Attempt) {

--- a/course/src/main/java/in/testpress/course/ui/CustomTestGenerationActivity.kt
+++ b/course/src/main/java/in/testpress/course/ui/CustomTestGenerationActivity.kt
@@ -55,12 +55,12 @@ class CustomTestGenerationActivity: AbstractWebViewActivity() {
                         startActivity(ReviewStatsActivity.createIntent(this@CustomTestGenerationActivity,result))
                         finish()
                     } else {
-                        showToast("Review not found!, Please try again later")
+                        showToast("Review not found, Please try again later")
                     }
                 }
 
                 override fun onException(exception: TestpressException) {
-                    showToast("Review not found!, Please try again later")
+                    showToast("Review not found, Please try again later")
                 }
             })
     }

--- a/course/src/main/res/values/strings.xml
+++ b/course/src/main/res/values/strings.xml
@@ -82,7 +82,7 @@
     <string name="no_upcoming_contents">There are no upcoming scheduled contents for you..</string>
     
     <string name="custom_test_permission_error">Permission Denied, You do not have permission to take this exam.</string>
-    <string name="custom_test_network_error">Network Error, Please check your internet connection & try again.</string>
+    <string name="custom_test_network_error">Network Error, Please check your internet connection &amp; try again.</string>
     <string name="custom_test_page_not_found_error">Exam is no longer available, Create a new exam</string>
     <string name="custom_test_unknown_error">Something went wrong, Please try again later</string>
 

--- a/course/src/main/res/values/strings.xml
+++ b/course/src/main/res/values/strings.xml
@@ -80,6 +80,11 @@
 
     <string name="testpress_upcoming_contents">Upcoming</string>
     <string name="no_upcoming_contents">There are no upcoming scheduled contents for you..</string>
+    
+    <string name="custom_test_permission_error">Permission Denied, You do not have permission to take this exam.</string>
+    <string name="custom_test_network_error">Network Error, Please check your internet connection & try again.</string>
+    <string name="custom_test_page_not_found_error">Exam is no longer available, Create a new exam</string>
+    <string name="custom_test_unknown_error">Something went wrong, Please try again later</string>
 
     <string-array name="exo_speed_values">
         <item>0.5</item>

--- a/exam/src/main/java/in/testpress/exam/api/ExamService.java
+++ b/exam/src/main/java/in/testpress/exam/api/ExamService.java
@@ -79,6 +79,10 @@ public interface ExamService {
     RetrofitCall<Attempt> startAttempt(
             @Path(value = "start_attempt_url", encoded = true) String startAttemptUrlFrag);
 
+    @GET("/{get_attempt_url}")
+    RetrofitCall<Attempt> getAttempt(
+            @Path(value = "get_attempt_url", encoded = true) String startAttemptUrlFrag);
+
     @PUT("/{answer_url}")
     RetrofitCall<AttemptItem> postAnswer(
             @Path(value = "answer_url", encoded = true) String answerUrlFrag,

--- a/exam/src/main/java/in/testpress/exam/api/TestpressExamApiClient.java
+++ b/exam/src/main/java/in/testpress/exam/api/TestpressExamApiClient.java
@@ -141,6 +141,10 @@ public class TestpressExamApiClient extends TestpressApiClient {
         return getExamService().startAttempt(startAttemptUrlFrag);
     }
 
+    public RetrofitCall<Attempt> getAttempt(String getAttemptUrlFrag) {
+        return getExamService().getAttempt(getAttemptUrlFrag);
+    }
+
     public RetrofitCall<Attempt> endAttempt(String endAttemptUrlFrag) {
         return getExamService().endExam(endAttemptUrlFrag);
     }


### PR DESCRIPTION
- In this commit, we introduced a JavaScript interface method `showReview()` in CustomTestGenerationActivity to display the review page on Android. Now, when users click on a review, we fetch the corresponding attempt using the `attemptId` and open the review page.