### PR TITLE
fix: Change data type of price field to String in `OrderItem` model

### DIFF
--- a/store/src/main/java/in/testpress/store/models/OrderItem.java
+++ b/store/src/main/java/in/testpress/store/models/OrderItem.java
@@ -7,14 +7,14 @@ public class OrderItem implements Parcelable {
 
     private String product;
     private Integer quantity;
-    private Integer price;
+    private String price;
 
     public OrderItem(){}
 
     // Parcelling part
     public OrderItem(Parcel parcel){
         product  = parcel.readString();
-        price    = parcel.readInt();
+        price    = parcel.readString();
         quantity = parcel.readInt();
     }
 
@@ -26,7 +26,7 @@ public class OrderItem implements Parcelable {
     @Override
     public void writeToParcel(Parcel parcel, int i) {
         parcel.writeString(product);
-        parcel.writeInt(price);
+        parcel.writeString(price);
         parcel.writeInt(quantity);
     }
 
@@ -81,7 +81,7 @@ public class OrderItem implements Parcelable {
      * @return
      * The price
      */
-    public Integer getPrice() {
+    public String getPrice() {
         return price;
     }
 
@@ -90,7 +90,7 @@ public class OrderItem implements Parcelable {
      * @param price
      * The price
      */
-    public void setPrice(Integer price) {
+    public void setPrice(String price) {
         this.price = price;
     }
 

--- a/store/src/main/java/in/testpress/store/ui/OrderConfirmActivity.java
+++ b/store/src/main/java/in/testpress/store/ui/OrderConfirmActivity.java
@@ -109,7 +109,7 @@ public class OrderConfirmActivity extends BaseToolBarActivity implements Payment
         priceId = getPriceId();
         orderItem.setProduct(product.getSlug());
         orderItem.setQuantity(1);
-        orderItem.setPrice(priceId);
+        orderItem.setPrice(String.valueOf(priceId));
         orderItems = new ArrayList<>();
         orderItems.add(orderItem);
         apiClient = new StoreApiClient(this);


### PR DESCRIPTION
- In commit 85b5204, the data type of the price field was changed to Integer.
- While creating an order, the price_id value (an Integer) was posted in the price field, hence the change.
- However, after the order is created, the response includes the price as a string with the actual product price.
- This discrepancy prevents product purchases.
- Changing the data type back to String resolves this issue, as the backend can automatically convert the string to an integer when necessary.