### PR TITLE
fix: Prevent screen captures during Zoom classes. 

### DIFF
--- a/course/src/main/java/in/testpress/course/util/ZoomMeetHandler.kt
+++ b/course/src/main/java/in/testpress/course/util/ZoomMeetHandler.kt
@@ -5,6 +5,7 @@ import `in`.testpress.core.TestpressSdk.COURSE_CONTENT_DETAIL_REQUEST_CODE
 import `in`.testpress.course.domain.DomainVideoConferenceContent
 import `in`.testpress.course.domain.zoom.callbacks.MeetingCommonCallback
 import `in`.testpress.course.ui.CustomMeetingActivity
+import `in`.testpress.course.ui.ZoomMeetActivity
 import `in`.testpress.models.InstituteSettings
 import `in`.testpress.models.ProfileDetails
 import `in`.testpress.util.isEmailValid
@@ -177,6 +178,7 @@ class ZoomMeetHandler(
             getMeetingOptions()
         )
         zoomSDK.zoomUIService.hideMeetingInviteUrl(true)
+        zoomSDK.zoomUIService?.setNewMeetingUI(ZoomMeetActivity::class.java)
     }
 
     private fun getMeetingOptions(): JoinMeetingOptions {

--- a/course/src/main/res/values/config.xml
+++ b/course/src/main/res/values/config.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="zm_config_conf_activity">in.testpress.course.ui.ZoomMeetActivity</string>
-</resources>


### PR DESCRIPTION
- In commit e47a34c, the Zoom SDK was updated, and at that time, the functionality to restrict users from taking screen captures was deprecated.
- In this commit, we fixed the issue by adding `zoomSDK.zoomUIService?.setNewMeetingUI(ZoomMeetActivity::class.java)`, allowing us to restrict users from taking screen captures.
- Additionally, we removed `config.xml` because it is no longer required since we are achieving the functionality through the aforementioned method.