### PR TITLE
enhancement: Use dependency as API instead of implementation

### DIFF
--- a/course/build.gradle
+++ b/course/build.gradle
@@ -70,8 +70,8 @@ dependencies {
     androidTestImplementation rootProject.testRunner
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
-    implementation 'com.github.mhiew:android-pdf-viewer:3.2.0-beta.1'
-    implementation 'com.github.alexto9090:PRDownloader:1.0'
+    api 'com.github.mhiew:android-pdf-viewer:3.2.0-beta.1'
+    api 'com.github.alexto9090:PRDownloader:1.0'
 
     androidTestImplementation "androidx.test:core:1.4.0"
     androidTestImplementation "androidx.test:rules:1.1.0"
@@ -79,7 +79,7 @@ dependencies {
 
     // Allow methods more than 64K
     implementation 'androidx.multidex:multidex:2.0.1'
-    implementation 'com.github.vkay94:DoubleTapPlayerView:1.0.0'
+    api 'com.github.vkay94:DoubleTapPlayerView:1.0.0'
 
     // Allow methods more than 64K
     implementation 'androidx.multidex:multidex:2.0.1'


### PR DESCRIPTION
- Changed dependencies to API for the following packages in this commit
- `android-pdf-viewer`, `PRDownloader`, `DoubleTapPlayerView`
- By doing this, we don't need to implement the following dependencies in the app project.