### PR TITLE
feat: Add resume offline button in exam detail screen

### DIFF
--- a/core/src/main/java/in/testpress/database/dao/OfflineAttemptDao.kt
+++ b/core/src/main/java/in/testpress/database/dao/OfflineAttemptDao.kt
@@ -21,4 +21,6 @@ interface OfflineAttemptDao: BaseDao<OfflineAttempt>{
     @Query("UPDATE OfflineAttempt SET remainingTime = :remainingTime, lastStartedTime = :lastStartedTime WHERE id = :attemptId")
     suspend fun updateRemainingTimeAndLastStartedTime(attemptId: Long, remainingTime: String, lastStartedTime: String)
 
+    @Query("SELECT * FROM OfflineAttempt WHERE examId = :examId AND state = :state")
+    suspend fun getOfflineAttemptsByExamIdAndState(examId: Long, state: String): List<OfflineAttempt>
 }

--- a/core/src/main/java/in/testpress/database/dao/OfflineAttemptItemDao.kt
+++ b/core/src/main/java/in/testpress/database/dao/OfflineAttemptItemDao.kt
@@ -16,4 +16,7 @@ interface OfflineAttemptItemDao : BaseDao<OfflineAttemptItem> {
 
     @Query("SELECT * FROM OfflineAttemptItem WHERE attemptId = :attemptId")
     suspend fun getOfflineAttemptItemByAttemptId(attemptId: Long): List<OfflineAttemptItem>
+
+    @Query("SELECT COUNT(*) FROM OfflineAttemptItem WHERE attemptId = :attemptId")
+    suspend fun getOfflineAttemptItemCountByAttemptId(attemptId: Long): Int
 }

--- a/core/src/main/java/in/testpress/database/dao/OfflineCourseAttemptDao.kt
+++ b/core/src/main/java/in/testpress/database/dao/OfflineCourseAttemptDao.kt
@@ -8,5 +8,5 @@ import androidx.room.Query
 @Dao
 interface OfflineCourseAttemptDao: BaseDao<OfflineCourseAttempt> {
     @Query("SELECT * FROM OfflineCourseAttempt WHERE assessmentId = :attemptId")
-    fun getById(attemptId: Long): OfflineCourseAttempt?
+    suspend fun getById(attemptId: Long): OfflineCourseAttempt?
 }

--- a/core/src/main/java/in/testpress/database/dao/OfflineExamDao.kt
+++ b/core/src/main/java/in/testpress/database/dao/OfflineExamDao.kt
@@ -29,4 +29,7 @@ interface OfflineExamDao: BaseDao<OfflineExam> {
 
     @Query("UPDATE OfflineExam SET downloadedQuestionCount = downloadedQuestionCount + :count WHERE id = :examId")
     suspend fun updateDownloadedQuestion(examId: Long, count: Long)
+
+    @Query("UPDATE OfflineExam SET pausedAttemptsCount = :pausedAttemptsCount WHERE id = :examId")
+    suspend fun updatePausedAttemptCount(examId: Long, pausedAttemptsCount: Long)
 }

