### PR TITLE
fix: Set Default Value for isOfflineExam as False

### DIFF
--- a/exam/src/main/java/in/testpress/exam/repository/AttemptRepository.kt
+++ b/exam/src/main/java/in/testpress/exam/repository/AttemptRepository.kt
@@ -28,7 +28,7 @@ class AttemptRepository(val context: Context) {
 
     lateinit var exam : Exam
     lateinit var attempt : Attempt
-    private val isOfflineExam: Boolean get() = exam.isOfflineExam
+    private val isOfflineExam: Boolean get() = exam.isOfflineExam ?: false
     var page = 1
     val attemptItem = mutableListOf<AttemptItem>()
     private var _totalQuestions = 0

--- a/exam/src/main/java/in/testpress/exam/repository/ExamRepository.kt
+++ b/exam/src/main/java/in/testpress/exam/repository/ExamRepository.kt
@@ -30,7 +30,7 @@ import kotlin.collections.HashMap
 class ExamRepository(val context: Context) {
 
     lateinit var exam : Exam
-    private val isOfflineExam: Boolean get() = exam.isOfflineExam
+    private val isOfflineExam: Boolean get() = exam.isOfflineExam ?: false
 
     private val database = TestpressDatabase.invoke(context)
     private val sectionsDao = database.sectionsDao()


### PR DESCRIPTION
In `AttemptRepository` and `ExamRepository`, set the default value of the `isOfflineExam` field to false.