### PR TITLE
feat: Create attempt item offline and integrate with existing exam template

### DIFF
--- a/core/src/main/java/in/testpress/database/dao/DirectionDao.kt
+++ b/core/src/main/java/in/testpress/database/dao/DirectionDao.kt
@@ -3,6 +3,11 @@ package `in`.testpress.database.dao
 import `in`.testpress.database.BaseDao
 import `in`.testpress.database.entities.Direction
 import androidx.room.Dao
+import androidx.room.Query
 
 @Dao
-interface DirectionDao: BaseDao<Direction>
+interface DirectionDao : BaseDao<Direction> {
+
+    @Query("SELECT * FROM Direction WHERE id = :directionId")
+    suspend fun getDirectionById(directionId: Long): Direction?
+}

--- a/core/src/main/java/in/testpress/database/dao/ExamQuestionDao.kt
+++ b/core/src/main/java/in/testpress/database/dao/ExamQuestionDao.kt
@@ -13,4 +13,7 @@ interface ExamQuestionDao: BaseDao<ExamQuestion> {
 
     @Query("SELECT DISTINCT sectionId FROM ExamQuestion WHERE examId = :examId")
     suspend fun getUniqueSectionIdsByExamId(examId: Long): List<Long>
+
+    @Query("SELECT * FROM ExamQuestion WHERE examId = :examId ORDER BY `order`")
+    suspend fun getExamQuestionsByExamId(examId: Long): List<ExamQuestion>
 }

--- a/core/src/main/java/in/testpress/database/dao/OfflineAttemptDao.kt
+++ b/core/src/main/java/in/testpress/database/dao/OfflineAttemptDao.kt
@@ -14,4 +14,7 @@ interface OfflineAttemptDao: BaseDao<OfflineAttempt>{
 
     @Query("SELECT * FROM OfflineAttempt WHERE id = :attemptId")
     suspend fun getById(attemptId: Long): OfflineAttempt
+
+    @Query("UPDATE OfflineAttempt SET state = :state WHERE id = :attemptId")
+    suspend fun updateAttemptState(attemptId: Long, state: String)
 }

--- a/core/src/main/java/in/testpress/database/dao/OfflineAttemptItemDao.kt
+++ b/core/src/main/java/in/testpress/database/dao/OfflineAttemptItemDao.kt
@@ -3,6 +3,10 @@ package `in`.testpress.database.dao
 import `in`.testpress.database.BaseDao
 import `in`.testpress.database.entities.OfflineAttemptItem
 import androidx.room.Dao
+import androidx.room.Query
 
 @Dao
-interface OfflineAttemptItemDao : BaseDao<OfflineAttemptItem>
+interface OfflineAttemptItemDao : BaseDao<OfflineAttemptItem> {
+    @Query("SELECT * FROM OfflineAttemptItem WHERE id = :id")
+    suspend fun getAttemptItemById(id: Long): OfflineAttemptItem?
+}

--- a/core/src/main/java/in/testpress/database/dao/OfflineAttemptItemDao.kt
+++ b/core/src/main/java/in/testpress/database/dao/OfflineAttemptItemDao.kt
@@ -4,9 +4,16 @@ import `in`.testpress.database.BaseDao
 import `in`.testpress.database.entities.OfflineAttemptItem
 import androidx.room.Dao
 import androidx.room.Query
+import androidx.room.Update
 
 @Dao
 interface OfflineAttemptItemDao : BaseDao<OfflineAttemptItem> {
     @Query("SELECT * FROM OfflineAttemptItem WHERE id = :id")
     suspend fun getAttemptItemById(id: Long): OfflineAttemptItem?
+
+    @Update
+    suspend fun update(offlineAttemptItem: OfflineAttemptItem)
+
+    @Query("SELECT * FROM OfflineAttemptItem WHERE attemptId = :attemptId")
+    suspend fun getOfflineAttemptItemByAttemptId(attemptId: Long): List<OfflineAttemptItem>
 }

--- a/core/src/main/java/in/testpress/database/dao/OfflineAttemptSectionDao.kt
+++ b/core/src/main/java/in/testpress/database/dao/OfflineAttemptSectionDao.kt
@@ -1,8 +1,13 @@
 package `in`.testpress.database.dao
 
 import `in`.testpress.database.BaseDao
