### PR TITLE
fix: Not able to end Exam if the section time is not given

### DIFF
--- a/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
@@ -626,7 +626,7 @@ public class TestFragment extends BaseFragment implements
                             .setTitle(R.string.testpress_end_title)
                             .setMessage(R.string.testpress_end_message);
 
-            if (exam.isPreemptiveSectionEndingEnabled() || sections.size() < 2) {
+            if (exam.isPreemptiveSectionEndingEnabled() ||(attempt.hasNoSectionalLock() || sections.size() < 2)) {
                 dialogBuilder
                         .setPositiveButton(R.string.testpress_end, new DialogInterface.OnClickListener() {
                             @Override


### PR DESCRIPTION
- In this commit 44ed6a7, we added validation for Preemptive Section Ending while ending the exam.
- However, Preemptive Section Ending only works when all sections have a time limit, causing issues with ending exams for sections without a time limit.
- Therefore, we check if the exam has a section lock before showing the exam end dialog box.