### PR TITLE
fix: Show Live Not Started Notice Message

### DIFF
--- a/course/src/main/java/in/testpress/course/fragments/LiveStreamFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/LiveStreamFragment.kt
@@ -36,7 +36,13 @@ class LiveStreamFragment : BaseContentDetailFragment() {
 
     override fun display() {
         when (content.liveStream?.status) {
-            "Running" -> displayPlayerViewWithChat()
+            "Running" -> {
+                if (content.liveStream?.streamUrl.isNullOrEmpty()) {
+                    displayNotStartedNotice()
+                } else {
+                    displayPlayerViewWithChat()
+                }
+            }
             "Not Started" -> displayNotStartedNotice()
             "Completed" -> displayEndedNotice()
         }


### PR DESCRIPTION
In this commit, we validate the live stream URL. If the URL is null or empty, we show the live Not Started notice message.