### PR TITLE
 fix: Lagging between switching questions on the offline exam

### DIFF
--- a/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
@@ -736,7 +736,6 @@ public class TestFragment extends BaseFragment implements
                             if (viewPager != null) {
                                 currentQuestion = viewPager.getCurrentItem();
                             }
-                            updatePanel();
                         } else {
                             questionsListView.setAdapter(questionsListAdapter);
                             startCountDownTimer();
@@ -975,7 +974,6 @@ public class TestFragment extends BaseFragment implements
                 startCountDownTimer(millisRemaining);
                 progressDialog.dismiss();
             }
-            updatePanel();
         }
     }
 


### PR DESCRIPTION
- Previously, while saving answers, we were updating the questionList, which was unnecessary.
- Additionally, we were updating the questionList after fetching all user-selected answers, which was also unnecessary.
- Due to these updates, lagging occurred while switching questions.
- In this commit, we have removed the unnecessary questionList updating part to resolve the lagging issue.