+import `in`.testpress.database.entities.OfflineAttempt
 import `in`.testpress.database.entities.OfflineAttemptSection
 import androidx.room.Dao
+import androidx.room.Query
 
 @Dao
-interface OfflineAttemptSectionDao: BaseDao<OfflineAttemptSection>
+interface OfflineAttemptSectionDao: BaseDao<OfflineAttemptSection> {
+    @Query("SELECT * FROM OfflineAttemptSection WHERE sectionId = :sectionId")
+    suspend fun getById(sectionId: Long?): OfflineAttemptSection?
+}

--- a/core/src/main/java/in/testpress/database/dao/OfflineAttemptSectionDao.kt
+++ b/core/src/main/java/in/testpress/database/dao/OfflineAttemptSectionDao.kt
@@ -9,5 +9,8 @@ import androidx.room.Query
 @Dao
 interface OfflineAttemptSectionDao: BaseDao<OfflineAttemptSection> {
     @Query("SELECT * FROM OfflineAttemptSection WHERE sectionId = :sectionId")
-    suspend fun getById(sectionId: Long?): OfflineAttemptSection?
+    suspend fun getBySectionId(sectionId: Long?): OfflineAttemptSection?
+
+    @Query("SELECT * FROM OfflineAttemptSection WHERE attemptId = :attemptId")
+    suspend fun getByAttemptId(attemptId: Long): List<OfflineAttemptSection>
 }

--- a/core/src/main/java/in/testpress/database/dao/OfflineCourseAttemptDao.kt
+++ b/core/src/main/java/in/testpress/database/dao/OfflineCourseAttemptDao.kt
@@ -3,6 +3,10 @@ package `in`.testpress.database.dao
 import `in`.testpress.database.BaseDao
 import `in`.testpress.database.entities.OfflineCourseAttempt
 import androidx.room.Dao
+import androidx.room.Query
 
 @Dao
-interface OfflineCourseAttemptDao: BaseDao<OfflineCourseAttempt>
+interface OfflineCourseAttemptDao: BaseDao<OfflineCourseAttempt> {
+    @Query("SELECT * FROM OfflineCourseAttempt WHERE assessmentId = :attemptId")
+    fun getById(attemptId: Long): OfflineCourseAttempt?
+}

--- a/core/src/main/java/in/testpress/database/dao/QuestionDao.kt
+++ b/core/src/main/java/in/testpress/database/dao/QuestionDao.kt
@@ -3,6 +3,11 @@ package `in`.testpress.database.dao
 import `in`.testpress.database.BaseDao
 import `in`.testpress.database.entities.Question
 import androidx.room.Dao
+import androidx.room.Query
 
 @Dao
-interface QuestionDao: BaseDao<Question>
+interface QuestionDao : BaseDao<Question> {
+
+    @Query("SELECT * FROM Question WHERE id = :id")
+    suspend fun getQuestionById(id: Long): Question?
+}

--- a/core/src/main/java/in/testpress/database/dao/SubjectDao.kt
+++ b/core/src/main/java/in/testpress/database/dao/SubjectDao.kt
@@ -3,6 +3,11 @@ package `in`.testpress.database.dao
 import `in`.testpress.database.BaseDao
 import `in`.testpress.database.entities.Subject
 import androidx.room.Dao
+import androidx.room.Query
 
 @Dao
-interface SubjectDao: BaseDao<Subject>
+interface SubjectDao : BaseDao<Subject> {
+
+    @Query("SELECT * FROM Subject WHERE id = :subjectId")
+    suspend fun getSubjectById(subjectId: Long): Subject?
+}

--- a/core/src/main/java/in/testpress/database/mapping/OfflineAttemptMapping.kt
+++ b/core/src/main/java/in/testpress/database/mapping/OfflineAttemptMapping.kt
@@ -4,7 +4,7 @@ import `in`.testpress.database.entities.OfflineAttempt
 import `in`.testpress.models.greendao.Attempt
 import `in`.testpress.models.greendao.AttemptSection
 
