### PR TITLE
refactor: Exam Start Button Naming

### DIFF
--- a/course/src/main/java/in/testpress/course/fragments/BaseExamWidgetFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/BaseExamWidgetFragment.kt
@@ -274,13 +274,13 @@ open class BaseExamWidgetFragment : Fragment() {
     private fun updateStartButtonTextAndVisibility(exam: DomainExamContent, pausedAttempt: DomainContentAttempt?) {
         if (pausedAttempt == null && content.canAttemptExam()) {
             if (contentAttempts.isEmpty()) {
-                startButton.text = getString(R.string.testpress_start)
+                startButton.text = if(isOfflineExamSupportEnables) getString(R.string.testpress_start_exam_online) else getString(R.string.testpress_start)
             } else {
-                startButton.text = getString(R.string.testpress_retake)
+                startButton.text = if(isOfflineExamSupportEnables) getString(R.string.testpress_retake_exam_online) else getString(R.string.testpress_retake)
             }
             startButton.visibility = View.VISIBLE
         } else if (pausedAttempt != null && !exam.isWebOnly()) {
-            startButton.text = getString(R.string.testpress_resume)
+            startButton.text = if(isOfflineExamSupportEnables) getString(R.string.testpress_resume_exam_online) else getString(R.string.testpress_resume)
             startButton.visibility = View.VISIBLE
         } else {
             startButton.visibility = View.GONE
@@ -295,14 +295,14 @@ open class BaseExamWidgetFragment : Fragment() {
 
         if (pausedAttempt == null && content.canAttemptExam()) {
             if (contentAttempts.isEmpty()) {
-                startButton.text = getString(R.string.testpress_start)
+                startButton.text = if(isOfflineExamSupportEnables) getString(R.string.testpress_start_exam_online) else getString(R.string.testpress_start)
             } else {
-                startButton.text = getString(R.string.testpress_retake)
+                startButton.text = if(isOfflineExamSupportEnables) getString(R.string.testpress_retake_exam_online) else getString(R.string.testpress_retake)
             }
             initStartForFreshExam(exam)
             startButton.visibility = View.VISIBLE
         } else if (pausedAttempt != null && !exam.isWebOnly()) {
-            startButton.text = getString(R.string.testpress_resume)
+            startButton.text = if(isOfflineExamSupportEnables) getString(R.string.testpress_resume_exam_online) else getString(R.string.testpress_resume)
             initStartForResumeExam(exam, pausedAttempt)
             startButton.visibility = View.VISIBLE
         } else {

--- a/course/src/main/res/values/strings.xml
+++ b/course/src/main/res/values/strings.xml
@@ -31,6 +31,7 @@
     <string name="testpress_previous_content">Previous</string>
     <string name="testpress_next_content">Next</string>
 
+    <string name="testpress_start_exam_online">Start Exam Online</string>
     <string name="testpress_start">Start</string>
     <string name="testpress_download_attachment">Download Attachment</string>
 

--- a/exam/src/main/res/values/strings.xml
+++ b/exam/src/main/res/values/strings.xml
@@ -60,7 +60,9 @@
     <string name="testpress_page_review">Marked for Review</string>
 
     <string name="testpress_pause">PAUSE</string>
+    <string name="testpress_resume_exam_online">RESUME EXAM ONLINE</string>
     <string name="testpress_resume">RESUME</string>
+    <string name="testpress_retake_exam_online">RETAKE EXAM ONLINE</string>
     <string name="testpress_retake">RETAKE</string>
     <string name="testpress_review">REVIEW</string>
     <string name="testpress_retake_exam">Retake Exam</string>


### PR DESCRIPTION
- Updated the names of the exam start buttons for better clarity.
- Changed the existing button name to `Start Exam Online`.
- Added a new button named `Start Exam Offline` to support the offline exam functionality recently added to the exam detail view.