--- a/course/src/main/java/in/testpress/course/fragments/BaseExamWidgetFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/BaseExamWidgetFragment.kt
@@ -375,6 +375,7 @@ open class BaseExamWidgetFragment : Fragment() {
         greenDaoContent?.exam?.refresh()
         val languages = content.exam?.languages
         greenDaoContent?.exam?.languages = languages?.toGreenDaoModels()
+        greenDaoContent?.exam?.isOfflineExam = true
         TestpressExam.startCourseExam(
             requireActivity(), greenDaoContent!!, discardExamDetails, isPartial,
             TestpressSdk.getTestpressSession(requireActivity())!!

--- a/course/src/main/java/in/testpress/course/fragments/BaseExamWidgetFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/BaseExamWidgetFragment.kt
@@ -2,14 +2,11 @@ package `in`.testpress.course.fragments
 
 import `in`.testpress.core.TestpressSdk
 import `in`.testpress.course.R
-import `in`.testpress.course.domain.DomainContent
-import `in`.testpress.course.domain.DomainContentAttempt
+import `in`.testpress.course.domain.*
 import `in`.testpress.exam.domain.DomainExamContent
 import `in`.testpress.exam.domain.DomainLanguage
 import `in`.testpress.exam.domain.ExamTemplateType.IELTS_TEMPLATE
 import `in`.testpress.exam.domain.asGreenDaoModel
-import `in`.testpress.course.domain.getGreenDaoContent
-import `in`.testpress.course.domain.getGreenDaoContentAttempt
 import `in`.testpress.exam.domain.toGreenDaoModels
 import `in`.testpress.enums.Status
 import `in`.testpress.network.Resource
@@ -180,7 +177,7 @@ open class BaseExamWidgetFragment : Fragment() {
             val greenDaoContent = content.getGreenDaoContent(requireContext())
             greenDaoContent?.exam = offlineExam?.asGreenDaoModel()
             greenDaoContent?.exam?.pausedAttemptsCount = 1
-            val a = offlineContentAttempt?.createGreenDoaModel(
+            val pausedCourseAttempt = offlineContentAttempt?.createGreenDoaModel(
                 offlineAttempt!!.createGreenDoaModel(
                     offlineAttemptSectionList!!.asGreenDoaModels()
                 )
@@ -188,7 +185,7 @@ open class BaseExamWidgetFragment : Fragment() {
             TestpressExam.resumeCourseAttempt(
                 requireActivity(),
                 greenDaoContent!!,
-                a,
+                pausedCourseAttempt,
                 false,
                 TestpressSdk.getTestpressSession(requireActivity())!!
             )

--- a/course/src/main/java/in/testpress/course/fragments/BaseExamWidgetFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/BaseExamWidgetFragment.kt
@@ -375,7 +375,6 @@ open class BaseExamWidgetFragment : Fragment() {
         greenDaoContent?.exam?.refresh()
         val languages = content.exam?.languages
         greenDaoContent?.exam?.languages = languages?.toGreenDaoModels()
-        greenDaoContent?.exam?.isOfflineExam = true
         TestpressExam.startCourseExam(
             requireActivity(), greenDaoContent!!, discardExamDetails, isPartial,
             TestpressSdk.getTestpressSession(requireActivity())!!

--- a/course/src/main/java/in/testpress/course/fragments/BaseExamWidgetFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/BaseExamWidgetFragment.kt
@@ -45,6 +45,7 @@ open class BaseExamWidgetFragment : Fragment() {
     lateinit var startButton: Button
     lateinit var downloadExam: Button
     lateinit var startExamOffline: Button
+    lateinit var resumeExamOffline: Button
     protected lateinit var viewModel: ExamContentViewModel
     protected lateinit var content: DomainContent
     protected var contentId: Long = -1
@@ -79,6 +80,7 @@ open class BaseExamWidgetFragment : Fragment() {
         startButton = view.findViewById(R.id.start_exam)
         downloadExam = view.findViewById(R.id.download_exam)
         startExamOffline = view.findViewById(R.id.start_exam_offline)
+        resumeExamOffline = view.findViewById(R.id.resume_exam_offline)
         contentId = requireArguments().getLong(ContentActivity.CONTENT_ID)
 
         viewModel.getContent(contentId).observe(viewLifecycleOwner, Observer {

--- a/course/src/main/java/in/testpress/course/fragments/BaseExamWidgetFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/BaseExamWidgetFragment.kt
@@ -23,7 +23,6 @@ import `in`.testpress.database.entities.OfflineExam
 import `in`.testpress.database.mapping.asGreenDaoModel
 import `in`.testpress.database.mapping.asGreenDoaModels
 import `in`.testpress.database.mapping.createGreenDoaModel
-import `in`.testpress.database.mapping.asGreenDaoModel
 import `in`.testpress.exam.TestpressExam
 import `in`.testpress.exam.api.TestpressExamApiClient
 import `in`.testpress.exam.util.MultiLanguagesUtil

--- a/course/src/main/java/in/testpress/course/fragments/BaseExamWidgetFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/BaseExamWidgetFragment.kt
@@ -148,10 +148,13 @@ open class BaseExamWidgetFragment : Fragment() {
     }
 
     private fun showOfflineExamButtons(){
+        if (!this.isAdded) return
         requireActivity().runOnUiThread {
             if (offlineAttempt == null){
+                resumeExamOffline.isVisible = false
                 startExamOffline.isVisible = true
             } else {
+                startExamOffline.isVisible = false
                 resumeExamOffline.isVisible = true
             }
         }

--- a/course/src/main/java/in/testpress/course/fragments/BaseExamWidgetFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/BaseExamWidgetFragment.kt
@@ -44,6 +44,7 @@ import androidx.lifecycle.ViewModelProvider
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 const val isOfflineExamSupportEnables = false
 
@@ -126,7 +127,9 @@ open class BaseExamWidgetFragment : Fragment() {
                         offlineAttemptSectionList = offlineExamViewModel.getOfflineAttemptSectionList(it.id)
                         offlineContentAttempt = offlineExamViewModel.getOfflineContentAttempts(it.id)
                     }
-                    showOfflineExamButtons()
+                    withContext(Dispatchers.Main) {
+                        showOfflineExamButtons()
+                    }
                 }
             }
         }
@@ -143,16 +146,14 @@ open class BaseExamWidgetFragment : Fragment() {
         }
     }
 
-    private fun showOfflineExamButtons(){
+    private fun showOfflineExamButtons() {
         if (!this.isAdded) return
-        requireActivity().runOnUiThread {
-            if (offlineAttempt == null){
-                resumeExamOffline.isVisible = false
-                startExamOffline.isVisible = true
-            } else {
-                startExamOffline.isVisible = false
-                resumeExamOffline.isVisible = true
-            }
+        if (offlineAttempt == null) {
+            resumeExamOffline.isVisible = false
+            startExamOffline.isVisible = true
+        } else {
+            startExamOffline.isVisible = false
+            resumeExamOffline.isVisible = true
         }
     }
 

--- a/course/src/main/java/in/testpress/course/fragments/BaseExamWidgetFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/BaseExamWidgetFragment.kt
@@ -46,7 +46,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
-const val isOfflineExamSupportEnables = false
+const val isOfflineExamSupportEnables = true
 
 open class BaseExamWidgetFragment : Fragment() {
     lateinit var startButton: Button

--- a/course/src/main/java/in/testpress/course/repository/OfflineExamRepository.kt
+++ b/course/src/main/java/in/testpress/course/repository/OfflineExamRepository.kt
@@ -7,6 +7,9 @@ import `in`.testpress.course.network.NetworkContent
 import `in`.testpress.course.network.NetworkOfflineQuestionResponse
 import `in`.testpress.course.network.asOfflineExam
 import `in`.testpress.database.TestpressDatabase
+import `in`.testpress.database.entities.OfflineAttempt
+import `in`.testpress.database.entities.OfflineAttemptSection
+import `in`.testpress.database.entities.OfflineCourseAttempt
 import `in`.testpress.database.entities.OfflineExam
 import `in`.testpress.exam.network.NetworkExamContent
 import `in`.testpress.exam.network.NetworkLanguage
@@ -36,6 +39,9 @@ class OfflineExamRepository(val context: Context) {
     private val sectionsDao = database.sectionsDao()
     private val examQuestionDao = database.examQuestionDao()
     private val questionDao = database.questionDao()
+    private val offlineAttemptDao = database.offlineAttemptDao()
+    private val offlineCourseAttemptDao = database.offlineCourseAttemptDao()
+    private val offlineAttemptSectionDao = database.offlineAttemptSectionDao()
 
     private val _downloadExamResult = MutableLiveData<Resource<Boolean>>()
     val downloadExamResult: LiveData<Resource<Boolean>> get() = _downloadExamResult
@@ -200,5 +206,17 @@ class OfflineExamRepository(val context: Context) {
                 offlineExamDao.updateSyncRequired(networkExam.id, true)
             }
         }
+    }
+
+    suspend fun getOfflineAttemptsByExamIdAndState(examId: Long, state: String): List<OfflineAttempt> {
+        return offlineAttemptDao.getOfflineAttemptsByExamIdAndState(examId,state)
+    }
+
+    suspend fun getOfflineContentAttempts(attemptId: Long): OfflineCourseAttempt? {
+        return offlineCourseAttemptDao.getById(attemptId)
+    }
+
+    suspend fun getOfflineAttemptSectionList(attemptId: Long): List<OfflineAttemptSection> {
+        return offlineAttemptSectionDao.getByAttemptId(attemptId)
     }
 }

--- a/course/src/main/java/in/testpress/course/viewmodels/OfflineExamViewModel.kt
+++ b/course/src/main/java/in/testpress/course/viewmodels/OfflineExamViewModel.kt
@@ -1,13 +1,13 @@
 package `in`.testpress.course.viewmodels
 
 import `in`.testpress.course.repository.OfflineExamRepository
+import `in`.testpress.database.entities.OfflineAttempt
+import `in`.testpress.database.entities.OfflineAttemptSection
+import `in`.testpress.database.entities.OfflineCourseAttempt
 import `in`.testpress.database.entities.OfflineExam
 import `in`.testpress.network.Resource
 import androidx.fragment.app.FragmentActivity
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.*
 import kotlinx.coroutines.launch
 
 class OfflineExamViewModel(private val repository: OfflineExamRepository) : ViewModel() {
@@ -40,6 +40,18 @@ class OfflineExamViewModel(private val repository: OfflineExamRepository) : View
 
     fun syncExam(offlineExam: OfflineExam) {
         downloadExam(offlineExam.contentId!!)
+    }
+
+    suspend fun getOfflineContentAttempts(attemptId: Long): OfflineCourseAttempt? {
+        return repository.getOfflineContentAttempts(attemptId)
+    }
+
+    suspend fun getOfflineAttemptSectionList(attemptId: Long): List<OfflineAttemptSection> {
+        return repository.getOfflineAttemptSectionList(attemptId)
+    }
+
+    suspend fun getOfflineAttemptsByExamIdAndState(examId: Long, state: String): List<OfflineAttempt> {
+        return repository.getOfflineAttemptsByExamIdAndState(examId, state)
     }
 
     companion object {

--- a/course/src/main/res/layout/attempts_list_view.xml
+++ b/course/src/main/res/layout/attempts_list_view.xml
@@ -63,6 +63,20 @@
             android:textColor="@android:color/white"
             android:textSize="16sp" />
 
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/resume_exam_offline"
+            android:layout_width="match_parent"
+            android:layout_height="37dp"
+            android:layout_marginLeft="20dp"
+            android:layout_marginRight="20dp"
+            android:layout_marginBottom="30dp"
+            android:background="@drawable/testpress_green_curved_edge_background"
+            android:gravity="center"
+            android:visibility="gone"
+            android:text="Resume Exam Offline"
+            android:textColor="@android:color/white"
+            android:textSize="16sp" />
+
     </LinearLayout>
 
 </LinearLayout>

--- a/course/src/main/res/layout/exam_start_screen.xml
+++ b/course/src/main/res/layout/exam_start_screen.xml
@@ -59,6 +59,20 @@
             android:textColor="@android:color/white"
             android:textSize="16sp" />
 
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/resume_exam_offline"
+            android:layout_width="match_parent"
+            android:layout_height="37dp"
+            android:layout_marginLeft="20dp"
+            android:layout_marginRight="20dp"
+            android:layout_marginBottom="30dp"
+            android:background="@drawable/testpress_green_curved_edge_background"
+            android:gravity="center"
+            android:visibility="gone"
+            android:text="Resume Exam Offline"
+            android:textColor="@android:color/white"
+            android:textSize="16sp" />
+
     </LinearLayout>
 
 </LinearLayout>

--- a/course/src/main/res/layout/quiz_start_screen.xml
+++ b/course/src/main/res/layout/quiz_start_screen.xml
@@ -63,5 +63,19 @@
             android:textColor="@android:color/white"
             android:textSize="16sp" />
 
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/resume_exam_offline"
+            android:layout_width="match_parent"
+            android:layout_height="37dp"
+            android:layout_marginLeft="20dp"
+            android:layout_marginRight="20dp"
+            android:layout_marginBottom="30dp"
+            android:background="@drawable/testpress_green_curved_edge_background"
+            android:gravity="center"
+            android:visibility="gone"
+            android:text="Resume Exam Offline"
+            android:textColor="@android:color/white"
+            android:textSize="16sp" />
+
     </LinearLayout>
 </LinearLayout>

--- a/exam/src/main/java/in/testpress/exam/repository/AttemptRepository.kt
+++ b/exam/src/main/java/in/testpress/exam/repository/AttemptRepository.kt
@@ -10,6 +10,7 @@ import `in`.testpress.database.mapping.createGreenDoaModel
 import `in`.testpress.exam.api.TestpressExamApiClient
 import `in`.testpress.exam.models.AttemptItem
 import `in`.testpress.exam.network.NetworkAttemptSection
+import `in`.testpress.exam.network.asNetworkModel
 import `in`.testpress.exam.ui.TestFragment.Action
 import `in`.testpress.exam.util.asAttemptItem
 import `in`.testpress.models.TestpressApiResponse

--- a/exam/src/main/java/in/testpress/exam/repository/AttemptRepository.kt
+++ b/exam/src/main/java/in/testpress/exam/repository/AttemptRepository.kt
@@ -4,12 +4,12 @@ import `in`.testpress.core.TestpressCallback
 import `in`.testpress.core.TestpressException
 import `in`.testpress.database.TestpressDatabase
 import `in`.testpress.database.entities.OfflineAttemptItem
+import `in`.testpress.database.entities.OfflineCourseAttempt
 import `in`.testpress.database.mapping.asGreenDoaModels
 import `in`.testpress.database.mapping.createGreenDoaModel
 import `in`.testpress.exam.api.TestpressExamApiClient
 import `in`.testpress.exam.models.AttemptItem
 import `in`.testpress.exam.network.NetworkAttemptSection
-import `in`.testpress.exam.network.asNetworkModel
 import `in`.testpress.exam.ui.TestFragment.Action
 import `in`.testpress.exam.util.asAttemptItem
 import `in`.testpress.models.TestpressApiResponse

--- a/exam/src/main/java/in/testpress/exam/ui/TestActivity.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestActivity.java
@@ -329,7 +329,6 @@ public class TestActivity extends BaseToolBarActivity  {
         if (courseContent != null) {
             if (exam == null) {
                 exam = courseContent.getRawExam();
-                exam.setIsOfflineExam(true);
                 examViewModel.setExam(exam);
             }
             if (courseAttempt == null && permission == null) {
@@ -341,7 +340,6 @@ public class TestActivity extends BaseToolBarActivity  {
                 checkStartExamScreenState();
             }
         } else if (exam != null) {
-            exam.setIsOfflineExam(true);
             examViewModel.setExam(exam);
             checkStartExamScreenState();
         } else {

--- a/exam/src/main/java/in/testpress/exam/ui/TestActivity.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestActivity.java
@@ -329,6 +329,7 @@ public class TestActivity extends BaseToolBarActivity  {
         if (courseContent != null) {
             if (exam == null) {
                 exam = courseContent.getRawExam();
+                exam.setIsOfflineExam(true);
                 examViewModel.setExam(exam);
             }
             if (courseAttempt == null && permission == null) {
@@ -340,6 +341,7 @@ public class TestActivity extends BaseToolBarActivity  {
                 checkStartExamScreenState();
             }
         } else if (exam != null) {
+            exam.setIsOfflineExam(true);
             examViewModel.setExam(exam);
             checkStartExamScreenState();
         } else {

--- a/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
@@ -916,6 +916,9 @@ public class TestFragment extends BaseFragment implements
             }
             attemptViewModel.saveAnswer(position,attemptItem,action, formatTime(millisRemaining));
         } else if (action.equals(Action.PAUSE)) {
+            if (exam.getIsOfflineExam()){
+                attemptViewModel.saveAnswer(position,attemptItem,action, formatTime(millisRemaining));
+            }
             progressDialog.dismiss();
             returnToHistory();
         }


### PR DESCRIPTION
- Added a Resume Offline Exam button that allows users to resume paused offline attempts.
- Users must complete the resumed attempt before starting a new attempt for the same exam.