### PR TITLE
 fix:  App crash on Video Conference detail page upon network reconnection

### DIFF
--- a/course/src/main/java/in/testpress/course/util/ZoomMeetHandler.kt
+++ b/course/src/main/java/in/testpress/course/util/ZoomMeetHandler.kt
@@ -139,7 +139,6 @@ class ZoomMeetHandler(
     }
 
     override fun onZoomSDKInitializeResult(errorCode: Int, internalErrorCode: Int) {
-        zoomSDK.zoomUIService.hideMeetingInviteUrl(true)
         if (errorCode != ZoomError.ZOOM_ERROR_SUCCESS) {
             Toast.makeText(
                 context,
@@ -177,6 +176,7 @@ class ZoomMeetHandler(
             getMeetingParameters(),
             getMeetingOptions()
         )
+        zoomSDK.zoomUIService.hideMeetingInviteUrl(true)
     }
 
     private fun getMeetingOptions(): JoinMeetingOptions {


### PR DESCRIPTION
- In commit e826f09, we hide the Zoom meeting URL to prevent users from sharing the meeting link.
- However, we encountered an issue in the `onZoomSDKInitializeResult()` method, which is triggered upon successful or failed initialization of the Zoom SDK. In the case of failure, `ZoomSDK.zoomUIService` becomes null at the time we try to hide the meeting URL leading to the application crash.
- To address this issue, we have now implemented a solution to hide the meeting URL when the user starts the meeting.