### PR TITLE
fix: Show Livestream Notice Message on the Player View

### DIFF
--- a/core/src/main/java/in/testpress/util/NetworkUtil.kt
+++ b/core/src/main/java/in/testpress/util/NetworkUtil.kt
@@ -1,0 +1,11 @@
+package `in`.testpress.util
+
+import okhttp3.OkHttpClient
+import okhttp3.Request
+
+fun makeHeadRequest(url: String): Int {
+    val request = Request.Builder().head().url(url).build()
+    OkHttpClient().newCall(request).execute().use { response ->
+        return response.code()
+    }
+}

--- a/course/src/main/res/layout/exo_player_view.xml
+++ b/course/src/main/res/layout/exo_player_view.xml
@@ -75,4 +75,24 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"/>
 
+    <LinearLayout
+        android:id="@+id/notice_screen"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@android:color/black"
+        android:visibility="gone"
+        android:orientation="vertical"
+        android:gravity="center"
+        >
+
+        <TextView
+            android:id="@+id/notice_message"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textColor="@android:color/white"
+            android:textAlignment="center"
+            android:textStyle="bold"
+            android:padding="16dp"/>
+    </LinearLayout>
+
 </merge>


### PR DESCRIPTION
- Previously, we were showing the livestream not started notice message on the full screen. Now, the notice message will be shown on the player view.
- During this process, we reload the content details every 15 seconds until we get the livestream URL.
- Once we get the livestream URL, we load the player and check for errors. If an error occurs, we show the livestream not started notice message again and make API requests for the URL every 5 seconds until we receive a successful response.
- Once we get a successful response, we load the player again and the livestream will begin.
