### PR TITLE
enhancement: Update Kotlin version to 1.7.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.6.0'
+    ext.kotlin_version = '1.7.0'
     ext.kotlin_coroutine_version = '1.3.3'
     repositories {
         google()

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -62,9 +62,9 @@ android {
 
 dependencies {
     api rootProject.constraintLayout
-    def core_version = "1.2.0"
+    def core_version = "1.7.0"
     def core_testing_version = "2.1.0"
-    def room_version = "2.4.0"
+    def room_version = "2.4.3"
     def multi_dex_version = "2.0.1"
     def fragment_version = "1.4.1"
 

--- a/course/src/main/java/in/testpress/course/fragments/BaseContentDetailFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/BaseContentDetailFragment.kt
@@ -104,6 +104,7 @@ abstract class BaseContentDetailFragment : Fragment(), BookmarkListener, Content
                         initializeBookmarkFragment()
                     }
                 }
+                else -> {}
             }
         })
     }
@@ -143,6 +144,7 @@ abstract class BaseContentDetailFragment : Fragment(), BookmarkListener, Content
                         Status.ERROR -> {
                             toast.show()
                         }
+                        else -> {}
                     }
                 }
             })
@@ -178,6 +180,7 @@ abstract class BaseContentDetailFragment : Fragment(), BookmarkListener, Content
             viewModel.getContent(content.nextContentId!!, forceRefresh = true).observe(viewLifecycleOwner, Observer {
                 when(it.status) {
                     Status.SUCCESS -> bottomNavigationFragment.initializeAndShowNavigationButtons()
+                    else -> {}
                 }
             })
         }

--- a/course/src/main/java/in/testpress/course/fragments/BaseExamWidgetFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/BaseExamWidgetFragment.kt
@@ -73,6 +73,7 @@ open class BaseExamWidgetFragment : Fragment() {
                     content = it.data!!
                     loadAttemptsAndUpdateStartButton()
                 }
+                else -> {}
             }
         })
     }
@@ -109,6 +110,7 @@ open class BaseExamWidgetFragment : Fragment() {
                         viewModel.getLanguages(exam.slug!!, exam.id)
                             .observe(viewLifecycleOwner, observer)
                     }
+                    else -> {}
                 }
             })
     }

--- a/course/src/main/java/in/testpress/course/fragments/ContentBottomNavigationFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/ContentBottomNavigationFragment.kt
@@ -110,6 +110,7 @@ class ContentBottomNavigationFragment : Fragment() {
                     viewModel.getContentsForChapter(content.chapterId!!)?.observe(
                             viewLifecycleOwner, contentsFromChapterObserver)
                 }
+                else -> {}
             }
         })
     }

--- a/course/src/main/java/in/testpress/course/fragments/ContentLoadingFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/ContentLoadingFragment.kt
@@ -88,6 +88,7 @@ class ContentLoadingFragment : Fragment(),
                     loadingLayout.visibility = View.GONE
                     emptyViewFragment.displayError(resource.exception!!)
                 }
+                else -> {}
             }
         })
     }
@@ -123,6 +124,7 @@ class ContentLoadingFragment : Fragment(),
                         loadingLayout.visibility = View.GONE
                         emptyViewFragment.displayError(resource.exception!!)
                     }
+                    else -> {}
                 }
             })
     }

--- a/course/src/main/java/in/testpress/course/fragments/DownloadsFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/DownloadsFragment.kt
@@ -157,6 +157,7 @@ class DownloadsFragment : Fragment(), EmptyViewListener {
                     ).show()
                 }
                 Status.SUCCESS -> checkCourseRefreshDateAndDisplay()
+                else -> {}
             }
         })
     }

--- a/course/src/main/java/in/testpress/course/fragments/LoadingQuestionsFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/LoadingQuestionsFragment.kt
@@ -96,6 +96,7 @@ class LoadingQuestionsFragment : Fragment(),
                         loadingLayout.visibility = View.GONE
                         emptyViewFragment.displayError(resource.exception!!)
                     }
+                    else -> {}
                 }
             })
         } else {
@@ -110,6 +111,7 @@ class LoadingQuestionsFragment : Fragment(),
                         loadingLayout.visibility = View.GONE
                         emptyViewFragment.displayError(resource.exception!!)
                     }
+                    else -> {}
                 }
             })
         }
@@ -130,6 +132,7 @@ class LoadingQuestionsFragment : Fragment(),
                     loadingLayout.visibility = View.GONE
                     emptyViewFragment.displayError(resource.exception!!)
                 }
+                else -> {}
             }
         })
     }

--- a/course/src/main/java/in/testpress/course/fragments/NativeVideoWidgetFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/NativeVideoWidgetFragment.kt
@@ -40,6 +40,7 @@ class NativeVideoWidgetFragment : BaseVideoWidgetFragment() {
                 Status.SUCCESS -> {
                     createAttemptAndInitializeExoplayer(it.data!!)
                 }
+                else -> {}
             }
         })
     }

