### PR TITLE
fix: App crash while opening chapters list fragment via deep link

### DIFF
--- a/course/src/main/java/in/testpress/course/ui/ChaptersListFragment.java
+++ b/course/src/main/java/in/testpress/course/ui/ChaptersListFragment.java
@@ -110,6 +110,10 @@ public class ChaptersListFragment extends BaseDataBaseFragment<Chapter, Long> {
         if (getCourse() != null && isItemsEmpty()) {
             showLoadingPlaceholder();
         }
+
+        if (getCourse() != null) {
+            showOrHideCustomTestIconInAppBar();
+        }
     }
 
     private void fetchCourseAndShowChapters(String courseId) {

--- a/course/src/main/java/in/testpress/course/ui/ChaptersListFragment.java
+++ b/course/src/main/java/in/testpress/course/ui/ChaptersListFragment.java
@@ -110,7 +110,6 @@ public class ChaptersListFragment extends BaseDataBaseFragment<Chapter, Long> {
         if (getCourse() != null && isItemsEmpty()) {
             showLoadingPlaceholder();
         }
-        setHasOptionsMenu(productSlug == null && isCustomTestGenerationEnabled());
     }
 
     private void fetchCourseAndShowChapters(String courseId) {
@@ -123,6 +122,7 @@ public class ChaptersListFragment extends BaseDataBaseFragment<Chapter, Long> {
                         courseDao.insertOrReplace(course);
                         configureList(getActivity(), getListView());
                         refreshWithProgress();
+                        showOrHideCustomTestIconInAppBar();
                     }
 
                     @Override
@@ -130,6 +130,10 @@ public class ChaptersListFragment extends BaseDataBaseFragment<Chapter, Long> {
                         getErrorMessage(exception);
                     }
                 });
+    }
+
+    private void showOrHideCustomTestIconInAppBar(){
+        setHasOptionsMenu(productSlug == null && isCustomTestGenerationEnabled());
     }
 
     private void displayBuyNowButton() {


### PR DESCRIPTION
- Added a custom test icon to the ChaptersListFragment in commit 87c8943. We use the `allowCustomTestGeneration` field to handle this icon, which is present in the course object.
- If the user opens the chapter list fragment via deep link and the `allowCustomTestGeneration` field and course object are null, the app crashes.
- In this commit, we validate the custom test icon after the course is fetched to prevent the crash.