### PR TITLE
fix: Handle PDF Hyperlinks in WebView by Opening in Browser

### DIFF
--- a/core/src/main/java/in/testpress/util/webview/CustomWebViewClient.kt
+++ b/core/src/main/java/in/testpress/util/webview/CustomWebViewClient.kt
@@ -10,17 +10,22 @@ class CustomWebViewClient(val fragment: WebViewFragment) : WebViewClient() {
 
     private var errorList = linkedMapOf<WebResourceRequest?,WebResourceResponse?>()
 
-    override fun shouldOverrideUrlLoading(
-        view: WebView?,
-        request: WebResourceRequest?
-    ): Boolean {
-        return if (shouldLoadInWebView(request?.url.toString())) {
-            false
-        } else {
-            fragment.openUrlInBrowser(request?.url.toString())
-            true
+    override fun shouldOverrideUrlLoading(view: WebView?, request: WebResourceRequest?): Boolean {
+        val url = request?.url.toString()
+        return when {
+            isPDFUrl(url) -> {
+                fragment.openUrlInBrowser(url)
+                true
+            }
+            shouldLoadInWebView(url) -> false
+            else -> {
+                fragment.openUrlInBrowser(url)
+                true
+            }
         }
     }
+
+    private fun isPDFUrl(url: String?) = url?.contains(".pdf") ?: false
 
     private fun shouldLoadInWebView(url: String?):Boolean {
         return if (fragment.isInstituteUrl(url)){


### PR DESCRIPTION
- Fix issue where hyperlinks containing PDF files are not responsive in Android WebView due to lack of native PDF support.
- In this commit, we check if the request URL points to a PDF. If it does, we open the PDF in an external browser instead.
- This ensures that PDF links are handled appropriately, providing a better user experience.
