### PR TITLE
feat: Add Constructors to Models for Offline Exam Support

### DIFF
--- a/exam/src/main/java/in/testpress/exam/models/AttemptAnswer.java
+++ b/exam/src/main/java/in/testpress/exam/models/AttemptAnswer.java
@@ -10,6 +10,11 @@ public class AttemptAnswer implements Parcelable {
 
     public AttemptAnswer() {}
 
+    public AttemptAnswer(String textHtml, Integer id) {
+        this.textHtml = textHtml;
+        this.id = id;
+    }
+
     // Parcelling part
     public AttemptAnswer(Parcel parcel){
         textHtml = parcel.readString();

--- a/exam/src/main/java/in/testpress/exam/models/AttemptItem.java
+++ b/exam/src/main/java/in/testpress/exam/models/AttemptItem.java
@@ -35,6 +35,27 @@ public class AttemptItem implements Parcelable {
         savedAnswers = new ArrayList<Integer>();
     }
 
+    public AttemptItem(Integer id, String url, AttemptQuestion question, List<Integer> selectedAnswers,
+                       Boolean review, List<Integer> savedAnswers, Integer index, Boolean currentReview,
+                       String shortText, String currentShortText, AttemptSection attemptSection,
+                       String essayText, String localEssayText, List<UserUploadedFile> files, List<String> unSyncedFiles) {
+        this.id = id;
+        this.url = url;
+        this.question = question;
+        this.selectedAnswers = selectedAnswers;
+        this.review = review;
+        this.savedAnswers = savedAnswers;
+        this.index = index;
+        this.currentReview = currentReview;
+        this.shortText = shortText;
+        this.currentShortText = currentShortText;
+        this.attemptSection = attemptSection;
+        this.essayText = essayText;
+        this.localEssayText = localEssayText;
+        this.files = files;
+        this.unSyncedFiles = unSyncedFiles;
+    }
+
     // Parcelling part
     protected AttemptItem(Parcel in) {
         id = in.readInt();

--- a/exam/src/main/java/in/testpress/exam/models/AttemptQuestion.java
+++ b/exam/src/main/java/in/testpress/exam/models/AttemptQuestion.java
@@ -18,6 +18,21 @@ public class AttemptQuestion implements Parcelable {
     private String marks;
     private String negativeMarks;
 
+    public AttemptQuestion(String questionHtml, List<AttemptAnswer> answers, String subject,
+                           String direction, String type, String language,
+                           ArrayList<AttemptQuestion> translations, String marks,
+                           String negativeMarks) {
+        this.questionHtml = questionHtml;
+        this.answers = answers;
+        this.subject = subject;
+        this.direction = direction;
+        this.type = type;
+        this.language = language;
+        this.translations = translations;
+        this.marks = marks;
+        this.negativeMarks = negativeMarks;
+    }
+
     // Parcelling part
     public AttemptQuestion(Parcel parcel){
         answers = new ArrayList<AttemptAnswer>();

--- a/exam/src/main/java/in/testpress/exam/models/Permission.java
+++ b/exam/src/main/java/in/testpress/exam/models/Permission.java
@@ -8,6 +8,11 @@ public class Permission implements Parcelable {
     private boolean hasPermission;
     private String nextRetakeTime;
 
+    public Permission(boolean hasPermission, String nextRetakeTime) {
+        this.hasPermission = hasPermission;
+        this.nextRetakeTime = nextRetakeTime;
+    }
+
     protected Permission(Parcel in) {
         hasPermission = in.readByte() != 0;
         nextRetakeTime = in.readString();


### PR DESCRIPTION
- Added constructors to the following models: `AttemptAnswer`, `AttemptItem`, `AttemptQuestion`, `Permission`. These constructors enable the local initialization of objects, which is crucial for offline exam support. Previously, these fields were only used for API responses and implemented with Parcelable.