### PR TITLE
fix: App crash when the DocumentViewerFragment re-instantiated

### DIFF
--- a/course/src/main/java/in/testpress/course/fragments/DocumentViewerFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/DocumentViewerFragment.kt
@@ -171,7 +171,9 @@ class DocumentViewerFragment : BaseContentDetailFragment(), PdfDownloadListener,
 
     override fun onDetach() {
         super.onDetach()
-        pdfDownloadManager.cancel()
-        pdfDownloadManager.cleanup()
+        if (::pdfDownloadManager.isInitialized) {
+            pdfDownloadManager.cancel()
+            pdfDownloadManager.cleanup()
+        }
     }
 }


### PR DESCRIPTION
- Activity recreation occurs when the device experiences low memory. This issue specifically occurs in the `DocumentViewerFragment`, where we access the `pdfDownloadManager` within the `onDetach()` lifecycle event. The `pdfDownloadManager` is declared as a `lateinit` property, and during the `onDetach()` call, the application crashes due to the `pdfDownloadManager` not being initialized at that point.
- In this commit, we handled the Initialization check in `onDetach()` function.