-fun OfflineAttempt.createGreenDoaModel(attemptSections: List<AttemptSection>): Attempt {
+fun OfflineAttempt.createGreenDoaModel(attemptSections: List<AttemptSection?>): Attempt {
     val attempt = Attempt()
     attempt.url = null
     attempt.id = this.id

--- a/core/src/main/java/in/testpress/database/mapping/OfflineAttemptSectionMapping.kt
+++ b/core/src/main/java/in/testpress/database/mapping/OfflineAttemptSectionMapping.kt
@@ -2,6 +2,7 @@ package `in`.testpress.database.mapping
 
 import `in`.testpress.database.entities.OfflineAttemptSection
 import `in`.testpress.models.greendao.AttemptSection
+import android.util.Log
 
 fun OfflineAttemptSection?.asGreenDoaModel(): AttemptSection? {
     if (this == null) return null
@@ -12,7 +13,10 @@ fun OfflineAttemptSection?.asGreenDoaModel(): AttemptSection? {
     attemptSection.startUrl = null
     attemptSection.endUrl = null
     attemptSection.remainingTime = this.remainingTime
+    Log.d("TAG", "asGreenDoaModel: ${attemptSection.name}")
     attemptSection.name = this.name
+    Log.d("TAG", "asGreenDoaModel: ${this.name}")
+    Log.d("TAG", "asGreenDoaModel: ${attemptSection.name}")
     attemptSection.duration = this.duration
     attemptSection.order = this.order
     attemptSection.instructions = this.instructions

--- a/core/src/main/java/in/testpress/database/mapping/OfflineAttemptSectionMapping.kt
+++ b/core/src/main/java/in/testpress/database/mapping/OfflineAttemptSectionMapping.kt
@@ -13,10 +13,7 @@ fun OfflineAttemptSection?.asGreenDoaModel(): AttemptSection? {
     attemptSection.startUrl = null
     attemptSection.endUrl = null
     attemptSection.remainingTime = this.remainingTime
-    Log.d("TAG", "asGreenDoaModel: ${attemptSection.name}")
     attemptSection.name = this.name
-    Log.d("TAG", "asGreenDoaModel: ${this.name}")
-    Log.d("TAG", "asGreenDoaModel: ${attemptSection.name}")
     attemptSection.duration = this.duration
     attemptSection.order = this.order
     attemptSection.instructions = this.instructions

--- a/core/src/main/java/in/testpress/database/mapping/OfflineAttemptSectionMapping.kt
+++ b/core/src/main/java/in/testpress/database/mapping/OfflineAttemptSectionMapping.kt
@@ -3,7 +3,8 @@ package `in`.testpress.database.mapping
 import `in`.testpress.database.entities.OfflineAttemptSection
 import `in`.testpress.models.greendao.AttemptSection
 
-fun OfflineAttemptSection.asGreenDoaModel(): AttemptSection {
+fun OfflineAttemptSection?.asGreenDoaModel(): AttemptSection? {
+    if (this == null) return null
     val attemptSection = AttemptSection()
     attemptSection.id = this.id
     attemptSection.state = this.state
@@ -19,8 +20,8 @@ fun OfflineAttemptSection.asGreenDoaModel(): AttemptSection {
     return attemptSection
 }
 
-fun List<OfflineAttemptSection>.asGreenDoaModels(): List<AttemptSection> {
+fun List<OfflineAttemptSection?>.asGreenDoaModels(): List<AttemptSection?> {
     return this.map {
-        it.asGreenDoaModel()
+        it?.asGreenDoaModel()
     }
 }

--- a/core/src/main/java/in/testpress/util/Converters.kt
+++ b/core/src/main/java/in/testpress/util/Converters.kt
@@ -42,8 +42,10 @@ object Converters {
 
     @TypeConverter
     @JvmStatic
-    fun toIntList(value: String?): List<Int>? {
-        return value?.split(",")?.map { it.toInt() }
+    fun toIntList(value: String?): List<Int> {
+        if (value == null) return listOf()
+        if (value.isEmpty()) return listOf()
+        return value.split(",").map { it.toInt() }
     }
 
     @TypeConverter
@@ -112,7 +114,7 @@ object Converters {
     @TypeConverter
     @JvmStatic
     fun toOfflineAttemptSection(value: String?): OfflineAttemptSection? {
-        val offlineAttemptSectionType = object : TypeToken<OfflineUserUploadedFile>() {}.type
+        val offlineAttemptSectionType = object : TypeToken<OfflineAttemptSection>() {}.type
         return Gson().fromJson(value, offlineAttemptSectionType)
     }
 }

--- a/exam/src/main/java/in/testpress/exam/repository/AttemptRepository.kt
+++ b/exam/src/main/java/in/testpress/exam/repository/AttemptRepository.kt
@@ -36,6 +36,7 @@ class AttemptRepository(val context: Context) {
     private val offlineAttemptItemDao = database.offlineAttemptItemDoa()
     private val subjectDao = database.subjectDao()
     private val directionDao = database.directionDao()
+    private val offlineAttemptSection = database.offlineAttemptSectionDao()
     private val languageDao = database.languageDao()
 
 
@@ -95,13 +96,7 @@ class AttemptRepository(val context: Context) {
 
     private fun createOfflineAttemptItemItem() {
         CoroutineScope(Dispatchers.IO).launch {
-            val hasSections = examQuestionDao.getUniqueSectionIdsByExamId(exam.id).count() > 1
-            if (hasSections){
-
-            } else {
-                createOfflineAttemptForAllQuestions()
-            }
-
+            createOfflineAttemptForAllQuestions()
         }
     }
 
@@ -111,6 +106,7 @@ class AttemptRepository(val context: Context) {
             OfflineAttemptItem(
                 question = questionDao.getQuestionById(examQuestion.questionId!!)!!,
                 order = examQuestion.order!!,
+                attemptSection = offlineAttemptSection.getById(examQuestion.sectionId)
             )
         }
         offlineAttemptItemDao.insertAll(offlineAttemptItems)

--- a/exam/src/main/java/in/testpress/exam/repository/AttemptRepository.kt
+++ b/exam/src/main/java/in/testpress/exam/repository/AttemptRepository.kt
@@ -119,11 +119,14 @@ class AttemptRepository(val context: Context) {
 
     private suspend fun createAttemptItem(offlineAttemptItems: List<OfflineAttemptItem>){
         val attemptItems = offlineAttemptItems.map { offlineAttemptItem ->
-            val subject = subjectDao.getSubjectById(offlineAttemptItem.question.subjectId!!)
-            val direction = directionDao.getDirectionById(offlineAttemptItem.question.directionId!!)
+
+            val subject = offlineAttemptItem.question.subjectId?.let { subjectDao.getSubjectById(it) }
+            val direction = offlineAttemptItem.question.directionId?.let { directionDao.getDirectionById(it) }
+            val subjectName = subject?.name ?: "Uncategorized"
+            val directionHtml = direction?.html
             offlineAttemptItem.asAttemptItem(
-                subject?.name!!,
-                direction?.html!!,
+                subjectName,
+                directionHtml,
             )
         }
         _attemptItemsResource.postValue(Resource.success(attemptItems))

--- a/exam/src/main/java/in/testpress/exam/repository/AttemptRepository.kt
+++ b/exam/src/main/java/in/testpress/exam/repository/AttemptRepository.kt
@@ -16,6 +16,7 @@ import androidx.lifecycle.MutableLiveData
 
 class AttemptRepository(val context: Context) {
 
+    var isOfflineExam = false
     var page = 1
     val attemptItem = mutableListOf<AttemptItem>()
     private var _totalQuestions = 0

--- a/exam/src/main/java/in/testpress/exam/repository/AttemptRepository.kt
+++ b/exam/src/main/java/in/testpress/exam/repository/AttemptRepository.kt
@@ -9,6 +9,7 @@ import `in`.testpress.exam.ui.TestFragment.Action
 import `in`.testpress.models.TestpressApiResponse
 import `in`.testpress.models.greendao.Attempt
 import `in`.testpress.models.greendao.CourseAttempt
+import `in`.testpress.models.greendao.Exam
 import `in`.testpress.network.Resource
 import android.content.Context
 import androidx.lifecycle.LiveData
@@ -16,7 +17,8 @@ import androidx.lifecycle.MutableLiveData
 
 class AttemptRepository(val context: Context) {
 
-    var isOfflineExam = false
+    lateinit var exam : Exam
+    private val isOfflineExam: Boolean get() = exam.isOfflineExam
     var page = 1
     val attemptItem = mutableListOf<AttemptItem>()
     private var _totalQuestions = 0
@@ -76,6 +78,9 @@ class AttemptRepository(val context: Context) {
     }
 
     private fun createOfflineAttemptItemItem() {
+
+
+
 
     }
 

--- a/exam/src/main/java/in/testpress/exam/ui/TestActivity.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestActivity.java
@@ -329,7 +329,6 @@ public class TestActivity extends BaseToolBarActivity  {
         if (courseContent != null) {
             if (exam == null) {
                 exam = courseContent.getRawExam();
-                exam.setIsOfflineExam(true);
                 examViewModel.setExam(exam);
             }
             if (courseAttempt == null && permission == null) {
@@ -341,7 +340,6 @@ public class TestActivity extends BaseToolBarActivity  {
                 checkStartExamScreenState();
             }
         } else if (exam != null) {
-            exam.setIsOfflineExam(true);
             examViewModel.setExam(exam);
             checkStartExamScreenState();
         } else {

--- a/exam/src/main/java/in/testpress/exam/ui/TestActivity.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestActivity.java
@@ -329,6 +329,7 @@ public class TestActivity extends BaseToolBarActivity  {
         if (courseContent != null) {
             if (exam == null) {
                 exam = courseContent.getRawExam();
+                exam.setIsOfflineExam(true);
                 examViewModel.setExam(exam);
             }
             if (courseAttempt == null && permission == null) {
@@ -340,6 +341,7 @@ public class TestActivity extends BaseToolBarActivity  {
                 checkStartExamScreenState();
             }
         } else if (exam != null) {
+            exam.setIsOfflineExam(true);
             examViewModel.setExam(exam);
             checkStartExamScreenState();
         } else {

--- a/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
@@ -838,7 +838,6 @@ public class TestFragment extends BaseFragment implements
             HashMap<String, List<AttemptItem>> groupedAttemptItems = new HashMap<>();
             for (AttemptItem attemptItem : attemptItemList) {
                 if (attempt.hasNoSectionalLock()) {
-                    Log.d("TAG", "initializeSectionSpinner: "+attemptItem.getAttemptSection().getName());
                     String section = attemptItem.getAttemptSection().getName();
                     groupAttemptItems(section, attemptItem, spinnerItemsList, groupedAttemptItems);
                 } else {

--- a/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
@@ -149,12 +149,12 @@ public class TestFragment extends BaseFragment implements
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        attemptViewModel = AttemptViewModel.Companion.initializeViewModel(requireActivity());
         initializeAttemptAndExamVariables(savedInstanceState);
         instituteSettings = TestpressSdk.getTestpressSession(getContext()).getInstituteSettings();
         eventsTrackerFacade = new EventsTrackerFacade(getContext());
         logEvent(EventsTrackerFacade.STARTED_EXAM);
         apiClient = new TestpressExamApiClient(getActivity());
-        attemptViewModel = AttemptViewModel.Companion.initializeViewModel(requireActivity());
     }
 
     private void logEvent(String name) {
@@ -176,6 +176,7 @@ public class TestFragment extends BaseFragment implements
             attempt = getArguments().getParcelable(PARAM_ATTEMPT);
             exam = getArguments().getParcelable(PARAM_EXAM);
         }
+        exam.setIsOfflineExam(true);
         attemptViewModel.setExam(exam);
         if (savedInstanceState != null && savedInstanceState.getParcelable(PARAM_ATTEMPT) != null) {
             attempt = savedInstanceState.getParcelable(PARAM_ATTEMPT);

--- a/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
@@ -176,7 +176,6 @@ public class TestFragment extends BaseFragment implements
             attempt = getArguments().getParcelable(PARAM_ATTEMPT);
             exam = getArguments().getParcelable(PARAM_EXAM);
         }
-        exam.setIsOfflineExam(true);
         attemptViewModel.setExam(exam);
         if (savedInstanceState != null && savedInstanceState.getParcelable(PARAM_ATTEMPT) != null) {
             attempt = savedInstanceState.getParcelable(PARAM_ATTEMPT);

--- a/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
@@ -176,6 +176,7 @@ public class TestFragment extends BaseFragment implements
             attempt = getArguments().getParcelable(PARAM_ATTEMPT);
             exam = getArguments().getParcelable(PARAM_EXAM);
         }
+        exam.setIsOfflineExam(true);
         attemptViewModel.setExam(exam);
         if (savedInstanceState != null && savedInstanceState.getParcelable(PARAM_ATTEMPT) != null) {
             attempt = savedInstanceState.getParcelable(PARAM_ATTEMPT);
@@ -808,11 +809,14 @@ public class TestFragment extends BaseFragment implements
     }
 
     private void fetchAttemptItems(){
-        String questionUrl = attempt.getQuestionsUrlFrag();
-        if (attempt.hasSectionalLock()) {
-            questionUrl = sections.get(attempt.getCurrentSectionPosition()).getQuestionsUrlFrag();
+        String questionUrl = "";
+        if (!exam.getIsOfflineExam()){
+            questionUrl =  attempt.getQuestionsUrlFrag();
+            if (attempt.hasSectionalLock()) {
+                questionUrl = sections.get(attempt.getCurrentSectionPosition()).getQuestionsUrlFrag();
+            }
+            questionUrl = questionUrl.replace("v2.3", "v2.2.1");
         }
-        questionUrl = questionUrl.replace("v2.3", "v2.2.1");
 
         if (attempt.hasSectionalLock()) {
             progressDialog.setMessage(getString(R.string.testpress_loading_section_questions,
@@ -834,6 +838,7 @@ public class TestFragment extends BaseFragment implements
             HashMap<String, List<AttemptItem>> groupedAttemptItems = new HashMap<>();
             for (AttemptItem attemptItem : attemptItemList) {
                 if (attempt.hasNoSectionalLock()) {
+                    Log.d("TAG", "initializeSectionSpinner: "+attemptItem.getAttemptSection().getName());
                     String section = attemptItem.getAttemptSection().getName();
                     groupAttemptItems(section, attemptItem, spinnerItemsList, groupedAttemptItems);
                 } else {

--- a/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
@@ -175,7 +175,7 @@ public class TestFragment extends BaseFragment implements
             attempt = getArguments().getParcelable(PARAM_ATTEMPT);
             exam = getArguments().getParcelable(PARAM_EXAM);
         }
-
+        attemptViewModel.setOfflineExam(Boolean.TRUE.equals(exam.getIsOfflineExam()));
         if (savedInstanceState != null && savedInstanceState.getParcelable(PARAM_ATTEMPT) != null) {
             attempt = savedInstanceState.getParcelable(PARAM_ATTEMPT);
         }

--- a/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
@@ -177,7 +177,7 @@ public class TestFragment extends BaseFragment implements
             exam = getArguments().getParcelable(PARAM_EXAM);
         }
         exam.setIsOfflineExam(true);
-        attemptViewModel.setExam(exam);
+        attemptViewModel.setExamAndAttempt(exam, attempt);
         if (savedInstanceState != null && savedInstanceState.getParcelable(PARAM_ATTEMPT) != null) {
             attempt = savedInstanceState.getParcelable(PARAM_ATTEMPT);
         }

--- a/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
@@ -22,6 +22,7 @@ import androidx.slidingpanelayout.widget.SlidingPaneLayout;
 import androidx.appcompat.app.AlertDialog;
 
 import android.text.Html;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -175,7 +176,7 @@ public class TestFragment extends BaseFragment implements
             attempt = getArguments().getParcelable(PARAM_ATTEMPT);
             exam = getArguments().getParcelable(PARAM_EXAM);
         }
-        attemptViewModel.setOfflineExam(Boolean.TRUE.equals(exam.getIsOfflineExam()));
+        attemptViewModel.setExam(exam);
         if (savedInstanceState != null && savedInstanceState.getParcelable(PARAM_ATTEMPT) != null) {
             attempt = savedInstanceState.getParcelable(PARAM_ATTEMPT);
         }

--- a/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
@@ -22,7 +22,6 @@ import androidx.slidingpanelayout.widget.SlidingPaneLayout;
 import androidx.appcompat.app.AlertDialog;
 
 import android.text.Html;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -176,7 +175,6 @@ public class TestFragment extends BaseFragment implements
             attempt = getArguments().getParcelable(PARAM_ATTEMPT);
             exam = getArguments().getParcelable(PARAM_EXAM);
         }
-        exam.setIsOfflineExam(true);
         attemptViewModel.setExamAndAttempt(exam, attempt);
         if (savedInstanceState != null && savedInstanceState.getParcelable(PARAM_ATTEMPT) != null) {
             attempt = savedInstanceState.getParcelable(PARAM_ATTEMPT);

--- a/exam/src/main/java/in/testpress/exam/ui/viewmodel/AttemptViewModel.kt
+++ b/exam/src/main/java/in/testpress/exam/ui/viewmodel/AttemptViewModel.kt
@@ -27,6 +27,10 @@ class AttemptViewModel(val repository: AttemptRepository) : ViewModel() {
     var isNextPageQuestionsBeingFetched: Boolean = false
     var currentQuestionPosition = 0
 
+    fun setOfflineExam(isOfflineExam: Boolean){
+        repository.isOfflineExam = isOfflineExam
+    }
+
     fun fetchAttemptItems(questionsUrlFrag: String, fetchSinglePageOnly: Boolean){
         repository.fetchAttemptItems(questionsUrlFrag, fetchSinglePageOnly)
     }

--- a/exam/src/main/java/in/testpress/exam/ui/viewmodel/AttemptViewModel.kt
+++ b/exam/src/main/java/in/testpress/exam/ui/viewmodel/AttemptViewModel.kt
@@ -6,6 +6,7 @@ import `in`.testpress.exam.repository.AttemptRepository
 import `in`.testpress.exam.ui.TestFragment
 import `in`.testpress.models.greendao.Attempt
 import `in`.testpress.models.greendao.CourseAttempt
+import `in`.testpress.models.greendao.Exam
 import `in`.testpress.network.Resource
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.LiveData
@@ -27,8 +28,8 @@ class AttemptViewModel(val repository: AttemptRepository) : ViewModel() {
     var isNextPageQuestionsBeingFetched: Boolean = false
     var currentQuestionPosition = 0
 
-    fun setOfflineExam(isOfflineExam: Boolean){
-        repository.isOfflineExam = isOfflineExam
+    fun setExam(exam: Exam){
+        repository.exam = exam
     }
 
     fun fetchAttemptItems(questionsUrlFrag: String, fetchSinglePageOnly: Boolean){

--- a/exam/src/main/java/in/testpress/exam/ui/viewmodel/AttemptViewModel.kt
+++ b/exam/src/main/java/in/testpress/exam/ui/viewmodel/AttemptViewModel.kt
@@ -30,8 +30,9 @@ class AttemptViewModel(val repository: AttemptRepository) : ViewModel() {
     var isNextPageQuestionsBeingFetched: Boolean = false
     var currentQuestionPosition = 0
 
-    fun setExam(exam: Exam){
+    fun setExamAndAttempt(exam: Exam, attempt: Attempt){
         repository.exam = exam
+        repository.attempt = attempt
     }
 
     fun fetchAttemptItems(questionsUrlFrag: String, fetchSinglePageOnly: Boolean){

--- a/exam/src/main/java/in/testpress/exam/ui/viewmodel/AttemptViewModel.kt
+++ b/exam/src/main/java/in/testpress/exam/ui/viewmodel/AttemptViewModel.kt
@@ -12,6 +12,8 @@ import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.launch
 
 class AttemptViewModel(val repository: AttemptRepository) : ViewModel() {
 
@@ -37,7 +39,9 @@ class AttemptViewModel(val repository: AttemptRepository) : ViewModel() {
     }
 
     fun saveAnswer(position: Int, attemptItem: AttemptItem, action: TestFragment.Action){
-        repository.saveAnswer(position, attemptItem, action)
+        viewModelScope.launch {
+            repository.saveAnswer(position, attemptItem, action)
+        }
     }
 
     fun updateSection(url: String, action: TestFragment.Action){

--- a/exam/src/main/java/in/testpress/exam/util/OfflineAttemptItemMapping.kt
+++ b/exam/src/main/java/in/testpress/exam/util/OfflineAttemptItemMapping.kt
@@ -46,7 +46,7 @@ fun List<Question>.asAttemptQuestions(subject: String, direction: String?) = thi
 fun Answer.asAttemptAnswer(): AttemptAnswer {
     return AttemptAnswer(
         this.textHtml!!,
-        this.id?.toInt()
+        this.saveId?.toInt() ?: this.id?.toInt()
     )
 }
 

--- a/exam/src/main/java/in/testpress/exam/util/OfflineAttemptItemMapping.kt
+++ b/exam/src/main/java/in/testpress/exam/util/OfflineAttemptItemMapping.kt
@@ -1,0 +1,57 @@
+package `in`.testpress.exam.util
+
+import `in`.testpress.database.entities.*
+import `in`.testpress.database.mapping.asGreenDoaModel
+import `in`.testpress.exam.models.AttemptAnswer
+import `in`.testpress.exam.models.AttemptItem
+import `in`.testpress.exam.models.AttemptQuestion
+import `in`.testpress.exam.models.UserUploadedFile
+
+fun OfflineAttemptItem.asAttemptItem(subject: String, direction: String): AttemptItem{
+    return AttemptItem(
+        id,
+        null,
+        question.asAttemptQuestion(subject, direction),
+        selectedAnswers,
+        review,
+       savedAnswers,
+        order,
+        null,
+        shortText,
+        currentShortText,
+        attemptSection?.asGreenDoaModel(),
+        essayText,
+        localEssayText,
+        files.asUserUploadedFiles(),
+        unSyncedFiles
+    )
+}
+
+fun Question.asAttemptQuestion(subject: String, direction: String): AttemptQuestion {
+    return AttemptQuestion(
+        questionHtml,
+        answers.asAttemptAnswers(),
+        subject,
+        direction,
+        type,
+        language,
+        translations.asAttemptQuestions(subject, direction) as ArrayList<AttemptQuestion>,
+        marks,
+        negativeMarks,
+    )
+}
+
+fun List<Question>.asAttemptQuestions(subject: String, direction: String) = this.map { it.asAttemptQuestion(subject, direction) }
+
+fun Answer.asAttemptAnswer(): AttemptAnswer {
+    return AttemptAnswer(
+        this.textHtml!!,
+        this.id?.toInt()
+    )
+}
+
+fun List<Answer>.asAttemptAnswers() = this.map { it.asAttemptAnswer() }
+
+fun OfflineUserUploadedFile.asUserUploadedFile() = UserUploadedFile(id, url, path)
+
+fun List<OfflineUserUploadedFile>.asUserUploadedFiles() = this.map { it.asUserUploadedFile() }

--- a/exam/src/main/java/in/testpress/exam/util/OfflineAttemptItemMapping.kt
+++ b/exam/src/main/java/in/testpress/exam/util/OfflineAttemptItemMapping.kt
@@ -7,7 +7,7 @@ import `in`.testpress.exam.models.AttemptItem
 import `in`.testpress.exam.models.AttemptQuestion
 import `in`.testpress.exam.models.UserUploadedFile
 
-fun OfflineAttemptItem.asAttemptItem(subject: String, direction: String): AttemptItem{
+fun OfflineAttemptItem.asAttemptItem(subject: String, direction: String?): AttemptItem{
     return AttemptItem(
         id,
         null,
@@ -27,7 +27,7 @@ fun OfflineAttemptItem.asAttemptItem(subject: String, direction: String): Attemp
     )
 }
 
-fun Question.asAttemptQuestion(subject: String, direction: String): AttemptQuestion {
+fun Question.asAttemptQuestion(subject: String, direction: String?): AttemptQuestion {
     return AttemptQuestion(
         questionHtml,
         answers.asAttemptAnswers(),
@@ -41,7 +41,7 @@ fun Question.asAttemptQuestion(subject: String, direction: String): AttemptQuest
     )
 }
 
-fun List<Question>.asAttemptQuestions(subject: String, direction: String) = this.map { it.asAttemptQuestion(subject, direction) }
+fun List<Question>.asAttemptQuestions(subject: String, direction: String?) = this.map { it.asAttemptQuestion(subject, direction) }
 
 fun Answer.asAttemptAnswer(): AttemptAnswer {
     return AttemptAnswer(


### PR DESCRIPTION
- Added creation of OfflineAttemptItem using exam questions, currently for exams without sections.
- Enabled users to take exams offline by creating attempts and updating answers locally.
- Set the status of the attempt to 'complete' when the user ends the exam.