--- a/course/src/main/java/in/testpress/course/fragments/QuizAttemptsList.kt
+++ b/course/src/main/java/in/testpress/course/fragments/QuizAttemptsList.kt
@@ -59,6 +59,7 @@ class QuizAttemptsList : Fragment() {
                     content = it.data!!
                     loadAttempts()
                 }
+                else -> {}
             }
         })
     }
@@ -72,6 +73,7 @@ class QuizAttemptsList : Fragment() {
                         contentAttempts = resource.data!!
                         display()
                     }
+                    else -> {}
                 }
             })
     }

--- a/course/src/main/java/in/testpress/course/fragments/QuizQuestionFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/QuizQuestionFragment.kt
@@ -96,6 +96,7 @@ class QuizQuestionFragment : Fragment() {
                     userSelectedAnswer = it.data?.sortedBy { it.order }?.get(position)!!
                     initWebview()
                 }
+                else -> {}
             }
         })
     }

--- a/course/src/main/java/in/testpress/course/fragments/QuizReviewFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/QuizReviewFragment.kt
@@ -105,6 +105,7 @@ class QuizReviewFragment: Fragment() {
                     userSelectedAnswer = it.data?.sortedBy { it.order }?.get(position)!!
                     initWebview()
                 }
+                else -> {}
             }
         })
     }

--- a/course/src/main/java/in/testpress/course/fragments/StartQuizFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/StartQuizFragment.kt
@@ -46,6 +46,7 @@ class StartQuizFragment: BaseExamWidgetFragment() {
                     display()
                     loadAttemptsAndUpdateStartButton()
                 }
+                else -> {}
             }
         })
     }

--- a/course/src/main/java/in/testpress/course/fragments/WebViewVideoFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/WebViewVideoFragment.kt
@@ -52,6 +52,7 @@ open class WebViewVideoFragment : BaseVideoWidgetFragment() {
                     video = it.data?.video
                     loadVideo(it.data!!)
                 }
+                else -> {}
             }
         })
     }

--- a/course/src/main/java/in/testpress/course/ui/ContentListFragment.kt
+++ b/course/src/main/java/in/testpress/course/ui/ContentListFragment.kt
@@ -84,6 +84,7 @@ class ContentListFragment : BaseContentListFragment(), EmptyViewListener {
                         emptyViewFragment.displayError(resource.exception!!)
                     }
                 }
+                else -> {}
             }
         })
     }

--- a/course/src/main/java/in/testpress/course/ui/QuizActivity.kt
+++ b/course/src/main/java/in/testpress/course/ui/QuizActivity.kt
@@ -83,6 +83,7 @@ class QuizActivity : BaseToolBarActivity(), ShowQuizHandler, ExamEndHanlder, Que
                 Status.ERROR -> {
                     handleExamEndError(it.exception!!)
                 }
+                else -> {}
             }
         }
 
@@ -100,6 +101,7 @@ class QuizActivity : BaseToolBarActivity(), ShowQuizHandler, ExamEndHanlder, Que
                 Status.ERROR -> {
                     handleExamEndError(it.exception!!)
                 }
+                else -> {}
             }
         })
     }

--- a/course/src/main/java/in/testpress/course/util/ZoomMeetHandler.kt
+++ b/course/src/main/java/in/testpress/course/util/ZoomMeetHandler.kt
@@ -118,6 +118,7 @@ class ZoomMeetHandler(
                     showCustomMeetingUI(false)
                 }
             }
+            else -> {}
         }
     }
 

--- a/exam/build.gradle
+++ b/exam/build.gradle
@@ -60,7 +60,7 @@ dependencies {
     androidTestImplementation rootProject.espressoCore
     androidTestImplementation rootProject.uiautomator
     androidTestImplementation 'androidx.test:rules:1.2.0'
-    implementation "androidx.core:core-ktx:1.2.0"
+    implementation "androidx.core:core-ktx:1.7.0"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }
 


### PR DESCRIPTION
- Updated Kotlin version from `1.6.0` to `1.7.0` and corresponding room database version from `2.4.0` to `2.4.3`.
- Added an `else` branch for all when statements due to Kotlin `1.7.0` changes, where `when` statements with `enum`, `sealed`, and `Boolean` subjects are exhaustive by default. More details can be found in the [[Docs](https://kotlinlang.org/docs/compatibility-guide-17.html#make-when-statements-with-enum-sealed-and-boolean-subjects-exhaustive-by-default)] and [[Issue](https://youtrack.jetbrains.com/issue/KT-47709?_gl=1*fa3yyi*_ga*MTE2NDk5ODIwNC4xNzEzNDM5NDk1*_ga_9J976DJZ68*MTcxMzQzOTQ5NC4xLjEuMTcxMzQ0MDU1Ni42MC4wLjA.&_ga=2.73157715.1326330261.1713439495-1164998204.1713439495)].
