### PR TITLE
fix: Update Answers After Completing the Offline Exam

### DIFF
--- a/course/src/main/java/in/testpress/course/fragments/BaseExamWidgetFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/BaseExamWidgetFragment.kt
@@ -99,7 +99,6 @@ open class BaseExamWidgetFragment : Fragment() {
             when (it?.status) {
                 Status.SUCCESS -> {
                     content = it.data!!
-                    offlineExamViewModel.syncCompletedAttempt(content.examId!!)
                     if (!isContentLoaded(it.data!!)) {
                         refetchContent(it.data!!.id)
                     } else {
@@ -143,11 +142,16 @@ open class BaseExamWidgetFragment : Fragment() {
                 else -> {}
             }
         }
+        offlineExamViewModel.syncCompletedAttempt(content.examId!!)
         offlineExamViewModel.syncCompletedAttempt.observe(requireActivity()) { it ->
             when (it.status){
-                Status.SUCCESS -> {}
+                Status.SUCCESS -> {
+                    if (!this.isAdded) return@observe
+                    Toast.makeText(requireContext(),"Answers submitted successfully. Results will be available shortly.",Toast.LENGTH_SHORT).show()
+                }
                 Status.LOADING -> {}
                 Status.ERROR -> {
+                    if (!this.isAdded) return@observe
                     Toast.makeText(requireContext(),"Please connect to the internet to view your results.",Toast.LENGTH_SHORT).show()
                 }
                 else -> {}

--- a/course/src/main/java/in/testpress/course/fragments/BaseExamWidgetFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/BaseExamWidgetFragment.kt
@@ -99,6 +99,7 @@ open class BaseExamWidgetFragment : Fragment() {
             when (it?.status) {
                 Status.SUCCESS -> {
                     content = it.data!!
+                    offlineExamViewModel.syncCompletedAttempt(content.examId!!)
                     if (!isContentLoaded(it.data!!)) {
                         refetchContent(it.data!!.id)
                     } else {
@@ -138,6 +139,16 @@ open class BaseExamWidgetFragment : Fragment() {
                 Status.ERROR -> {
                     downloadExam.text = "Download Exam"
                     Toast.makeText(requireContext(),"Please check your internet connection",Toast.LENGTH_SHORT).show()
+                }
+                else -> {}
+            }
+        }
+        offlineExamViewModel.syncCompletedAttempt.observe(requireActivity()) { it ->
+            when (it.status){
+                Status.SUCCESS -> {}
+                Status.LOADING -> {}
+                Status.ERROR -> {
+                    Toast.makeText(requireContext(),"Please connect to the internet to view your results.",Toast.LENGTH_SHORT).show()
                 }
                 else -> {}
             }

--- a/course/src/main/java/in/testpress/course/fragments/BaseExamWidgetFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/BaseExamWidgetFragment.kt
@@ -143,7 +143,7 @@ open class BaseExamWidgetFragment : Fragment() {
             }
         }
         offlineExamViewModel.syncCompletedAttempt(content.examId!!)
-        offlineExamViewModel.syncCompletedAttempt.observe(requireActivity()) { it ->
+        offlineExamViewModel.offlineAttemptSyncResult.observe(requireActivity()) { it ->
             when (it.status){
                 Status.SUCCESS -> {
                     if (!this.isAdded) return@observe

--- a/course/src/main/java/in/testpress/course/repository/OfflineExamRepository.kt
+++ b/course/src/main/java/in/testpress/course/repository/OfflineExamRepository.kt
@@ -266,6 +266,7 @@ class OfflineExamRepository(val context: Context) {
     }
 
     private suspend fun updateCompletedAttempts(completedOfflineAttempts: List<OfflineAttempt>){
+        if(completedOfflineAttempts.isEmpty()) return
         val totalAttempts = completedOfflineAttempts.size
         var currentAttemptSize = 0
         completedOfflineAttempts.forEach { completedOfflineAttempt ->

--- a/course/src/main/java/in/testpress/course/repository/OfflineExamRepository.kt
+++ b/course/src/main/java/in/testpress/course/repository/OfflineExamRepository.kt
@@ -267,6 +267,7 @@ class OfflineExamRepository(val context: Context) {
 
     private suspend fun updateCompletedAttempts(completedOfflineAttempts: List<OfflineAttempt>){
         if(completedOfflineAttempts.isEmpty()) return
+        Log.d("TAG", "updateCompletedAttempts: ${completedOfflineAttempts.size}")
         val totalAttempts = completedOfflineAttempts.size
         var currentAttemptSize = 0
         completedOfflineAttempts.forEach { completedOfflineAttempt ->

--- a/course/src/main/java/in/testpress/course/repository/OfflineExamRepository.kt
+++ b/course/src/main/java/in/testpress/course/repository/OfflineExamRepository.kt
@@ -267,7 +267,6 @@ class OfflineExamRepository(val context: Context) {
 
     private suspend fun updateCompletedAttempts(completedOfflineAttempts: List<OfflineAttempt>){
         if(completedOfflineAttempts.isEmpty()) return
-        Log.d("TAG", "updateCompletedAttempts: ${completedOfflineAttempts.size}")
         val totalAttempts = completedOfflineAttempts.size
         var currentAttemptSize = 0
         completedOfflineAttempts.forEach { completedOfflineAttempt ->

--- a/course/src/main/java/in/testpress/course/repository/OfflineExamRepository.kt
+++ b/course/src/main/java/in/testpress/course/repository/OfflineExamRepository.kt
@@ -59,8 +59,8 @@ class OfflineExamRepository(val context: Context) {
     private val _downloadExamResult = MutableLiveData<Resource<Boolean>>()
     val downloadExamResult: LiveData<Resource<Boolean>> get() = _downloadExamResult
 
-    private val _syncCompletedAttempt = MutableLiveData<Resource<Boolean>>()
-    val syncCompletedAttempt: LiveData<Resource<Boolean>> get() = _syncCompletedAttempt
+    private val _offlineAttemptSyncResult = MutableLiveData<Resource<Boolean>>()
+    val offlineAttemptSyncResult: LiveData<Resource<Boolean>> get() = _offlineAttemptSyncResult
 
     fun downloadExam(contentId: Long) {
         _downloadExamResult.postValue(Resource.loading(null))
@@ -305,7 +305,7 @@ class OfflineExamRepository(val context: Context) {
                         deleteSyncedAttempt(completedOfflineAttempt.id)
                         currentAttemptSize++
                         if (totalAttempts == currentAttemptSize){
-                            _syncCompletedAttempt.postValue(Resource.success(true))
+                            _offlineAttemptSyncResult.postValue(Resource.success(true))
                         }
                     }
                 }
@@ -314,7 +314,7 @@ class OfflineExamRepository(val context: Context) {
                     Log.e("OfflineExamRepository", "Failed to update offline answers", exception)
                     currentAttemptSize++
                     if (totalAttempts == currentAttemptSize){
-                        _syncCompletedAttempt.postValue(Resource.error(exception, null))
+                        _offlineAttemptSyncResult.postValue(Resource.error(exception, null))
                     }
                 }
             })

--- a/course/src/main/java/in/testpress/course/ui/OfflineExamListActivity.kt
+++ b/course/src/main/java/in/testpress/course/ui/OfflineExamListActivity.kt
@@ -15,6 +15,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
 import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.*
@@ -43,6 +44,7 @@ class OfflineExamListActivity : BaseToolBarActivity() {
         initializeProgressDialog()
         syncExamsModifiedDates()
         syncCompletedAttempts()
+        observeOfflineAttemptSyncResult()
     }
 
     private fun initializeViewModel() {
@@ -103,6 +105,29 @@ class OfflineExamListActivity : BaseToolBarActivity() {
 
     private fun syncCompletedAttempts() {
         offlineExamViewModel.syncCompletedAllAttemptToBackEnd()
+    }
+
+    private fun observeOfflineAttemptSyncResult() {
+        offlineExamViewModel.offlineAttemptSyncResult.observe(this) { it ->
+            when (it.status) {
+                Status.SUCCESS -> {
+                    Toast.makeText(
+                        this,
+                        "Answers submitted successfully. To review the results, please visit the exam page within the course.",
+                        Toast.LENGTH_SHORT
+                    ).show()
+                }
+                Status.LOADING -> {}
+                Status.ERROR -> {
+                    Toast.makeText(
+                        this,
+                        "Please connect to the internet to submit your answers.",
+                        Toast.LENGTH_SHORT
+                    ).show()
+                }
+                else -> {}
+            }
+        }
     }
 
     private fun resumeExam(exam: OfflineExam) {

--- a/course/src/main/java/in/testpress/course/ui/OfflineExamListActivity.kt
+++ b/course/src/main/java/in/testpress/course/ui/OfflineExamListActivity.kt
@@ -102,7 +102,7 @@ class OfflineExamListActivity : BaseToolBarActivity() {
     }
 
     private fun syncCompletedAttempts() {
-        offlineExamViewModel.syncCompletedAttemptToBackEnd()
+        offlineExamViewModel.syncCompletedAllAttemptToBackEnd()
     }
 
     private fun resumeExam(exam: OfflineExam) {

--- a/course/src/main/java/in/testpress/course/ui/OfflineExamListActivity.kt
+++ b/course/src/main/java/in/testpress/course/ui/OfflineExamListActivity.kt
@@ -43,8 +43,12 @@ class OfflineExamListActivity : BaseToolBarActivity() {
         initializeListView()
         initializeProgressDialog()
         syncExamsModifiedDates()
-        syncCompletedAttempts()
         observeOfflineAttemptSyncResult()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        syncCompletedAttempts()
     }
 
     private fun initializeViewModel() {

--- a/course/src/main/java/in/testpress/course/viewmodels/OfflineExamViewModel.kt
+++ b/course/src/main/java/in/testpress/course/viewmodels/OfflineExamViewModel.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.launch
 class OfflineExamViewModel(private val repository: OfflineExamRepository) : ViewModel() {
 
     val downloadExamResult: LiveData<Resource<Boolean>> get() = repository.downloadExamResult
+    val syncCompletedAttempt: LiveData<Resource<Boolean>> get() = repository.syncCompletedAttempt
 
     fun downloadExam(courseId: Long) {
         repository.downloadExam(courseId)
@@ -56,9 +57,15 @@ class OfflineExamViewModel(private val repository: OfflineExamRepository) : View
         return repository.getOfflineAttemptsByExamIdAndState(examId, state)
     }
 
-    fun syncCompletedAttemptToBackEnd(){
+    fun syncCompletedAllAttemptToBackEnd(){
         viewModelScope.launch {
-            repository.syncCompletedAttemptToBackEnd()
+            repository.syncCompletedAllAttemptToBackEnd()
+        }
+    }
+
+    fun syncCompletedAttempt(examId: Long){
+        viewModelScope.launch {
+            repository.syncCompletedAttempt(examId)
         }
     }
 

--- a/course/src/main/java/in/testpress/course/viewmodels/OfflineExamViewModel.kt
+++ b/course/src/main/java/in/testpress/course/viewmodels/OfflineExamViewModel.kt
@@ -15,7 +15,7 @@ import kotlinx.coroutines.launch
 class OfflineExamViewModel(private val repository: OfflineExamRepository) : ViewModel() {
 
     val downloadExamResult: LiveData<Resource<Boolean>> get() = repository.downloadExamResult
-    val syncCompletedAttempt: LiveData<Resource<Boolean>> get() = repository.syncCompletedAttempt
+    val offlineAttemptSyncResult: LiveData<Resource<Boolean>> get() = repository.offlineAttemptSyncResult
 
     fun downloadExam(courseId: Long) {
         repository.downloadExam(courseId)

--- a/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
@@ -1165,7 +1165,6 @@ public class TestFragment extends BaseFragment implements
                             progressDialog.dismiss();
                         }
                         if (isOfflineExam()){
-                            Toast.makeText(requireActivity(),"Please connect to the internet to view your results.",Toast.LENGTH_SHORT).show();
                             returnToHistory();
                             return;
                         }
@@ -1209,7 +1208,6 @@ public class TestFragment extends BaseFragment implements
                             progressDialog.dismiss();
                         }
                         if (isOfflineExam()){
-                            Toast.makeText(requireActivity(),"Please connect to the internet to view your results.",Toast.LENGTH_SHORT).show();
                             returnToHistory();
                             return;
                         }

--- a/samples/src/main/java/in/testpress/samples/core/TestpressCoreSampleActivity.java
+++ b/samples/src/main/java/in/testpress/samples/core/TestpressCoreSampleActivity.java
@@ -119,8 +119,8 @@ public class TestpressCoreSampleActivity extends BaseToolBarActivity {
     }
 
     private void authenticate(String userId, String accessToken, TestpressSdk.Provider provider) {
-        InstituteSettings instituteSettings = new InstituteSettings("https://lmsdemo.testpress.in");
-        instituteSettings.setWhiteLabeledHostUrl("https://lmsdemo.testpress.in");
+        InstituteSettings instituteSettings = new InstituteSettings("https://sandbox.testpress.in");
+        instituteSettings.setWhiteLabeledHostUrl("https://sandbox.testpress.in");
         instituteSettings.setAndroidSentryDns("https://186f9948d5294b4c9c03aa9d2a11c982@sentry.testpress.in/3");
         instituteSettings.setEnableOfflineExam(true);
         TestpressSdk.initialize(this, instituteSettings, userId, accessToken, provider,

--- a/samples/src/main/java/in/testpress/samples/core/TestpressCoreSampleActivity.java
+++ b/samples/src/main/java/in/testpress/samples/core/TestpressCoreSampleActivity.java
@@ -119,8 +119,8 @@ public class TestpressCoreSampleActivity extends BaseToolBarActivity {
     }
 
     private void authenticate(String userId, String accessToken, TestpressSdk.Provider provider) {
-        InstituteSettings instituteSettings = new InstituteSettings("https://sandbox.testpress.in");
-        instituteSettings.setWhiteLabeledHostUrl("https://sandbox.testpress.in");
+        InstituteSettings instituteSettings = new InstituteSettings("https://lmsdemo.testpress.in");
+        instituteSettings.setWhiteLabeledHostUrl("https://lmsdemo.testpress.in");
         instituteSettings.setAndroidSentryDns("https://186f9948d5294b4c9c03aa9d2a11c982@sentry.testpress.in/3");
         instituteSettings.setEnableOfflineExam(true);
         TestpressSdk.initialize(this, instituteSettings, userId, accessToken, provider,

--- a/samples/src/main/java/in/testpress/samples/course/OfflineExamSampleActivity.kt
+++ b/samples/src/main/java/in/testpress/samples/course/OfflineExamSampleActivity.kt
@@ -100,7 +100,7 @@ class OfflineExamSampleActivity: BaseToolBarActivity() {
     }
 
     private fun syncCompletedAttempts() {
-        offlineExamViewModel.syncCompletedAttemptToBackEnd()
+        offlineExamViewModel.syncCompletedAllAttemptToBackEnd()
     }
 
     inner class OfflineExamAdapter :


### PR DESCRIPTION
- Previously, we updated answers whenever the user visited the OfflineExamListActivity.
- In this commit, we've added the option to update answers after the user completes the offline exam. Once the answers are submitted, we show a success message; otherwise, we display an internet error message.