### PR TITLE
fix: Prevent Custom test activity closing

### DIFF
--- a/course/src/main/java/in/testpress/course/ui/CustomTestGenerationActivity.kt
+++ b/course/src/main/java/in/testpress/course/ui/CustomTestGenerationActivity.kt
@@ -58,7 +58,6 @@ class CustomTestGenerationActivity: AbstractWebViewActivity() {
                                 result
                             )
                         )
-                        finish()
                     }
                 }
 


### PR DESCRIPTION
- Previously, when the user opened the review activity from the custom test, we would finish the custom test activity.
- With this commit, we no longer finish the custom test activity.