### PR TITLE
fix: Show Exam start button and Download Button in same time

### DIFF
--- a/course/src/main/java/in/testpress/course/fragments/AttemptsListFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/AttemptsListFragment.kt
@@ -30,6 +30,7 @@ open class AttemptsListFragment : BaseExamWidgetFragment() {
     }
 
     override fun display() {
+        initializeObserversForOfflineDownload()
         val greenDaoContent = content.getGreenDaoContent(requireContext())
         val attempts = content.getGreenDaoContentAttempts(requireContext())
         attemptList.isNestedScrollingEnabled = false

--- a/course/src/main/java/in/testpress/course/fragments/BaseExamWidgetFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/BaseExamWidgetFragment.kt
@@ -103,7 +103,6 @@ open class BaseExamWidgetFragment : Fragment() {
                     } else {
                         display()
                         loadAttemptsAndUpdateStartButton()
-                        initializeObserversForOfflineDownload()
                     }
                 }
                 else -> {}
@@ -112,7 +111,7 @@ open class BaseExamWidgetFragment : Fragment() {
         addOnClickListeners()
     }
 
-    private fun initializeObserversForOfflineDownload() {
+    protected fun initializeObserversForOfflineDownload() {
         offlineExamViewModel.get(contentId).observe(requireActivity()) { offlineExam ->
             this.offlineExam = offlineExam
             if (offlineExam == null) {
@@ -214,7 +213,6 @@ open class BaseExamWidgetFragment : Fragment() {
                     }
                     else -> {}
                 }
-                initializeObserversForOfflineDownload()
             })
     }
 
@@ -226,6 +224,7 @@ open class BaseExamWidgetFragment : Fragment() {
                     var exam = content.exam!!
                     exam.languages = resource.data!!
                     content.exam = exam
+                    display()
                     updateStartButton(contentAttempts)
                 }
                 else -> {
@@ -244,7 +243,6 @@ open class BaseExamWidgetFragment : Fragment() {
                 when (resource.status) {
                     Status.SUCCESS -> {
                         contentAttempts = resource.data!!
-                        display()
                         val exam = content.exam!!
                         examRefreshListener.showOrHideRefresh(true)
                         viewModel.getLanguages(exam.slug!!, exam.id)

--- a/course/src/main/java/in/testpress/course/fragments/ExamStartScreenFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/ExamStartScreenFragment.kt
@@ -93,6 +93,7 @@ class ExamStartScreenFragment : BaseExamWidgetFragment() {
     }
 
     override fun display() {
+        initializeObserversForOfflineDownload()
         val exam = content.exam!!
         markPerQuestion.text = exam.markPerQuestion
         negativeMarks.text = exam.negativeMarks


### PR DESCRIPTION
- Previously, the view was displayed before the language was fully fetched. In this commit, we ensured the view is displayed only after the language fetch is complete.