### PR TITLE
fix: Hide Analytics button when Analytics is disabled in Exam

### DIFF
--- a/exam/src/main/java/in/testpress/exam/ui/ReviewStatsFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/ReviewStatsFragment.java
@@ -390,7 +390,7 @@ public class ReviewStatsFragment extends BaseFragment {
             analyticsButton.setVisibility(View.VISIBLE);
             timeAnalyticsButtonLayout.setVisibility(View.GONE);
         } else {
-            analyticsButton.setVisibility(View.VISIBLE);
+            analyticsButton.setVisibility(View.GONE);
             timeAnalyticsButtonLayout.setVisibility(View.GONE);
         }
     }


### PR DESCRIPTION
- Previously, the Analytics button was shown even when Analytics was disabled in the exam settings.
- In this commit, the Analytics button is now hidden if Analytics is disabled in the exam settings.
