### PR TITLE
enhancement: Update Android Gradle Plugin version to `7.2.2`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.4'
+        classpath 'com.android.tools.build:gradle:7.2.2'
         classpath 'com.google.gms:google-services:3.2.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         // NOTE: Do not place your application dependencies here; they belong

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ ext {
     minSdkVersion = 23
     targetSdkVersion = 33
     minSdkVersionForUITest = 23
-    buildToolsVersion = '30.0.2'
+    buildToolsVersion = '30.0.3'
     supportLib = '27.1.1'
     exoPlayer = '2.17.1'
     powermock = '2.0.5'

--- a/course/src/androidTest/AndroidManifest.xml
+++ b/course/src/androidTest/AndroidManifest.xml
@@ -3,4 +3,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="in.testpress.course.androidTest">
     <uses-sdk tools:overrideLibrary="android_libs.ub_uiautomator"/>
+
+    <application
+        android:allowBackup="true"
+        tools:replace="android:allowBackup"/>
 </manifest>

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue Dec 21 15:47:53 IST 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
- Updated Android Gradle Plugin version from `7.0.4` to `7.2.2`.
- Updated Gradle version from `7.3.2` to `7.3.3`.
- Updated SDK Build Tools from `30.0.2` to `30.0.3`.
- Updated corresponding dependencies. See [Docs](https://developer.android.com/build/releases/past-releases/agp-7-2-0-release-notes) for more details.
