### PR TITLE
fix: Change WebView cache mode to `LOAD_CACHE_ELSE_NETWORK`

### DIFF
--- a/core/src/main/java/in/testpress/fragments/WebViewFragment.kt
+++ b/core/src/main/java/in/testpress/fragments/WebViewFragment.kt
@@ -116,7 +116,7 @@ class WebViewFragment : Fragment(), EmptyViewListener {
         webView.settings.domStorageEnabled = true
         // Disable pinch to zoom without the zoom buttons
         webView.settings.builtInZoomControls = false
-        webView.settings.cacheMode = WebSettings.LOAD_NO_CACHE
+        webView.settings.cacheMode = WebSettings.LOAD_CACHE_ELSE_NETWORK
         webView.settings.setSupportZoom(allowZoomControl)
         webView.webViewClient = CustomWebViewClient(this)
         webView.webChromeClient = CustomWebChromeClient(this)

--- a/core/src/main/java/in/testpress/util/WebViewUtils.java
+++ b/core/src/main/java/in/testpress/util/WebViewUtils.java
@@ -42,7 +42,7 @@ public class WebViewUtils {
         webSettings.setLoadWithOverviewMode(true);
         webSettings.setDatabaseEnabled(true);
         webSettings.setDomStorageEnabled(true);
-        webSettings.setCacheMode(WebSettings.LOAD_NO_CACHE);
+        webSettings.setCacheMode(WebSettings.LOAD_CACHE_ELSE_NETWORK);
         webSettings.setRenderPriority(WebSettings.RenderPriority.HIGH);
     }
 


### PR DESCRIPTION
- The cache mode for the WebView in the WebViewUtils class has been switched from LOAD_NO_CACHE to LOAD_CACHE_ELSE_NETWORK. This adjustment aims to enhance performance by leveraging cached resources whenever possible, resorting to network resources only when necessary.
- By making these adjustments, WebView is now designed to prioritize loading resources from the cache when available, thereby minimizing unnecessary downloads and preserving user data.