### PR TITLE
fix: Update Remaining Time and Last Started Time While Updating Answer Locally

### DIFF
--- a/core/src/main/java/in/testpress/database/dao/OfflineAttemptDao.kt
+++ b/core/src/main/java/in/testpress/database/dao/OfflineAttemptDao.kt
@@ -17,4 +17,8 @@ interface OfflineAttemptDao: BaseDao<OfflineAttempt>{
 
     @Query("UPDATE OfflineAttempt SET state = :state WHERE id = :attemptId")
     suspend fun updateAttemptState(attemptId: Long, state: String)
+
+    @Query("UPDATE OfflineAttempt SET remainingTime = :remainingTime, lastStartedTime = :lastStartedTime WHERE id = :attemptId")
+    suspend fun updateRemainingTimeAndLastStartedTime(attemptId: Long, remainingTime: String, lastStartedTime: String)
+
 }

--- a/exam/src/main/java/in/testpress/exam/repository/AttemptRepository.kt
+++ b/exam/src/main/java/in/testpress/exam/repository/AttemptRepository.kt
@@ -23,6 +23,7 @@ import androidx.lifecycle.MutableLiveData
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import java.util.*
 
 class AttemptRepository(val context: Context) {
 
@@ -134,8 +135,9 @@ class AttemptRepository(val context: Context) {
         _attemptItemsResource.postValue(Resource.success(attemptItems))
     }
 
-    suspend fun saveAnswer(position: Int, attemptItem: AttemptItem, action: Action) {
+    suspend fun saveAnswer(position: Int, attemptItem: AttemptItem, action: Action, remainingTime: String) {
         if (isOfflineExam){
+            offlineAttemptDao.updateRemainingTimeAndLastStartedTime(attempt.id, remainingTime, Date().toString())
             updateLocalAttemptItem(attemptItem) { updateAttemptItem ->
                 _saveResultResource.postValue(Resource.success(Triple(position, updateAttemptItem, action)))
             }

--- a/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
@@ -914,7 +914,7 @@ public class TestFragment extends BaseFragment implements
             if (action != Action.UPDATE_ANSWER) {
                 showProgress(R.string.testpress_saving_last_change);
             }
-            attemptViewModel.saveAnswer(position,attemptItem,action);
+            attemptViewModel.saveAnswer(position,attemptItem,action, formatTime(millisRemaining));
         } else if (action.equals(Action.PAUSE)) {
             progressDialog.dismiss();
             returnToHistory();

--- a/exam/src/main/java/in/testpress/exam/ui/viewmodel/AttemptViewModel.kt
+++ b/exam/src/main/java/in/testpress/exam/ui/viewmodel/AttemptViewModel.kt
@@ -39,9 +39,9 @@ class AttemptViewModel(val repository: AttemptRepository) : ViewModel() {
         repository.fetchAttemptItems(questionsUrlFrag, fetchSinglePageOnly)
     }
 
-    fun saveAnswer(position: Int, attemptItem: AttemptItem, action: TestFragment.Action){
+    fun saveAnswer(position: Int, attemptItem: AttemptItem, action: TestFragment.Action, remainingTime: String){
         viewModelScope.launch {
-            repository.saveAnswer(position, attemptItem, action)
+            repository.saveAnswer(position, attemptItem, action, remainingTime)
         }
     }
 


### PR DESCRIPTION
- For offline exams, we need to handle the remaining time and last started time for attempts. In this commit, we are updating the `remainingTime` and `lastStartedDate` whenever the user saves their answers.