### PR TITLE
fix: Show total time in TestReport page

### DIFF
--- a/core/src/main/java/in/testpress/util/TimeUtils.kt
+++ b/core/src/main/java/in/testpress/util/TimeUtils.kt
@@ -5,4 +5,27 @@ object TimeUtils {
     fun convertMilliSecondsToSeconds(milliseconds: Long): Long {
         return maxOf(0, milliseconds) / 1000
     }
+
+    fun convertDurationStringToSeconds(durationString: String?): Long {
+        if (durationString == null) return 0
+        val durationList = durationString.split(":").toMutableList()
+        var seconds = 0L
+        var minutes = 1L
+
+        while (durationList.size > 0) {
+            seconds += minutes * durationList.removeLast().toLong()
+            minutes *= 60
+        }
+
+        return seconds
+    }
+
+    fun addTimeStrings(timeTaken: String?, remainingTime: String?): String {
+        // Here, we add one second to totalTime because remainingTime is always one second less than the actual value.
+        val totalTime: Long = convertDurationStringToSeconds(timeTaken) + convertDurationStringToSeconds(remainingTime) + 1
+        val hours = (totalTime / (60 * 60)).toInt()
+        val minutes = (totalTime / 60 % 60).toInt()
+        val seconds = (totalTime % 60).toInt()
+        return String.format("%02d:%02d:%02d", hours, minutes, seconds)
+    }
 }

--- a/exam/src/main/java/in/testpress/exam/ui/ReviewStatsFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/ReviewStatsFragment.java
@@ -30,10 +30,7 @@ import android.widget.TextView;
 
 import junit.framework.Assert;
 
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.util.HashMap;
-import java.util.TimeZone;
 
 import in.testpress.core.TestpressCallback;
 import in.testpress.core.TestpressException;

--- a/exam/src/main/java/in/testpress/exam/ui/ReviewStatsFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/ReviewStatsFragment.java
@@ -55,6 +55,7 @@ import in.testpress.util.FileDownloader;
 import in.testpress.util.FileType;
 import in.testpress.util.PermissionsUtils;
 import in.testpress.util.StringUtils;
+import in.testpress.util.TimeUtils;
 import in.testpress.util.UIUtils;
 import in.testpress.util.ViewUtils;
 
@@ -477,33 +478,9 @@ public class ReviewStatsFragment extends BaseFragment {
         if (isExamNotNull()){
             totalTime.setText(exam.getDuration());
         } else if (!attempt.getRemainingTime().equals(INFINITE_EXAM_TIME)) {
-            totalTime.setText(addTimeStrings(attempt.getTimeTaken(),attempt.getRemainingTime()));
+            totalTime.setText(TimeUtils.INSTANCE.addTimeStrings(attempt.getTimeTaken(),attempt.getRemainingTime()));
         } else {
             totalTime.setText("");
-        }
-    }
-
-    public String addTimeStrings(String timeTaken, String remainingTime) {
-        // Here, we add one second to totalTime because remainingTime is always one second less than the actual value.
-        long totalTime = formatMillisecond(timeTaken) + formatMillisecond(remainingTime) + 1000;
-        int hours = (int) (totalTime / (1000 * 60 * 60));
-        int minutes = (int) ((totalTime / (1000 * 60)) % 60);
-        int seconds = (int) ((totalTime / 1000) % 60);
-        return String.format("%02d:%02d:%02d", hours, minutes, seconds);
-    }
-
-    @SuppressLint("SimpleDateFormat")
-    long formatMillisecond(String inputString) {
-        if (inputString == null) {
-            return 0;
-        }
-        SimpleDateFormat simpleDateFormat = new SimpleDateFormat("HH:mm:ss");
-        simpleDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
-        try {
-            return simpleDateFormat.parse(inputString).getTime();
-        } catch (ParseException e) {
-            e.printStackTrace();
-            return 0;
         }
     }
 

--- a/exam/src/main/java/in/testpress/exam/ui/ReviewStatsFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/ReviewStatsFragment.java
@@ -30,7 +30,10 @@ import android.widget.TextView;
 
 import junit.framework.Assert;
 
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.HashMap;
+import java.util.TimeZone;
 
 import in.testpress.core.TestpressCallback;
 import in.testpress.core.TestpressException;
@@ -60,6 +63,7 @@ import static in.testpress.exam.ui.ReviewStatsActivity.PARAM_ATTEMPT;
 import static in.testpress.exam.ui.ReviewStatsActivity.PARAM_COURSE_ATTEMPT;
 import static in.testpress.exam.ui.ReviewStatsActivity.PARAM_EXAM;
 import static in.testpress.exam.ui.ReviewStatsActivity.PARAM_PREVIOUS_ACTIVITY;
+import static in.testpress.exam.ui.TestFragment.INFINITE_EXAM_TIME;
 
 public class ReviewStatsFragment extends BaseFragment {
 
@@ -472,8 +476,34 @@ public class ReviewStatsFragment extends BaseFragment {
     private void setTotalTime() {
         if (isExamNotNull()){
             totalTime.setText(exam.getDuration());
+        } else if (!attempt.getRemainingTime().equals(INFINITE_EXAM_TIME)) {
+            totalTime.setText(addTimeStrings(attempt.getTimeTaken(),attempt.getRemainingTime()));
         } else {
             totalTime.setText("");
+        }
+    }
+
+    public String addTimeStrings(String timeTaken, String remainingTime) {
+        // Here, we add one second to totalTime because remainingTime is always one second less than the actual value.
+        long totalTime = formatMillisecond(timeTaken) + formatMillisecond(remainingTime) + 1000;
+        int hours = (int) (totalTime / (1000 * 60 * 60));
+        int minutes = (int) ((totalTime / (1000 * 60)) % 60);
+        int seconds = (int) ((totalTime / 1000) % 60);
+        return String.format("%02d:%02d:%02d", hours, minutes, seconds);
+    }
+
+    @SuppressLint("SimpleDateFormat")
+    long formatMillisecond(String inputString) {
+        if (inputString == null) {
+            return 0;
+        }
+        SimpleDateFormat simpleDateFormat = new SimpleDateFormat("HH:mm:ss");
+        simpleDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+        try {
+            return simpleDateFormat.parse(inputString).getTime();
+        } catch (ParseException e) {
+            e.printStackTrace();
+            return 0;
         }
     }
 


### PR DESCRIPTION
- In this commit bcc2c5c, a timer for a custom test has been added. When the user finishes the exam, the report page is displayed without showing the total time.
- In this commit, we showcase the total time on the report page by adding both the `timeTaken` and `remainingTime` values in attempt.