### PR TITLE
enhancement: Use dependency as API instead of implementation

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -79,7 +79,7 @@ dependencies {
     api 'pub.devrel:easypermissions:3.0.0'
     api 'io.branch.sdk.android:library:5.0.1'
     api 'com.facebook.android:facebook-android-sdk:5.15.3'
-    implementation 'com.google.firebase:firebase-analytics:17.4.0'
+    api 'com.google.firebase:firebase-analytics:17.4.0'
     api rootProject.pagingRuntime
     api "androidx.fragment:fragment-ktx:$fragment_version"
     api "com.github.skydoves:powerspinner:1.1.9"


### PR DESCRIPTION
- Changed dependency to API for firebase-analytics in this commit.
- This eliminates the need to implement the firebase-analytics dependency in the app project.