### PR TITLE
fix: Hide Download and Start Exam Offline buttons if exam has ended

### DIFF
--- a/course/src/main/java/in/testpress/course/fragments/BaseExamWidgetFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/BaseExamWidgetFragment.kt
@@ -123,10 +123,12 @@ open class BaseExamWidgetFragment : Fragment() {
                         offlineContentAttempt = offlineExamViewModel.getOfflineContentAttempts(it.id)
                     }
                     withContext(Dispatchers.Main) {
-                        showOfflineExamButtons()
+                        if (content.exam?.isEnded() == false){
+                            showOfflineExamButtons()
+                        }
                     }
                 }
-            } else if (offlineExam == null) {
+            } else if (offlineExam == null && content.exam?.isEnded() == false) {
                 downloadExam.isVisible = true && isOfflineExamSupportEnables
             }
         }


### PR DESCRIPTION
- In this commit, we handle the visibility of the Download Exam button and Start Exam Offline button in the content detail screen based on the isEnded() function. If the exam has ended, we hide all buttons. If the exam has not ended, we show either the Start Exam Offline button (if the exam is already downloaded) or the Download Exam button.