### PR TITLE
fix: Close Custom test activity when user press the back button

### DIFF
--- a/course/src/main/java/in/testpress/course/ui/CustomTestGenerationActivity.kt
+++ b/course/src/main/java/in/testpress/course/ui/CustomTestGenerationActivity.kt
@@ -94,7 +94,7 @@ class CustomTestGenerationActivity: AbstractWebViewActivity() {
         if (testFragment != null) {
             testFragment.showEndExamAlert()
         } else {
-            super.onBackPressed()
+            this.finish()
         }
     }
 


### PR DESCRIPTION
- Previously when pressing the back button we navigated between the webview if it have a back stack.
- In this commit, the activity is closed when the user presses the back button.