### PR TITLE
fix: Not able to end Offline Exam from TestActivity

### DIFF
--- a/exam/src/main/java/in/testpress/exam/ui/TestActivity.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestActivity.java
@@ -14,6 +14,7 @@ import android.widget.Button;
 import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -297,6 +298,7 @@ public class TestActivity extends BaseToolBarActivity  {
         this.courseAttempt = courseAttempt;
         if (isOfflineExamComplete(courseAttempt.getRawAssessment())){
             this.finish();
+            Toast.makeText(this,"Please connect to the internet to view your results.",Toast.LENGTH_SHORT).show();
             return;
         }
         saveCourseAttemptInDB(courseAttempt, true);
@@ -310,6 +312,7 @@ public class TestActivity extends BaseToolBarActivity  {
     private void handleSuccessAttempt(Attempt attempt) {
         if (isOfflineExamComplete(attempt)){
             this.finish();
+            Toast.makeText(this,"Please connect to the internet to view your results.",Toast.LENGTH_SHORT).show();
             return;
         }
         if (attempt.getState().equals("Running")) {

--- a/exam/src/main/java/in/testpress/exam/ui/TestActivity.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestActivity.java
@@ -295,6 +295,10 @@ public class TestActivity extends BaseToolBarActivity  {
 
     private void handleCourseAttemptSuccess(CourseAttempt courseAttempt) {
         this.courseAttempt = courseAttempt;
+        if (isOfflineExamComplete(courseAttempt.getRawAssessment())){
+            this.finish();
+            return;
+        }
         saveCourseAttemptInDB(courseAttempt, true);
         Attempt attempt = courseAttempt.getRawAssessment();
         if (attempt.getState().equals("Running") && attempt.getRemainingTime().equals("0:00:00")) {
@@ -304,6 +308,10 @@ public class TestActivity extends BaseToolBarActivity  {
     }
 
     private void handleSuccessAttempt(Attempt attempt) {
+        if (isOfflineExamComplete(attempt)){
+            this.finish();
+            return;
+        }
         if (attempt.getState().equals("Running")) {
             Bundle bundle = new Bundle();
             bundle.putParcelable(TestFragment.PARAM_ATTEMPT, attempt);
@@ -581,9 +589,9 @@ public class TestActivity extends BaseToolBarActivity  {
     private void endExam() {
         progressBar.setVisibility(View.VISIBLE);
         if (courseContent != null){
-            examViewModel.endContentAttempt(courseAttempt.getEndAttemptUrl());
+            examViewModel.endContentAttempt(attempt.getId(), courseAttempt.getEndAttemptUrl());
         } else {
-            examViewModel.endAttempt(attempt.getEndUrlFrag());
+            examViewModel.endAttempt(attempt.getId(), attempt.getEndUrlFrag());
         }
     }
 
@@ -659,7 +667,7 @@ public class TestActivity extends BaseToolBarActivity  {
         if (isPartialQuestions) {
             data.put(IS_PARTIAL, true);
         }
-        String attemptsUrl = exam.getIsOfflineExam() ? "" : courseContent.getAttemptsUrl().replace("v2.3", "v2.2.1");
+        String attemptsUrl = isOfflineExam() ? "" : courseContent.getAttemptsUrl().replace("v2.3", "v2.2.1");
         examViewModel.createContentAttempt(attemptsUrl, data);
     }
 
@@ -738,6 +746,14 @@ public class TestActivity extends BaseToolBarActivity  {
         return new RetrofitCall[] {
                 examApiRequest, languagesApiRequest, attemptsApiRequest, permissionsApiRequest
         };
+    }
+
+    boolean isOfflineExamComplete(Attempt attempt) {
+        return isOfflineExam() && attempt.getState().equals(Attempt.COMPLETED);
+    }
+
+    boolean isOfflineExam() {
+        return Boolean.TRUE.equals(exam.getIsOfflineExam());
     }
 
 }

--- a/exam/src/main/java/in/testpress/exam/ui/viewmodel/ExamViewModel.kt
+++ b/exam/src/main/java/in/testpress/exam/ui/viewmodel/ExamViewModel.kt
@@ -39,12 +39,12 @@ class ExamViewModel(val repository: ExamRepository) : ViewModel() {
         repository.startAttempt(attemptStartFrag)
     }
 
-    fun endContentAttempt(attemptEndFrag: String) {
-        repository.endContentAttempt(attemptEndFrag)
+    fun endContentAttempt(attemptId: Long, attemptEndFrag: String) {
+        repository.endContentAttempt(attemptId, attemptEndFrag)
     }
 
-    fun endAttempt(attemptEndFrag: String) {
-        repository.endAttempt(attemptEndFrag)
+    fun endAttempt(attemptId: Long, attemptEndFrag: String) {
+        repository.endAttempt(attemptId, attemptEndFrag)
     }
 
     fun fetchLanguages(examSlug: String) {


### PR DESCRIPTION
- Added option to handle ending offline exams from the exam start screen.
- Previously, the internet was required to perform this action.