### PR TITLE
fix: Refresh Exam Content in BaseExamWidgetFragment

### DIFF
--- a/course/src/main/java/in/testpress/course/fragments/ContentLoadingFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/ContentLoadingFragment.kt
@@ -96,7 +96,7 @@ class ContentLoadingFragment : Fragment(),
     private fun isContentLoaded(content: DomainContent): Boolean {
         if(content.isLocked == true) return false
         return when(content.contentType) {
-            "Exam" -> (content.exam != null) && (content.attemptsUrl != null)
+            "Exam" -> (content.exam != null)
             "Video" -> content.video != null && !hasCourseVideoViewsLimit(content)
             "Attachment" -> content.attachment != null
             "Html", "Notes" -> content.htmlContent != null


### PR DESCRIPTION
- Previously, the content was refreshed in `ContentLoadingFragment`, which showed an internet error if the internet was not connected.
- In this commit, the exam detail view is shown even if the internet is not available. Therefore, the content is now refreshed in `BaseExamWidgetFragment` instead of `ContentLoadingFragment`.