### PR TITLE
feat: Add option to download Exam

### DIFF
--- a/core/src/main/java/in/testpress/database/Room.kt
+++ b/core/src/main/java/in/testpress/database/Room.kt
@@ -68,6 +68,7 @@ abstract class TestpressDatabase : RoomDatabase() {
     abstract fun productCategoryDao(): ProductCategoryDao
     abstract fun contentLiteDao(): ContentLiteDao
     abstract fun contentLiteRemoteKeyDao():ContentLiteRemoteKeyDao
+    abstract fun offlineExamDao():OfflineExamDao
 
     companion object {
         private lateinit var INSTANCE: TestpressDatabase

--- a/core/src/main/java/in/testpress/database/dao/OfflineExamDao.kt
+++ b/core/src/main/java/in/testpress/database/dao/OfflineExamDao.kt
@@ -1,0 +1,8 @@
+package `in`.testpress.database.dao
+
+import `in`.testpress.database.BaseDao
+import `in`.testpress.database.entities.OfflineExam
+import androidx.room.Dao
+
+@Dao
+interface OfflineExamDao: BaseDao<OfflineExam>

--- a/course/src/main/java/in/testpress/course/network/CourseService.kt
+++ b/course/src/main/java/in/testpress/course/network/CourseService.kt
@@ -73,6 +73,11 @@ interface CourseService {
         @Path(value = "course_id", encoded = true) courseId: Long,
         @QueryMap queryParams: HashMap<String, Any>
     ): ApiResponse<List<ContentEntityLite>>
+
+    @GET("$CONTENTS_PATH_v2_4{content_id}/")
+    fun getNetworkContentWithId(
+        @Path(value = "content_id", encoded = true) contentId: Long
+    ): RetrofitCall<NetworkContent>
 }
 
 
@@ -129,5 +134,9 @@ class CourseNetwork(context: Context) : TestpressApiClient(context, TestpressSdk
 
     suspend fun getUpcomingContents(courseId: Long, arguments: HashMap<String, Any>): ApiResponse<List<ContentEntityLite>> {
         return getCourseService().getUpcomingContents(courseId, arguments)
+    }
+
+    fun getNetworkContentWithId(contentId: Long): RetrofitCall<NetworkContent> {
+        return getCourseService().getNetworkContentWithId(contentId)
     }
 }

--- a/course/src/main/java/in/testpress/course/network/NetworkContent.kt
+++ b/course/src/main/java/in/testpress/course/network/NetworkContent.kt
@@ -1,6 +1,7 @@
 package `in`.testpress.course.network
 
 import `in`.testpress.database.ContentEntity
+import `in`.testpress.database.entities.OfflineExam
 import `in`.testpress.exam.network.NetworkExamContent
 import `in`.testpress.models.greendao.Content
 
@@ -139,5 +140,50 @@ fun NetworkContent.asGreenDaoModel(): Content {
         this.videoId,
         this.attachmentId,
         this.examId
+    )
+}
+
+fun NetworkContent.asOfflineExam(): OfflineExam {
+    return OfflineExam(
+        this.exam?.id,
+        this.exam?.totalMarks,
+        this.exam?.url,
+        this.exam?.attemptsCount,
+        this.exam?.pausedAttemptsCount,
+        this.exam?.title,
+        this.exam?.description,
+        this.exam?.startDate,
+        this.exam?.endDate,
+        this.exam?.duration,
+        this.exam?.numberOfQuestions,
+        this.exam?.negativeMarks,
+        this.exam?.markPerQuestion,
+        this.exam?.templateType,
+        this.exam?.allowRetake,
+        this.exam?.allowPdf,
+        this.exam?.showAnswers,
+        this.exam?.maxRetakes,
+        this.exam?.attemptsUrl,
+        this.exam?.deviceAccessControl,
+        this.exam?.commentsCount,
+        this.exam?.slug,
+        selectedLanguage = null,
+        this.exam?.variableMarkPerQuestion,
+        this.exam?.passPercentage,
+        this.exam?.enableRanks,
+        this.exam?.showScore,
+        this.exam?.showPercentile,
+        categories = null,
+        isDetailsFetched = null,
+        this.exam?.isGrowthHackEnabled,
+        this.exam?.shareTextForSolutionUnlock,
+        this.exam?.showAnalytics,
+        this.exam?.instructions,
+        this.exam?.hasAudioQuestions,
+        this.exam?.rankPublishingDate,
+        this.exam?.enableQuizMode,
+        this.exam?.disableAttemptResume,
+        this.exam?.allowPreemptiveSectionEnding,
+        examDataModifiedOn = null
     )
 }

