### PR TITLE
fix: Not able to upload file in file type question

### DIFF
--- a/core/src/main/java/in/testpress/util/Misc.kt
+++ b/core/src/main/java/in/testpress/util/Misc.kt
@@ -2,6 +2,7 @@ package `in`.testpress.util
 
 import android.content.Context
 import android.net.ConnectivityManager
+import android.os.Build
 import java.net.URL
 import java.util.*
 import android.webkit.MimeTypeMap
@@ -36,4 +37,6 @@ object Misc {
         }
         return type
     }
+
+    fun isAndroid13OrHigher() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
 }

--- a/exam/src/main/java/in/testpress/exam/ui/TestQuestionFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestQuestionFragment.java
@@ -47,6 +47,7 @@ import in.testpress.models.FileDetails;
 import in.testpress.models.InstituteSettings;
 import in.testpress.models.greendao.Exam;
 import in.testpress.models.greendao.Language;
+import in.testpress.util.Misc;
 import in.testpress.util.PermissionHandler;
 import in.testpress.util.ProgressDialog;
 import in.testpress.util.WebViewUtils;
@@ -342,16 +343,11 @@ public class TestQuestionFragment extends Fragment implements PickiTCallbacks, E
         @JavascriptInterface
         public void onFileUploadClick() {
             Log.d("TAG", "onFileUploadClick: ");
-            if (isAndroid13OrHigher()) {
+            if (Misc.INSTANCE.isAndroid13OrHigher()) {
                 pickFile();
             } else {
                 handlePermissionsForFilePick();
             }
-        }
-
-        @ChecksSdkIntAtLeast(api = Build.VERSION_CODES.TIRAMISU)
-        boolean isAndroid13OrHigher() {
-            return Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU;
         }
 
         void handlePermissionsForFilePick() {

--- a/exam/src/main/java/in/testpress/exam/ui/TestQuestionFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestQuestionFragment.java
@@ -11,6 +11,7 @@ import android.content.Intent;
 import android.os.Build;
 import android.os.Bundle;
 
+import androidx.annotation.ChecksSdkIntAtLeast;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
@@ -341,6 +342,19 @@ public class TestQuestionFragment extends Fragment implements PickiTCallbacks, E
         @JavascriptInterface
         public void onFileUploadClick() {
             Log.d("TAG", "onFileUploadClick: ");
+            if (isAndroid13OrHigher()) {
+                pickFile();
+            } else {
+                handlePermissionsForFilePick();
+            }
+        }
+
+        @ChecksSdkIntAtLeast(api = Build.VERSION_CODES.TIRAMISU)
+        boolean isAndroid13OrHigher() {
+            return Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU;
+        }
+
+        void handlePermissionsForFilePick() {
             if (PermissionHandler.Companion.hasPermissions(
                     requireActivity(),
                     Arrays.asList(READ_EXTERNAL_STORAGE, WRITE_EXTERNAL_STORAGE)

--- a/exam/src/main/java/in/testpress/exam/ui/TestQuestionFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestQuestionFragment.java
@@ -11,7 +11,6 @@ import android.content.Intent;
 import android.os.Build;
 import android.os.Bundle;
 
-import androidx.annotation.ChecksSdkIntAtLeast;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;


### PR DESCRIPTION
- Previously, we used to verify file access permissions before uploading files from Android. Starting from Android 13, permission is no longer required to access the file picker. Now, permission checks are only conducted for Android 12 and below.