### PR TITLE
fix: Custom header getting removed in WebView

### DIFF
--- a/core/src/main/java/in/testpress/fragments/WebViewFragment.kt
+++ b/core/src/main/java/in/testpress/fragments/WebViewFragment.kt
@@ -104,7 +104,7 @@ class WebViewFragment : Fragment(), EmptyViewListener {
     private fun setupCookieManager(){
         val cookieManager = CookieManager.getInstance()
         cookieManager.setAcceptCookie(true)
-        cookieManager.removeAllCookies(null)
+        cookieManager.removeSessionCookies(null)
     }
 
     private fun setupWebView() {

--- a/core/src/main/java/in/testpress/fragments/WebViewFragment.kt
+++ b/core/src/main/java/in/testpress/fragments/WebViewFragment.kt
@@ -62,7 +62,6 @@ class WebViewFragment : Fragment(), EmptyViewListener {
         initializeEmptyViewFragment()
         webView = layout.webView
         listener?.onWebViewInitializationSuccess()
-        setupCookieManager()
         setupWebView()
         loadContent()
     }
@@ -99,12 +98,6 @@ class WebViewFragment : Fragment(), EmptyViewListener {
         childFragmentManager.beginTransaction()
             .replace(R.id.empty_view_container, emptyViewFragment)
             .commit()
-    }
-
-    private fun setupCookieManager(){
-        val cookieManager = CookieManager.getInstance()
-        cookieManager.setAcceptCookie(true)
-        cookieManager.removeSessionCookies(null)
     }
 
     private fun setupWebView() {


### PR DESCRIPTION
- Previously, we were clearing all cookies while loading the WebView, which also cleared any custom headers added to the WebView.
- By removing the process of clearing all cookies, this issue will be fixed.
- The cookie clearing process was initially added to fix an issue in commit b04ebc4.
- Now, this process is no longer required because the issue is already handled on the web.