### PR TITLE
Refactor: Use ApiResponse class to parse languages

### DIFF
--- a/core/src/main/java/in/testpress/v2_4/models/ApiResponse.java
+++ b/core/src/main/java/in/testpress/v2_4/models/ApiResponse.java
@@ -88,4 +88,8 @@ public class ApiResponse<T> {
         this.results = results;
     }
 
+    public boolean hasMore() {
+        return getNext() != null;
+    }
+
 }

--- a/exam/src/main/java/in/testpress/exam/api/ExamService.java
+++ b/exam/src/main/java/in/testpress/exam/api/ExamService.java
@@ -1,6 +1,7 @@
 package in.testpress.exam.api;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import in.testpress.exam.models.AttemptItem;
@@ -20,6 +21,7 @@ import in.testpress.models.greendao.Exam;
 import in.testpress.models.greendao.Language;
 import in.testpress.models.greendao.ReviewItem;
 import in.testpress.network.RetrofitCall;
+import in.testpress.v2_4.models.ApiResponse;
 import retrofit2.http.Body;
 import retrofit2.http.DELETE;
 import retrofit2.http.GET;
@@ -149,7 +151,7 @@ public interface ExamService {
             @Path(value = "content_id", encoded = true) long contentId);
 
     @GET(EXAMS_LIST_v2_3_PATH + "{exam_slug}" + LANGUAGES_PATH)
