### PR TITLE
 fix: Add missed field for parcelable in `AttemptSection` model

### DIFF
--- a/core/src/main/java/in/testpress/database/mapping/OfflineAttemptSectionMapping.kt
+++ b/core/src/main/java/in/testpress/database/mapping/OfflineAttemptSectionMapping.kt
@@ -2,12 +2,12 @@ package `in`.testpress.database.mapping
 
 import `in`.testpress.database.entities.OfflineAttemptSection
 import `in`.testpress.models.greendao.AttemptSection
-import android.util.Log
 
 fun OfflineAttemptSection?.asGreenDoaModel(): AttemptSection? {
     if (this == null) return null
     val attemptSection = AttemptSection()
     attemptSection.id = this.id
+    attemptSection.attemptSectionId = this.attemptSectionId
     attemptSection.state = this.state
     attemptSection.questionsUrl = null
     attemptSection.startUrl = null

--- a/core/src/main/java/in/testpress/models/greendao/AttemptSection.java
+++ b/core/src/main/java/in/testpress/models/greendao/AttemptSection.java
@@ -163,7 +163,7 @@ public class AttemptSection implements android.os.Parcelable {
         } else {
             id = in.readLong();
         }
-        attemptSectionId = in.readLong();
+        attemptSectionId = in.readByte() == 0 ? null : in.readLong();
         state = in.readString();
         questionsUrl = in.readString();
         startUrl = in.readString();
@@ -192,7 +192,12 @@ public class AttemptSection implements android.os.Parcelable {
             dest.writeByte((byte) 1);
             dest.writeLong(id);
         }
-        dest.writeLong(attemptSectionId);
+        if (attemptSectionId == null) {
+            dest.writeByte((byte) 0);
+        } else {
+            dest.writeByte((byte) 1);
+            dest.writeLong(attemptSectionId);
+        }
         dest.writeString(state);
         dest.writeString(questionsUrl);
         dest.writeString(startUrl);

--- a/core/src/main/java/in/testpress/models/greendao/AttemptSection.java
+++ b/core/src/main/java/in/testpress/models/greendao/AttemptSection.java
@@ -163,6 +163,7 @@ public class AttemptSection implements android.os.Parcelable {
         } else {
             id = in.readLong();
         }
+        attemptSectionId = in.readLong();
         state = in.readString();
         questionsUrl = in.readString();
         startUrl = in.readString();
@@ -191,6 +192,7 @@ public class AttemptSection implements android.os.Parcelable {
             dest.writeByte((byte) 1);
             dest.writeLong(id);
         }
+        dest.writeLong(attemptSectionId);
         dest.writeString(state);
         dest.writeString(questionsUrl);
         dest.writeString(startUrl);


### PR DESCRIPTION
- We are passing the `AttemptSection` model via intent in many places, parcelable is required to pass custom objects via intent.
- In this commit, we are adding missed fields for parcelable in the `AttemptSection` model.
