### PR TITLE
fix: Download Exam button showing before Start Exam Online button

### DIFF
--- a/course/src/main/java/in/testpress/course/fragments/BaseExamWidgetFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/BaseExamWidgetFragment.kt
@@ -101,7 +101,6 @@ open class BaseExamWidgetFragment : Fragment() {
                     if (!isContentLoaded(it.data!!)) {
                         refetchContent(it.data!!.id)
                     } else {
-                        display()
                         loadAttemptsAndUpdateStartButton()
                     }
                 }

--- a/course/src/main/java/in/testpress/course/fragments/BaseExamWidgetFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/BaseExamWidgetFragment.kt
@@ -138,6 +138,7 @@ open class BaseExamWidgetFragment : Fragment() {
                 Status.SUCCESS -> {}
                 Status.LOADING -> {}
                 Status.ERROR -> {
+                    downloadExam.text = "Download Exam"
                     Toast.makeText(requireContext(),"Please check your internet connection",Toast.LENGTH_SHORT).show()
                 }
                 else -> {}
@@ -248,7 +249,9 @@ open class BaseExamWidgetFragment : Fragment() {
                         viewModel.getLanguages(exam.slug!!, exam.id)
                             .observe(viewLifecycleOwner, observer)
                     }
-                    else -> {}
+                    else -> {
+                        display()
+                    }
                 }
             })
     }

--- a/course/src/main/java/in/testpress/course/fragments/BaseExamWidgetFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/BaseExamWidgetFragment.kt
@@ -161,6 +161,7 @@ open class BaseExamWidgetFragment : Fragment() {
             if (downloadExam.text.toString() == "Downloading...") {
                 Toast.makeText(requireContext(),"Please Wait downloading exam",Toast.LENGTH_SHORT).show()
             } else {
+                downloadExam.text = "Downloading..."
                 offlineExamViewModel.downloadExam(contentId)
             }
         }


### PR DESCRIPTION
- When reloading the content, the download button was showing before the Start Exam Online button.
- In this commit, we ensured that both buttons appear in the UI at the same time.
