### PR TITLE
fix: Prevent Deletion of Existing Attempts

### DIFF
--- a/core/src/main/java/in/testpress/database/entities/OfflineAttempt.kt
+++ b/core/src/main/java/in/testpress/database/entities/OfflineAttempt.kt
@@ -6,7 +6,7 @@ import androidx.room.PrimaryKey
 @Entity
 data class OfflineAttempt(
     @PrimaryKey(autoGenerate = true)
-    val id: Long = 1,
+    val id: Long = 0,
     val date: String,
     val totalQuestions: Int,
     val lastStartedTime: String,

--- a/core/src/main/java/in/testpress/database/entities/OfflineAttemptSection.kt
+++ b/core/src/main/java/in/testpress/database/entities/OfflineAttemptSection.kt
@@ -7,7 +7,7 @@ import androidx.room.PrimaryKey
 data class OfflineAttemptSection(
     var id: Long,
     @PrimaryKey(autoGenerate = true)
-    val attemptSectionId: Long = 1,
+    val attemptSectionId: Long = 0,
     val state: String,
     val remainingTime: String? = null,
     val name: String,

--- a/core/src/main/java/in/testpress/database/entities/OfflineCourseAttempt.kt
+++ b/core/src/main/java/in/testpress/database/entities/OfflineCourseAttempt.kt
@@ -6,6 +6,6 @@ import androidx.room.PrimaryKey
 @Entity
 data class OfflineCourseAttempt(
     @PrimaryKey(autoGenerate = true)
-    val id: Long = 1,
+    val id: Long = 0,
     val assessmentId: Long
 )


### PR DESCRIPTION
- Previously, we mistakenly set the default value to 1, causing the deletion of old attempts whenever a new attempt was created.
- When setting a primary key to auto-generate, the default value should be set to 0 for it to work correctly.