--- a/course/src/main/java/in/testpress/course/repository/OfflineExamRepository.kt
+++ b/course/src/main/java/in/testpress/course/repository/OfflineExamRepository.kt
@@ -1,0 +1,46 @@
+package `in`.testpress.course.repository
+
+import `in`.testpress.core.TestpressCallback
+import `in`.testpress.core.TestpressException
+import `in`.testpress.course.network.CourseNetwork
+import `in`.testpress.course.network.NetworkContent
+import `in`.testpress.course.network.asOfflineExam
+import `in`.testpress.database.TestpressDatabase
+import `in`.testpress.network.Resource
+import android.content.Context
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+class OfflineExamRepository(val context: Context) {
+
+    private val courseClient = CourseNetwork(context)
+    private val database = TestpressDatabase.invoke(context)
+    private var offlineExamDao = database.offlineExamDao()
+
+
+    private val _downloadExamResult = MutableLiveData<Resource<Boolean>>()
+    val downloadExamResult: LiveData<Resource<Boolean>> get() = _downloadExamResult
+
+    fun downloadExam(contentId: Long) {
+        _downloadExamResult.postValue(Resource.loading(null))
+        courseClient.getNetworkContentWithId(contentId)
+            .enqueue(object : TestpressCallback<NetworkContent>() {
+                override fun onSuccess(result: NetworkContent) {
+                    CoroutineScope(Dispatchers.IO).launch {
+                        offlineExamDao.insert(result.asOfflineExam())
+                        _downloadExamResult.postValue(Resource.success(true))
+                    }
+                }
+
+                override fun onException(exception: TestpressException) {
+                    _downloadExamResult.postValue(Resource.error(exception, null))
+                }
+            })
+    }
+
+
+
+}

--- a/course/src/main/java/in/testpress/course/viewmodels/OfflineExamViewModel.kt
+++ b/course/src/main/java/in/testpress/course/viewmodels/OfflineExamViewModel.kt
@@ -1,0 +1,17 @@
+package `in`.testpress.course.viewmodels
+
+import `in`.testpress.course.repository.OfflineExamRepository
+import `in`.testpress.network.Resource
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.ViewModel
+
+class OfflineExamViewModel(private val repository: OfflineExamRepository) : ViewModel() {
+
+    val downloadExamResult: LiveData<Resource<Boolean>> get() = repository.downloadExamResult
+
+    fun downloadExam(courseId: Long) {
+        repository.downloadExam(courseId)
+    }
+
+
+}

--- a/samples/build.gradle
+++ b/samples/build.gradle
@@ -1,4 +1,6 @@
 apply plugin: 'com.android.application'
+apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-kapt'
 
 android {
     packagingOptions {
@@ -48,6 +50,14 @@ android {
     compileOptions {
         sourceCompatibility 1.8
         targetCompatibility 1.8
+    }
+
+    buildFeatures {
+        viewBinding true
+    }
+
+    kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_1_8.toString()
     }
 }
 

--- a/samples/src/main/AndroidManifest.xml
+++ b/samples/src/main/AndroidManifest.xml
@@ -64,6 +64,11 @@
             android:label="@string/example_fragment_in_drawer" />
 
         <activity
+            android:name=".course.OfflineExamSampleActivity"
+            android:configChanges="orientation|keyboard|screenSize"
+            android:label="Offline Exam" />
+
+        <activity
             android:name="com.facebook.CustomTabActivity"
             android:exported="true">
             <intent-filter>

--- a/samples/src/main/java/in/testpress/samples/course/CourseSampleActivity.java
+++ b/samples/src/main/java/in/testpress/samples/course/CourseSampleActivity.java
@@ -167,6 +167,13 @@ public class CourseSampleActivity extends BaseToolBarActivity {
                 launchCustomTestGenerationActivity();
             }
         });
+
+        findViewById(R.id.offline_exam_download).setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                openOfflineExamActivity();
+            }
+        });
     }
 
     @SuppressWarnings("ConstantConditions")
@@ -280,6 +287,10 @@ public class CourseSampleActivity extends BaseToolBarActivity {
                                 });
                     }
                 });
+    }
+
+    private void openOfflineExamActivity() {
+        startActivity(new Intent(this,OfflineExamSampleActivity.class));
     }
 
     @Override

