### PR TITLE
fix: Unable to take screenshot even if it's enabled.

### DIFF
--- a/course/src/main/java/in/testpress/course/ui/ZoomMeetActivity.kt
+++ b/course/src/main/java/in/testpress/course/ui/ZoomMeetActivity.kt
@@ -19,9 +19,11 @@ class ZoomMeetActivity: NewMeetingActivity() {
     }
 
     private fun disableScreenRecording() {
-        window.setFlags(
-            WindowManager.LayoutParams.FLAG_SECURE,
-            WindowManager.LayoutParams.FLAG_SECURE
-        )
+        if (session != null && session.instituteSettings.isScreenshotDisabled) {
+            window.setFlags(
+                WindowManager.LayoutParams.FLAG_SECURE,
+                WindowManager.LayoutParams.FLAG_SECURE
+            )
+        }
     }
 }


### PR DESCRIPTION
- Previously, we disabled screen recording for Zoom classes even if screen recording was enabled in the institute settings.
- In this commit, we fixed this behavior. If screen recording is enabled, we don't restrict the user from screen recording or taking screenshots.