### PR TITLE
enhancement: Add option to purchase product at multiple prices

### DIFF
--- a/store/src/main/java/in/testpress/store/models/OrderItem.java
+++ b/store/src/main/java/in/testpress/store/models/OrderItem.java
@@ -8,6 +8,8 @@ public class OrderItem implements Parcelable {
     private String product;
     private Integer quantity;
     private String price;
+    private Integer priceId;
+    private String productSlug;
 
     public OrderItem(){}
 
@@ -16,6 +18,8 @@ public class OrderItem implements Parcelable {
         product  = parcel.readString();
         price    = parcel.readString();
         quantity = parcel.readInt();
+        priceId = parcel.readInt();
+        productSlug = parcel.readString();
     }
 
     @Override
@@ -28,6 +32,8 @@ public class OrderItem implements Parcelable {
         parcel.writeString(product);
         parcel.writeString(price);
         parcel.writeInt(quantity);
+        parcel.writeInt(priceId);
+        parcel.writeString(productSlug);
     }
 
     public static final Creator<OrderItem> CREATOR = new Creator<OrderItem>() {
@@ -92,6 +98,42 @@ public class OrderItem implements Parcelable {
      */
     public void setPrice(String price) {
         this.price = price;
+    }
+
+    /**
+     *
+     * @return
+     * The priceId
+     */
+    public Integer getPriceId() {
+        return priceId;
+    }
+
+    /**
+     *
+     * @param priceId
+     * The priceId
+     */
+    public void setPriceId(Integer priceId) {
+        this.priceId = priceId;
+    }
+
+    /**
+     *
+     * @return
+     * The productSlug
+     */
+    public String getProductSlug() {
+        return productSlug;
+    }
+
+    /**
+     *
+     * @param productSlug
+     * The productSlug
+     */
+    public void setProductSlug(String productSlug) {
+        this.productSlug = productSlug;
     }
 
 }

--- a/store/src/main/java/in/testpress/store/models/OrderItem.java
+++ b/store/src/main/java/in/testpress/store/models/OrderItem.java
@@ -7,19 +7,15 @@ public class OrderItem implements Parcelable {
 
     private String product;
     private Integer quantity;
-    private String price;
-    private Integer priceId;
-    private String productSlug;
+    private Integer price;
 
     public OrderItem(){}
 
     // Parcelling part
     public OrderItem(Parcel parcel){
         product  = parcel.readString();
-        price    = parcel.readString();
+        price    = parcel.readInt();
         quantity = parcel.readInt();
-        priceId = parcel.readInt();
-        productSlug = parcel.readString();
     }
 
     @Override
@@ -30,10 +26,8 @@ public class OrderItem implements Parcelable {
     @Override
     public void writeToParcel(Parcel parcel, int i) {
         parcel.writeString(product);
-        parcel.writeString(price);
+        parcel.writeInt(price);
         parcel.writeInt(quantity);
-        parcel.writeInt(priceId);
-        parcel.writeString(productSlug);
     }
 
     public static final Creator<OrderItem> CREATOR = new Creator<OrderItem>() {
@@ -87,7 +81,7 @@ public class OrderItem implements Parcelable {
      * @return
      * The price
      */
-    public String getPrice() {
+    public Integer getPrice() {
         return price;
     }
 
@@ -96,44 +90,8 @@ public class OrderItem implements Parcelable {
      * @param price
      * The price
      */
-    public void setPrice(String price) {
+    public void setPrice(Integer price) {
         this.price = price;
-    }
-
-    /**
-     *
-     * @return
-     * The priceId
-     */
-    public Integer getPriceId() {
-        return priceId;
-    }
-
-    /**
-     *
-     * @param priceId
-     * The priceId
-     */
-    public void setPriceId(Integer priceId) {
-        this.priceId = priceId;
-    }
-
-    /**
-     *
-     * @return
-     * The productSlug
-     */
-    public String getProductSlug() {
-        return productSlug;
-    }
-
-    /**
-     *
-     * @param productSlug
-     * The productSlug
-     */
-    public void setProductSlug(String productSlug) {
-        this.productSlug = productSlug;
     }
 
 }

--- a/store/src/main/java/in/testpress/store/models/PriceItem.kt
+++ b/store/src/main/java/in/testpress/store/models/PriceItem.kt
@@ -1,0 +1,46 @@
+package `in`.testpress.store.models
+
+import android.os.Parcel
+import android.os.Parcelable
+
+data class PricesItem(
+    var id: Int? = null,
+    var name: String? = null,
+    var price: String? = null,
+    var validity: Int? = null,
+    var endDate: String? = null,
+    var startDate: String? = null
+) : Parcelable {
+    constructor(parcel: Parcel) : this(
+        parcel.readValue(Int::class.java.classLoader) as? Int,
+        parcel.readString(),
+        parcel.readString(),
+        parcel.readValue(Int::class.java.classLoader) as? Int,
+        parcel.readString(),
+        parcel.readString()
+    )
+
+    override fun writeToParcel(parcel: Parcel, flags: Int) {
+        parcel.writeValue(id)
+        parcel.writeString(name)
+        parcel.writeString(price)
+        parcel.writeValue(validity)
+        parcel.writeString(endDate)
+        parcel.writeString(startDate)
+    }
+
+    override fun describeContents(): Int {
+        return 0
+    }
+
+    companion object CREATOR : Parcelable.Creator<PricesItem> {
+        override fun createFromParcel(parcel: Parcel): PricesItem {
+            return PricesItem(parcel)
+        }
+
+        override fun newArray(size: Int): Array<PricesItem?> {
+            return arrayOfNulls(size)
+        }
+    }
+}
+

--- a/store/src/main/java/in/testpress/store/models/Product.java
+++ b/store/src/main/java/in/testpress/store/models/Product.java
@@ -31,6 +31,7 @@ public class Product implements Parcelable {
     private Boolean requiresShipping;
     private List<Exam> exams = new ArrayList<Exam>();
     private List<Notes> notes = new ArrayList<Notes>();
+    private List<PricesItem> prices = new ArrayList<PricesItem>();
 
     // Parcelling part
     public Product(Parcel parcel){
@@ -53,6 +54,7 @@ public class Product implements Parcelable {
         requiresShipping = parcel.readByte() != 0;
         parcel.readTypedList(exams, Exam.CREATOR);
         parcel.readTypedList(notes, Notes.CREATOR);
+        parcel.readTypedList(prices,PricesItem.CREATOR);
     }
 
     @Override
@@ -81,6 +83,7 @@ public class Product implements Parcelable {
         parcel.writeByte((byte) (requiresShipping ? 1 : 0));
         parcel.writeTypedList(exams);
         parcel.writeTypedList(notes);
+        parcel.writeTypedList(prices);
     }
 
     public static final Parcelable.Creator CREATOR = new Parcelable.Creator() {
@@ -445,6 +448,24 @@ public class Product implements Parcelable {
      */
     public void setNotes(List<Notes> notes) {
         this.notes = notes;
+    }
+
+    /**
+     *
+     * @return
+     * The prices
+     */
+    public List<PricesItem> getPrices() {
+        return prices;
+    }
+
+    /**
+     *
+     * @param prices
+     * The prices
+     */
+    public void setPrices(List<PricesItem> prices) {
+        this.prices = prices;
     }
 
 }

--- a/store/src/main/java/in/testpress/store/models/ProductDetailResponse.kt
+++ b/store/src/main/java/in/testpress/store/models/ProductDetailResponse.kt
@@ -70,12 +70,3 @@ data class Course(
     val order: Int? = null,
     val externalLinkLabel: String? = null
 )
-
-data class PricesItem(
-    var id: Int? = null,
-    var name: String? = null,
-    var price: String? = null,
-    var validity: Int? = null,
-    var endDate: String? = null,
-    var startDate: String? = null
-)

--- a/store/src/main/java/in/testpress/store/network/ProductService.java
+++ b/store/src/main/java/in/testpress/store/network/ProductService.java
@@ -21,6 +21,7 @@ import static in.testpress.store.network.StoreApiClient.ORDER_API_PATH;
 import static in.testpress.store.network.StoreApiClient.ORDER_CONFIRM_PATH;
 import static in.testpress.store.network.StoreApiClient.ORDER_STATE_REFRESH_PATH;
 import static in.testpress.store.network.StoreApiClient.PAYU_HASH_GENERATOR_PATH;
+import static in.testpress.store.network.StoreApiClient.v3_ORDERS_PATH;
 
 public interface ProductService {
 
@@ -34,7 +35,7 @@ public interface ProductService {
     RetrofitCall<Product> getProductDetails(
             @Path(value = "product_slug", encoded = true) String productUrlFrag);
 
-    @POST(ORDERS_PATH)
+    @POST(v3_ORDERS_PATH)
     RetrofitCall<Order> order(@Body HashMap<String, Object> arguments);
 
     @PUT(ORDERS_PATH + "{order_id}" + ORDER_CONFIRM_PATH)

--- a/store/src/main/java/in/testpress/store/network/StoreApiClient.java
+++ b/store/src/main/java/in/testpress/store/network/StoreApiClient.java
@@ -35,6 +35,8 @@ public class StoreApiClient extends TestpressApiClient {
 
     public static final String PAYU_HASH_GENERATOR_PATH = "/api/v2.5/payu/dynamic_hash/";
 
+    public static final String v3_ORDERS_PATH = "/api/v3/orders/";
+
     public StoreApiClient(final Context context) {
         super(context, checkTestpressSessionIsNull(TestpressSdk.getTestpressSession(context)));
     }

--- a/store/src/main/java/in/testpress/store/ui/OrderConfirmActivity.java
+++ b/store/src/main/java/in/testpress/store/ui/OrderConfirmActivity.java
@@ -49,6 +49,7 @@ import static android.view.inputmethod.EditorInfo.IME_ACTION_DONE;
 import static in.testpress.store.TestpressStore.PAYMENT_SUCCESS;
 import static in.testpress.store.TestpressStore.PAYMENT_FAILURE;
 import static in.testpress.store.TestpressStore.STORE_REQUEST_CODE;
+import static in.testpress.store.ui.ProductDetailsActivity.PRICE_ID;
 import static in.testpress.store.ui.ProductDetailsActivity.PRODUCT;
 
 
@@ -71,6 +72,7 @@ public class OrderConfirmActivity extends BaseToolBarActivity implements Payment
     private Button retryButton;
     private TextWatcher watcher = validationTextWatcher();
     private Product product;
+    private int priceId;
     private List<OrderItem> orderItems;
     public Order order;
     private OrderItem orderItem = new OrderItem();
@@ -104,7 +106,10 @@ public class OrderConfirmActivity extends BaseToolBarActivity implements Payment
         retryButton = (Button) findViewById(R.id.retry_button);
 
         product = getIntent().getParcelableExtra(PRODUCT);
+        priceId = getIntent().getIntExtra(PRICE_ID, product.getPrices().get(0).getId());
         orderItem.setProduct(product.getUrl());
+        orderItem.setPriceId(priceId);
+        orderItem.setProductSlug(product.getSlug());
         orderItem.setQuantity(1);
         orderItem.setPrice(product.getPrice());
         orderItems = new ArrayList<>();

--- a/store/src/main/java/in/testpress/store/ui/OrderConfirmActivity.java
+++ b/store/src/main/java/in/testpress/store/ui/OrderConfirmActivity.java
@@ -107,11 +107,9 @@ public class OrderConfirmActivity extends BaseToolBarActivity implements Payment
 
         product = getIntent().getParcelableExtra(PRODUCT);
         priceId = getIntent().getIntExtra(PRICE_ID, product.getPrices().get(0).getId());
-        orderItem.setProduct(product.getUrl());
-        orderItem.setPriceId(priceId);
-        orderItem.setProductSlug(product.getSlug());
+        orderItem.setProduct(product.getSlug());
         orderItem.setQuantity(1);
-        orderItem.setPrice(product.getPrice());
+        orderItem.setPrice(priceId);
         orderItems = new ArrayList<>();
         orderItems.add(orderItem);
         apiClient = new StoreApiClient(this);
@@ -125,6 +123,8 @@ public class OrderConfirmActivity extends BaseToolBarActivity implements Payment
         apiClient.order(orderItems).enqueue(new TestpressCallback<Order>() {
             @Override
             public void onSuccess(Order createdOrder) {
+                Log.d("TAG", "onSuccess: "+createdOrder);
+                Log.d("TAG", "onSuccess: "+createdOrder);
                 order = createdOrder;
                 progressBar.setVisibility(View.GONE);
                 if (createdOrder.getStatus().equals("Completed")) {

--- a/store/src/main/java/in/testpress/store/ui/OrderConfirmActivity.java
+++ b/store/src/main/java/in/testpress/store/ui/OrderConfirmActivity.java
@@ -106,7 +106,7 @@ public class OrderConfirmActivity extends BaseToolBarActivity implements Payment
         retryButton = (Button) findViewById(R.id.retry_button);
 
         product = getIntent().getParcelableExtra(PRODUCT);
-        priceId = getIntent().getIntExtra(PRICE_ID, product.getPrices().get(0).getId());
+        priceId = getPriceId();
         orderItem.setProduct(product.getSlug());
         orderItem.setQuantity(1);
         orderItem.setPrice(priceId);
@@ -117,14 +117,20 @@ public class OrderConfirmActivity extends BaseToolBarActivity implements Payment
         order();
     }
 
+    private int getPriceId() {
+        try {
+            return getIntent().getIntExtra(PRICE_ID, product.getPrices().get(0).getId());
+        } catch (Exception e) {
+            return -1;
+        }
+    }
+
     void order() {
         progressBar.setVisibility(View.VISIBLE);
         emptyView.setVisibility(View.GONE);
         apiClient.order(orderItems).enqueue(new TestpressCallback<Order>() {
             @Override
             public void onSuccess(Order createdOrder) {
-                Log.d("TAG", "onSuccess: "+createdOrder);
-                Log.d("TAG", "onSuccess: "+createdOrder);
                 order = createdOrder;
                 progressBar.setVisibility(View.GONE);
                 if (createdOrder.getStatus().equals("Completed")) {

--- a/store/src/main/java/in/testpress/store/ui/ProductDetailsActivity.java
+++ b/store/src/main/java/in/testpress/store/ui/ProductDetailsActivity.java
@@ -40,6 +40,7 @@ public class ProductDetailsActivity extends BaseToolBarActivity {
 
     public static final String PRODUCT_SLUG = "productSlug";
     public static final String PRODUCT = "product";
+    public static final String PRICE_ID = "price_id";
 
     private LinearLayout emptyView;
     private TextView emptyTitleView;


### PR DESCRIPTION
- Upgraded the order API from version `v2.2` to version `v3`.
- Added required parameters `price_id` and `product_slug` to the `order_item` in the order API request body.
- Added an option to retrieve `price_id` via intent; if the intent value is not available, the first index value in the price list will be used by default.
- Although there is currently no UI for selecting from multiple prices, this commit includes SDK changes that enable the Yukthi app to use this feature immediately.