-    RetrofitCall<TestpressApiResponse<Language>> getLanguages(
+    RetrofitCall<ApiResponse<List<Language>>> getLanguages(
             @Path(value = "exam_slug", encoded = true) String examSlug);
 
     @GET(REPORT_QUESTION+"{question_id}"+REPORTEES)

--- a/exam/src/main/java/in/testpress/exam/api/TestpressExamApiClient.java
+++ b/exam/src/main/java/in/testpress/exam/api/TestpressExamApiClient.java
@@ -286,7 +286,7 @@ public class TestpressExamApiClient extends TestpressApiClient {
         return getExamService().checkPermission(contentId);
     }
 
-    public RetrofitCall<TestpressApiResponse<Language>> getLanguages(String examSlug) {
+    public RetrofitCall<ApiResponse<List<Language>>> getLanguages(String examSlug) {
         return getExamService().getLanguages(examSlug);
     }
 

--- a/exam/src/main/java/in/testpress/exam/ui/AttemptsActivity.java
+++ b/exam/src/main/java/in/testpress/exam/ui/AttemptsActivity.java
@@ -34,7 +34,6 @@ import in.testpress.exam.pager.AttemptsPager;
 import in.testpress.exam.api.TestpressExamApiClient;
 import in.testpress.exam.util.MultiLanguagesUtil;
 import in.testpress.exam.util.RetakeExamUtil;
-import in.testpress.models.TestpressApiResponse;
 import in.testpress.models.greendao.Attempt;
 import in.testpress.models.greendao.Exam;
 import in.testpress.models.greendao.Language;
@@ -44,6 +43,7 @@ import in.testpress.util.CommonUtils;
 import in.testpress.util.ThrowableLoader;
 import in.testpress.util.UIUtils;
 import in.testpress.util.ViewUtils;
+import in.testpress.v2_4.models.ApiResponse;
 
 import static in.testpress.Constants.DEFAULT_ATTEMPTS_TITLE;
 import static in.testpress.exam.TestpressExam.PARAM_EXAM_SLUG;
@@ -72,7 +72,7 @@ public class AttemptsActivity extends BaseToolBarActivity
     private List<Attempt> attempts = new ArrayList<>();
     private AttemptsPager pager;
     private RetrofitCall<Exam> examApiRequest;
-    private RetrofitCall<TestpressApiResponse<Language>> languagesApiRequest;
+    private RetrofitCall<ApiResponse<List<Language>>> languagesApiRequest;
 
     @SuppressWarnings({"ConstantConditions", "deprecation"})
     @SuppressLint({"SetJavaScriptEnabled", "AddJavascriptInterface", "DefaultLocale"})
@@ -263,9 +263,9 @@ public class AttemptsActivity extends BaseToolBarActivity
     void fetchLanguages() {
         progressBar.setVisibility(View.VISIBLE);
         languagesApiRequest = apiClient.getLanguages(exam.getSlug())
-                .enqueue(new TestpressCallback<TestpressApiResponse<Language>>() {
+                .enqueue(new TestpressCallback<ApiResponse<List<Language>>>() {
                     @Override
-                    public void onSuccess(TestpressApiResponse<Language> apiResponse) {
+                    public void onSuccess(ApiResponse<List<Language>> apiResponse) {
                         List<Language> languages = exam.getRawLanguages();
                         languages.addAll(apiResponse.getResults());
                         Map<String, Language> uniqueLanguages = new HashMap<>();

--- a/exam/src/main/java/in/testpress/exam/ui/ReviewQuestionsActivity.java
+++ b/exam/src/main/java/in/testpress/exam/ui/ReviewQuestionsActivity.java
@@ -73,6 +73,7 @@ import in.testpress.ui.BaseToolBarActivity;
 import in.testpress.ui.ExploreSpinnerAdapter;
 import in.testpress.util.UIUtils;
 import in.testpress.util.ViewUtils;
+import in.testpress.v2_4.models.ApiResponse;
 
 public class ReviewQuestionsActivity extends BaseToolBarActivity  {
 
@@ -120,7 +121,7 @@ public class ReviewQuestionsActivity extends BaseToolBarActivity  {
     protected Boolean spinnerDefaultCallback = true;
     protected int selectedItemPosition = -1;
     private RetrofitCall<TestpressApiResponse<ReviewItem>> reviewItemsLoader;
-    private RetrofitCall<TestpressApiResponse<Language>> languageApiRequest;
+    private RetrofitCall<ApiResponse<List<Language>>> languageApiRequest;
     private TestpressExamApiClient apiClient;
     private Menu optionsMenu;
     String reviewUrl;
@@ -542,9 +543,9 @@ public class ReviewQuestionsActivity extends BaseToolBarActivity  {
         if (exam == null) return;
         progressBar.setVisibility(View.VISIBLE);
         languageApiRequest = apiClient.getLanguages(exam.getSlug())
-                .enqueue(new TestpressCallback<TestpressApiResponse<Language>>() {
+                .enqueue(new TestpressCallback<ApiResponse<List<Language>>>() {
                     @Override
-                    public void onSuccess(TestpressApiResponse<Language> apiResponse) {
+                    public void onSuccess(ApiResponse<List<Language>> apiResponse) {
                         List<Language> languages = exam.getRawLanguages();
                         languages.addAll(apiResponse.getResults());
                         Map<String, Language> uniqueLanguages = new HashMap<>();

--- a/exam/src/main/java/in/testpress/exam/ui/TestActivity.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestActivity.java
@@ -50,6 +50,7 @@ import in.testpress.util.FormatDate;
 import in.testpress.util.ThrowableLoader;
 import in.testpress.util.UIUtils;
 import in.testpress.util.ViewUtils;
+import in.testpress.v2_4.models.ApiResponse;
 import retrofit2.Response;
 
 import static in.testpress.exam.api.TestpressExamApiClient.IS_PARTIAL;
@@ -99,7 +100,7 @@ public class TestActivity extends BaseToolBarActivity implements LoaderManager.L
     private RetrofitCall<Exam> examApiRequest;
     private RetrofitCall<Permission> permissionsApiRequest;
     private RetrofitCall<TestpressApiResponse<Attempt>> attemptsApiRequest;
-    private RetrofitCall<TestpressApiResponse<Language>> languagesApiRequest;
+    private RetrofitCall<ApiResponse<List<Language>>> languagesApiRequest;
 
     @Override
     protected void onCreate(final Bundle savedInstanceState) {
@@ -270,9 +271,9 @@ public class TestActivity extends BaseToolBarActivity implements LoaderManager.L
         }
         progressBar.setVisibility(View.VISIBLE);
         languagesApiRequest = apiClient.getLanguages(exam.getSlug())
-                .enqueue(new TestpressCallback<TestpressApiResponse<Language>>() {
+                .enqueue(new TestpressCallback<ApiResponse<List<Language>>>() {
                     @Override
-                    public void onSuccess(TestpressApiResponse<Language> apiResponse) {
+                    public void onSuccess(ApiResponse<List<Language>> apiResponse) {
                         List<Language> languages = exam.getRawLanguages();
                         languages.addAll(apiResponse.getResults());
                         Map<String, Language> uniqueLanguages = new HashMap<>();


### PR DESCRIPTION
- Replaced `TestpressApiResponse<Language>` with `ApiResponse<List<Language>>` in the `getLanguages` method.
- The `ApiResponse` class is now used for all paginated API calls due to its support for both flat nested objects and list responses, unlike the previous implementation which lacked support for flat nested objects.