### PR TITLE
fix: Handled Error message in exoplayer

### DIFF
--- a/course/src/main/java/in/testpress/course/util/ExoPlayerUtil.java
+++ b/course/src/main/java/in/testpress/course/util/ExoPlayerUtil.java
@@ -684,6 +684,13 @@ public class ExoPlayerUtil implements VideoTimeRangeListener, DrmSessionManagerP
         errorMessageTextView.setVisibility(View.VISIBLE);
     }
 
+    private void displayError(String message) {
+        player.setPlayWhenReady(false);
+        player.getPlaybackState();
+        errorMessageTextView.setText(message);
+        errorMessageTextView.setVisibility(View.VISIBLE);
+    }
+
     private void hideError(@StringRes int message) {
         if (errorMessageTextView.getText().equals(activity.getString(message))) {
             errorMessageTextView.setVisibility(View.GONE);
@@ -692,10 +699,24 @@ public class ExoPlayerUtil implements VideoTimeRangeListener, DrmSessionManagerP
         }
     }
 
-    private void handleError(boolean networkError) {
-        if (networkError) {
-            displayError(R.string.testpress_no_internet_try_again);
+    private void handleError(PlaybackException exception) {
+        String errorMessage = "";
+        if (1000 <= exception.errorCode && exception.errorCode < 2000) { // Miscellaneous errors
+            errorMessage = activity.getString(R.string.exoplayer_miscellaneous_error, exception.getErrorCodeName(), exception.errorCode);
+        } else if (2001 == exception.errorCode) { // No network error
+            errorMessage = activity.getString(R.string.testpress_no_internet_try_again);
+        } else if (2000 <= exception.errorCode && exception.errorCode <= 3000) { // Input/Output errors
+            errorMessage = activity.getString(R.string.exoplayer_input_or_output_error, exception.getErrorCodeName(), exception.errorCode);
+        } else if (3000 <= exception.errorCode && exception.errorCode <= 4000) { // Content parsing errors
+            errorMessage = activity.getString(R.string.exoplayer_content_parsing_error, exception.getErrorCodeName(), exception.errorCode);
+        } else if (4000 <= exception.errorCode && exception.errorCode <= 5000) { // Decoding errors
+            errorMessage = activity.getString(R.string.exoplayer_decoding_error, exception.getErrorCodeName(), exception.errorCode);
+        } else if (5000 <= exception.errorCode && exception.errorCode <= 6000) { // AudioTrack errors
+            errorMessage = activity.getString(R.string.exoplayer_audio_track_error, exception.getErrorCodeName(), exception.errorCode);
+        } else if (6000 <= exception.errorCode && exception.errorCode <= 7000) { // DRM errors
+            errorMessage = activity.getString(R.string.exoplayer_drm_error, exception.getErrorCodeName(), exception.errorCode);
         }
+        displayError(errorMessage);
     }
 
     private boolean isScreenCasted() {
@@ -791,7 +812,7 @@ public class ExoPlayerUtil implements VideoTimeRangeListener, DrmSessionManagerP
                     displayError(R.string.license_request_failed);
                 }
             } else {
-                handleError(exception.errorCode == TYPE_SOURCE);
+                handleError(exception);
             }
         }
 

--- a/course/src/main/res/values/strings.xml
+++ b/course/src/main/res/values/strings.xml
@@ -113,4 +113,11 @@
         <item name="android:textColor">@color/testpress_black</item>
     </style>
 
+    <string name="exoplayer_miscellaneous_error">An unexpected error occurred. Please try again later.\n\n%1$s\n(Code: %2$d)</string>
+    <string name="exoplayer_input_or_output_error">A network error occurred. Please try again later.\n\n%1$s\n(Code: %2$d)</string>
+    <string name="exoplayer_content_parsing_error">A content parsing error occurred. Please try again later.\n\n%1$s\n(Code: %2$d)</string>
+    <string name="exoplayer_decoding_error">A decoding error occurred. Please try again later.\n\n%1$s\n(Code: %2$d)</string>
+    <string name="exoplayer_audio_track_error">An AudioTrack error occurred. Please try again later.\n\n%1$s\n(Code: %2$d)</string>
+    <string name="exoplayer_drm_error">A DRM error occurred. Please try again later.\n\n%1$s\n(Code: %2$d)</string>
+
 </resources>


### PR DESCRIPTION
- Previously, we only handled errors for network errors, leaving other errors to display an empty screen, making it difficult to identify the actual error.
- In this commit, we have added specific error messages for each error, making it easier to identify and understand the errors.