### PR TITLE
fix: Delete Offline Attempts when deleting the exam

### DIFF
--- a/core/src/main/java/in/testpress/database/dao/OfflineAttemptDao.kt
+++ b/core/src/main/java/in/testpress/database/dao/OfflineAttemptDao.kt
@@ -29,4 +29,7 @@ interface OfflineAttemptDao: BaseDao<OfflineAttempt>{
 
     @Query("DELETE FROM OfflineAttempt WHERE id = :attemptId")
     suspend fun deleteByAttemptId(attemptId: Long)
+
+    @Query("SELECT id FROM OfflineAttempt WHERE examId = :examId")
+    suspend fun getAttemptIdsByExamId(examId: Long): List<Long>
 }

--- a/course/src/main/java/in/testpress/course/repository/OfflineExamRepository.kt
+++ b/course/src/main/java/in/testpress/course/repository/OfflineExamRepository.kt
@@ -158,6 +158,13 @@ class OfflineExamRepository(val context: Context) {
     suspend fun deleteOfflineExam(examId: Long) {
         offlineExamDao.deleteById(examId)
         examQuestionDao.deleteByExamId(examId)
+        val attemptIds = offlineAttemptDao.getAttemptIdsByExamId(examId)
+        attemptIds.forEach { attemptId ->
+            offlineAttemptDao.deleteByAttemptId(attemptId)
+            offlineAttemptSectionDao.deleteByAttemptId(attemptId)
+            offlineAttemptItemDao.deleteByAttemptId(attemptId)
+            offlineCourseAttemptDao.deleteByAttemptId(attemptId)
+        }
         // Here we are deleting exam and exam question only
         // Deleting Question, Direction, Section, Subject need to handle
     }


### PR DESCRIPTION
- Previously, when deleting an offline exam, only the exam itself was deleted.
- In this commit, we added the option to delete all running and completed attempts related to the exam.