--- a/samples/src/main/java/in/testpress/samples/course/OfflineExamSampleActivity.kt
+++ b/samples/src/main/java/in/testpress/samples/course/OfflineExamSampleActivity.kt
@@ -1,0 +1,70 @@
+package `in`.testpress.samples.course
+
+import `in`.testpress.course.repository.OfflineExamRepository
+import `in`.testpress.course.viewmodels.OfflineExamViewModel
+import `in`.testpress.enums.Status
+import `in`.testpress.samples.databinding.ActivityOfflineExamSampleBinding
+import `in`.testpress.ui.BaseToolBarActivity
+import android.os.Bundle
+import android.widget.Toast
+import androidx.core.view.isVisible
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+
+class OfflineExamSampleActivity: BaseToolBarActivity() {
+
+    private lateinit var binding: ActivityOfflineExamSampleBinding
+    private lateinit var offlineExamViewModel: OfflineExamViewModel
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityOfflineExamSampleBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+        initializeViewModel()
+        setActionBarTitle("Offline Exam")
+
+        binding.downloads.setOnClickListener {
+            if (binding.editText.text.isNullOrEmpty()){
+                Toast.makeText(this,"Content Id required to download the exam",Toast.LENGTH_SHORT).show()
+            } else {
+                offlineExamViewModel.downloadExam(binding.editText.text.toString().toLong())
+            }
+        }
+
+        observeDownloadExamResult()
+    }
+
+    private fun initializeViewModel() {
+        offlineExamViewModel = ViewModelProvider(this, object : ViewModelProvider.Factory {
+            override fun <T : ViewModel> create(modelClass: Class<T>): T {
+                return OfflineExamViewModel(
+                    OfflineExamRepository(this@OfflineExamSampleActivity)
+                ) as T
+            }
+        })[OfflineExamViewModel::class.java]
+    }
+
+    private fun observeDownloadExamResult() {
+        offlineExamViewModel.downloadExamResult.observe(this){ result ->
+            when(result.status){
+                Status.SUCCESS -> {
+                    binding.downloads.isVisible = true
+                    binding.loadingProgressBar.isVisible = false
+                    Toast.makeText(this,"Download completed",Toast.LENGTH_SHORT).show()
+                }
+                Status.LOADING -> {
+                    binding.loadingProgressBar.isVisible = true
+                    binding.downloads.isVisible = false
+                }
+                Status.ERROR -> {
+                    binding.downloads.isVisible = true
+                    binding.loadingProgressBar.isVisible = false
+                    Toast.makeText(this,"Download Failed",Toast.LENGTH_SHORT).show()
+                }
+            }
+
+        }
+    }
+
+
+}

--- a/samples/src/main/res/layout/activity_offline_exam_sample.xml
+++ b/samples/src/main/res/layout/activity_offline_exam_sample.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <include layout="@layout/testpress_toolbar" />
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="5dp"
+        android:theme="@style/TextInputLayoutTheme"
+        tools:ignore="MissingConstraints">
+        <androidx.appcompat.widget.AppCompatEditText
+            style="@style/EditTextStyle"
+            android:id="@+id/edit_text"
+            android:inputType="number"
+            android:textSize="16sp"
+            android:maxLines="6"
+            android:textColor="@color/black"
+            android:hint="Enter the Content Id"
+            android:imeOptions="actionDone" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <ProgressBar
+        android:id="@+id/loading_progress_bar"
+        android:layout_gravity="center"
+        android:visibility="gone"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"/>
+
+    <androidx.appcompat.widget.AppCompatButton
+        style="@style/Button"
+        android:text="Downloads"
+        android:layout_gravity="center"
+        android:layout_width="wrap_content"
+        android:id="@+id/downloads" />
+
+</LinearLayout>

--- a/samples/src/main/res/layout/activity_open_in.xml
+++ b/samples/src/main/res/layout/activity_open_in.xml
@@ -86,6 +86,11 @@
             android:text="Custom Test"
             android:id="@+id/custom_test_generation" />
 
+        <androidx.appcompat.widget.AppCompatButton
+            style="@style/Button"
+            android:text="Offline Exam"
+            android:id="@+id/offline_exam_download" />
+
     </LinearLayout>
 
     </ScrollView>


### PR DESCRIPTION
- Implemented the repository pattern to download exams and exam settings and store them in the local database.
- Added a sample activity in the sample app to test the download functionality for exams.
