### PR TITLE
enhancement: Add Sentry Message Capture with `playback_id` for Exo player errors

### DIFF
--- a/course/src/main/java/in/testpress/course/util/VideoUtils.kt
+++ b/course/src/main/java/in/testpress/course/util/VideoUtils.kt
@@ -45,4 +45,11 @@ object VideoUtils {
         }
         return null
     }
+
+    fun generatePlayerIdString(): String {
+        return (1..10)
+            .map { ('a'..'z').toList() + ('0'..'9').toList() }
+            .map { it.random() }
+            .joinToString("")
+    }
 }

--- a/course/src/main/res/values/strings.xml
+++ b/course/src/main/res/values/strings.xml
@@ -64,7 +64,7 @@
     <string name="syncing_video">Please wait... We are syncing video</string>
     <string name="no_internet_to_sync_license">Please turn on internet to fetch video license</string>
     <string name="license_error">Error in fetching video license. Please try again</string>
-    <string name="license_request_failed">Couldn\'t fetch decryption key. Please try again</string>
+    <string name="license_request_failed">Couldn\'t fetch decryption key. Please try again.\n\n(Code: %1$d, ID: %2$s)</string>
 
     <string name="testpress_open_bookmark_file">View</string>
 
@@ -113,11 +113,11 @@
         <item name="android:textColor">@color/testpress_black</item>
     </style>
 
-    <string name="exoplayer_miscellaneous_error">An unexpected error occurred. Please try again later.\n\n%1$s\n(Code: %2$d)</string>
-    <string name="exoplayer_input_or_output_error">A network error occurred. Please try again later.\n\n%1$s\n(Code: %2$d)</string>
-    <string name="exoplayer_content_parsing_error">A content parsing error occurred. Please try again later.\n\n%1$s\n(Code: %2$d)</string>
-    <string name="exoplayer_decoding_error">A decoding error occurred. Please try again later.\n\n%1$s\n(Code: %2$d)</string>
-    <string name="exoplayer_audio_track_error">An AudioTrack error occurred. Please try again later.\n\n%1$s\n(Code: %2$d)</string>
-    <string name="exoplayer_drm_error">A DRM error occurred. Please try again later.\n\n%1$s\n(Code: %2$d)</string>
+    <string name="exoplayer_miscellaneous_error">An unexpected error occurred. Please try again later.\n\n%1$s\n(Code: %2$d, ID: %3$s)</string>
+    <string name="exoplayer_input_or_output_error">A network error occurred. Please try again later.\n\n%1$s\n(Code: %2$d, ID: %3$s)</string>
+    <string name="exoplayer_content_parsing_error">A content parsing error occurred. Please try again later.\n\n%1$s\n(Code: %2$d, ID: %3$s)</string>
+    <string name="exoplayer_decoding_error">A decoding error occurred. Please try again later.\n\n%1$s\n(Code: %2$d, ID: %3$s)</string>
+    <string name="exoplayer_audio_track_error">An AudioTrack error occurred. Please try again later.\n\n%1$s\n(Code: %2$d, ID: %3$s)</string>
+    <string name="exoplayer_drm_error">A DRM error occurred. Please try again later.\n\n%1$s\n(Code: %2$d, ID: %3$s)</string>
 
 </resources>


### PR DESCRIPTION
- In this commit, we added a randomly generated string known as `playback_id` to the error message, displaying it as error text. Furthermore, we included the Sentry logger to handle this, ensuring the `playback_id` tag is utilized for improved error tracking.