### PR TITLE
fix: Add sync button to update answers

### DIFF
--- a/core/src/main/java/in/testpress/database/dao/OfflineAttemptDao.kt
+++ b/core/src/main/java/in/testpress/database/dao/OfflineAttemptDao.kt
@@ -2,6 +2,8 @@ package `in`.testpress.database.dao
 
 import `in`.testpress.database.BaseDao
 import `in`.testpress.database.entities.OfflineAttempt
+import `in`.testpress.models.greendao.Attempt
+import androidx.lifecycle.LiveData
 import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.Query
@@ -32,4 +34,7 @@ interface OfflineAttemptDao: BaseDao<OfflineAttempt>{
 
     @Query("SELECT id FROM OfflineAttempt WHERE examId = :examId")
     suspend fun getAttemptIdsByExamId(examId: Long): List<Long>
+
+    @Query("SELECT * FROM OfflineAttempt WHERE state = :state")
+    fun getOfflineAttemptsByCompleteState(state: String = Attempt.COMPLETED): LiveData<List<OfflineAttempt>>
 }

--- a/course/src/main/java/in/testpress/course/repository/OfflineExamRepository.kt
+++ b/course/src/main/java/in/testpress/course/repository/OfflineExamRepository.kt
@@ -150,6 +150,10 @@ class OfflineExamRepository(val context: Context) {
         }
     }
 
+    fun getOfflineAttemptsByCompleteState() :LiveData<List<OfflineAttempt>> {
+        return offlineAttemptDao.getOfflineAttemptsByCompleteState()
+    }
+
     private fun saveQuestionsToDB(response: NetworkOfflineQuestionResponse){
         CoroutineScope(Dispatchers.IO).launch {
             directionDao.insertAll(response.directions)

--- a/course/src/main/java/in/testpress/course/ui/OfflineExamListActivity.kt
+++ b/course/src/main/java/in/testpress/course/ui/OfflineExamListActivity.kt
@@ -12,9 +12,7 @@ import `in`.testpress.enums.Status
 import `in`.testpress.exam.TestpressExam
 import `in`.testpress.ui.BaseToolBarActivity
 import android.os.Bundle
-import android.view.LayoutInflater
-import android.view.View
-import android.view.ViewGroup
+import android.view.*
 import android.widget.Toast
 import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
@@ -32,6 +30,7 @@ class OfflineExamListActivity : BaseToolBarActivity() {
     private lateinit var progressDialog: ProgressDialog
     private lateinit var onItemClickListener: OnItemClickListener
     private var offlineExam: OfflineExam? = null
+    private var isSyncButtonVisible = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -46,11 +45,33 @@ class OfflineExamListActivity : BaseToolBarActivity() {
         syncExamsModifiedDates()
         observeOfflineAttemptSyncResult()
         observeExamDownloadState()
+        observeCompletedOfflineAttemptCount()
     }
 
     override fun onResume() {
         super.onResume()
         syncCompletedAttempts()
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu): Boolean {
+        menuInflater.inflate(R.menu.offline_attempt_sync, menu)
+        return super.onCreateOptionsMenu(menu)
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        return when (item.itemId) {
+            R.id.sync_completed_attempt -> {
+                syncCompletedAttempts()
+                true
+            }
+            else -> super.onOptionsItemSelected(item)
+        }
+    }
+
+    override fun onPrepareOptionsMenu(menu: Menu): Boolean {
+        val syncItem = menu.findItem(R.id.sync_completed_attempt)
+        syncItem?.isVisible = isSyncButtonVisible
+        return super.onPrepareOptionsMenu(menu)
     }
 
     private fun initializeViewModel() {
@@ -111,6 +132,13 @@ class OfflineExamListActivity : BaseToolBarActivity() {
 
     private fun syncCompletedAttempts() {
         offlineExamViewModel.syncCompletedAllAttemptToBackEnd()
+    }
+
+    private fun observeCompletedOfflineAttemptCount() {
+        offlineExamViewModel.getOfflineAttemptsByCompleteState().observe(this) {
+            isSyncButtonVisible = it.isNotEmpty()
+            invalidateOptionsMenu()
+        }
     }
 
     private fun observeOfflineAttemptSyncResult() {

--- a/course/src/main/java/in/testpress/course/ui/OfflineExamListActivity.kt
+++ b/course/src/main/java/in/testpress/course/ui/OfflineExamListActivity.kt
@@ -144,7 +144,7 @@ class OfflineExamListActivity : BaseToolBarActivity() {
         item.actionView?.clearAnimation()
         item.actionView = null
         item.actionView = if (shouldRotate) {
-            val syncActionView = LayoutInflater.from(this).inflate(R.layout.sync_action_view, null)
+            val syncActionView = LayoutInflater.from(this).inflate(R.layout.refresh_action_view, null)
             val rotateAnimation = RotateAnimation(
                 0f, 360f,
                 RotateAnimation.RELATIVE_TO_SELF, 0.5f,

--- a/course/src/main/java/in/testpress/course/ui/OfflineExamListActivity.kt
+++ b/course/src/main/java/in/testpress/course/ui/OfflineExamListActivity.kt
@@ -142,7 +142,7 @@ class OfflineExamListActivity : BaseToolBarActivity() {
     private fun rotateSyncButton(item: MenuItem?, shouldRotate: Boolean) {
         if (item == null) return
         item.actionView = if (shouldRotate) {
-            val syncActionView = item.actionView!!
+            val syncActionView = LayoutInflater.from(this).inflate(R.layout.sync_action_view, null)
             val rotateAnimation = RotateAnimation(
                 0f, 360f,
                 RotateAnimation.RELATIVE_TO_SELF, 0.5f,

--- a/course/src/main/java/in/testpress/course/viewmodels/OfflineExamViewModel.kt
+++ b/course/src/main/java/in/testpress/course/viewmodels/OfflineExamViewModel.kt
@@ -45,6 +45,10 @@ class OfflineExamViewModel(private val repository: OfflineExamRepository) : View
         downloadExam(offlineExam.contentId!!)
     }
 
+    fun getOfflineAttemptsByCompleteState(): LiveData<List<OfflineAttempt>> {
+        return repository.getOfflineAttemptsByCompleteState()
+    }
+
     suspend fun getOfflineContentAttempts(attemptId: Long): OfflineCourseAttempt? {
         return repository.getOfflineContentAttempts(attemptId)
     }

--- a/course/src/main/res/layout/sync_action_view.xml
+++ b/course/src/main/res/layout/sync_action_view.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<ImageView xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:paddingLeft="12dp"
-    android:paddingRight="12dp"
-    android:src="@drawable/ic_baseline_sync_24" />

--- a/course/src/main/res/layout/sync_action_view.xml
+++ b/course/src/main/res/layout/sync_action_view.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ImageView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:paddingLeft="12dp"
+    android:paddingRight="12dp"
+    android:src="@drawable/ic_baseline_sync_24" />

--- a/course/src/main/res/menu/offline_attempt_sync.xml
+++ b/course/src/main/res/menu/offline_attempt_sync.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:id="@+id/sync_completed_attempt"
+        android:icon="@drawable/ic_baseline_sync_24"
+        android:title="Sync"
+        app:showAsAction="always" />
+
+</menu>


### PR DESCRIPTION
- In this commit, we added a sync button to the action bar. If the offline attempt is not synced, this button will be visible. When the user clicks the button, it will update the offline attempts. Additionally, an animation has been added for the sync button.