### PR TITLE
enhancement: Show offline exam ending alert toast

### DIFF
--- a/core/src/main/java/in/testpress/models/InstituteSettings.java
+++ b/core/src/main/java/in/testpress/models/InstituteSettings.java
@@ -49,7 +49,7 @@ public class InstituteSettings {
     private String androidSentryDns;
     private Boolean disableImageFullscreenZoomInExam;
     private Boolean enableOfflineExam;
-    private Boolean showOfflineExamEndToast;
+    private Boolean showOfflineExamEndingAlertToast;
 
     public InstituteSettings(String baseUrl) {
         setBaseUrl(baseUrl);
@@ -440,12 +440,12 @@ public class InstituteSettings {
         return this;
     }
 
-    public Boolean getShowOfflineExamEndToast() {
-        return showOfflineExamEndToast != null && showOfflineExamEndToast;
+    public Boolean getShowOfflineExamEndingAlertToast() {
+        return showOfflineExamEndingAlertToast != null && showOfflineExamEndingAlertToast;
     }
 
-    public InstituteSettings setShowOfflineExamEndToast(Boolean showOfflineExamEndToast) {
-        this.showOfflineExamEndToast = showOfflineExamEndToast;
+    public InstituteSettings setShowOfflineExamEndingAlertToast(Boolean showOfflineExamEndToast) {
+        this.showOfflineExamEndingAlertToast = showOfflineExamEndToast;
         return this;
     }
 }

--- a/core/src/main/java/in/testpress/models/InstituteSettings.java
+++ b/core/src/main/java/in/testpress/models/InstituteSettings.java
@@ -49,6 +49,7 @@ public class InstituteSettings {
     private String androidSentryDns;
     private Boolean disableImageFullscreenZoomInExam;
     private Boolean enableOfflineExam;
+    private Boolean showOfflineExamEndToast;
 
     public InstituteSettings(String baseUrl) {
         setBaseUrl(baseUrl);
@@ -436,6 +437,15 @@ public class InstituteSettings {
 
     public InstituteSettings setEnableOfflineExam(Boolean enableOfflineExam) {
         this.enableOfflineExam = enableOfflineExam;
+        return this;
+    }
+
+    public Boolean getShowOfflineExamEndToast() {
+        return showOfflineExamEndToast != null && showOfflineExamEndToast;
+    }
+
+    public InstituteSettings setShowOfflineExamEndToast(Boolean showOfflineExamEndToast) {
+        this.showOfflineExamEndToast = showOfflineExamEndToast;
         return this;
     }
 }

--- a/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
@@ -22,7 +22,6 @@ import androidx.slidingpanelayout.widget.SlidingPaneLayout;
 import androidx.appcompat.app.AlertDialog;
 
 import android.text.Html;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -1431,7 +1430,7 @@ public class TestFragment extends BaseFragment implements
         final long WARNING_TIME_MS = 30000; // 30 seconds
         final long WARNING_RANGE_MS = 1000; // 1 second
 
-        if (instituteSettings.getShowOfflineExamEndToast() &&
+        if (instituteSettings.getShowOfflineExamEndingAlertToast() &&
                 millisUntilFinished > WARNING_TIME_MS - WARNING_RANGE_MS &&
                 millisUntilFinished < WARNING_TIME_MS + WARNING_RANGE_MS) {
             Toast.makeText(requireContext(), "Please connect to the internet. The exam will end in 30 seconds.", Toast.LENGTH_SHORT).show();

--- a/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
@@ -22,6 +22,7 @@ import androidx.slidingpanelayout.widget.SlidingPaneLayout;
 import androidx.appcompat.app.AlertDialog;
 
 import android.text.Html;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -1406,6 +1407,7 @@ public class TestFragment extends BaseFragment implements
         countDownTimer = new CountDownTimer(millisInFuture, 1000) {
 
             public void onTick(long millisUntilFinished) {
+                showExamEndingMessage(millisUntilFinished);
                 updateTimeRemaining(millisUntilFinished);
             }
 
@@ -1423,6 +1425,17 @@ public class TestFragment extends BaseFragment implements
                 onRemainingTimeOver();
             }
         }.start();
+    }
+
+    void showExamEndingMessage(long millisUntilFinished) {
+        final long WARNING_TIME_MS = 30000; // 30 seconds
+        final long WARNING_RANGE_MS = 1000; // 1 second
+
+        if (instituteSettings.getShowOfflineExamEndToast() &&
+                millisUntilFinished > WARNING_TIME_MS - WARNING_RANGE_MS &&
+                millisUntilFinished < WARNING_TIME_MS + WARNING_RANGE_MS) {
+            Toast.makeText(requireContext(), "Please connect to the internet. The exam will end in 30 seconds.", Toast.LENGTH_SHORT).show();
+        }
     }
 
     class TestEngineAlertDialog extends AlertDialog.Builder {

--- a/samples/src/main/java/in/testpress/samples/core/TestpressCoreSampleActivity.java
+++ b/samples/src/main/java/in/testpress/samples/core/TestpressCoreSampleActivity.java
@@ -123,6 +123,7 @@ public class TestpressCoreSampleActivity extends BaseToolBarActivity {
         instituteSettings.setWhiteLabeledHostUrl("https://sandbox.testpress.in");
         instituteSettings.setAndroidSentryDns("https://186f9948d5294b4c9c03aa9d2a11c982@sentry.testpress.in/3");
         instituteSettings.setEnableOfflineExam(true);
+        instituteSettings.setShowOfflineExamEndToast(true);
         TestpressSdk.initialize(this, instituteSettings, userId, accessToken, provider,
                 new TestpressCallback<TestpressSession>() {
                     @Override

--- a/samples/src/main/java/in/testpress/samples/core/TestpressCoreSampleActivity.java
+++ b/samples/src/main/java/in/testpress/samples/core/TestpressCoreSampleActivity.java
@@ -123,7 +123,7 @@ public class TestpressCoreSampleActivity extends BaseToolBarActivity {
         instituteSettings.setWhiteLabeledHostUrl("https://sandbox.testpress.in");
         instituteSettings.setAndroidSentryDns("https://186f9948d5294b4c9c03aa9d2a11c982@sentry.testpress.in/3");
         instituteSettings.setEnableOfflineExam(true);
-        instituteSettings.setShowOfflineExamEndToast(true);
+        instituteSettings.setShowOfflineExamEndingAlertToast(true);
         TestpressSdk.initialize(this, instituteSettings, userId, accessToken, provider,
                 new TestpressCallback<TestpressSession>() {
                     @Override

--- a/samples/src/main/java/in/testpress/samples/course/CourseSampleActivity.java
+++ b/samples/src/main/java/in/testpress/samples/course/CourseSampleActivity.java
@@ -219,6 +219,7 @@ public class CourseSampleActivity extends BaseToolBarActivity {
             session.getInstituteSettings().setStoreEnabled(true);
             session.getInstituteSettings().setDisableStoreInApp(false);
             session.getInstituteSettings().setEnableOfflineExam(true);
+            session.getInstituteSettings().setShowOfflineExamEndToast(true);
             session.getInstituteSettings().setAppToolbarLogo("https://media.testpress.in/institute/elixir/institutes/elixir-neet-pg-preparation-app/9571158ee51b4c36b9dd14b9dae17452.png");
             session.getInstituteSettings().setAndroidSentryDns("https://186f9948d5294b4c9c03aa9d2a11c982@sentry.testpress.in/3");
 

--- a/samples/src/main/java/in/testpress/samples/course/CourseSampleActivity.java
+++ b/samples/src/main/java/in/testpress/samples/course/CourseSampleActivity.java
@@ -219,7 +219,7 @@ public class CourseSampleActivity extends BaseToolBarActivity {
             session.getInstituteSettings().setStoreEnabled(true);
             session.getInstituteSettings().setDisableStoreInApp(false);
             session.getInstituteSettings().setEnableOfflineExam(true);
-            session.getInstituteSettings().setShowOfflineExamEndToast(true);
+            session.getInstituteSettings().setShowOfflineExamEndingAlertToast(true);
             session.getInstituteSettings().setAppToolbarLogo("https://media.testpress.in/institute/elixir/institutes/elixir-neet-pg-preparation-app/9571158ee51b4c36b9dd14b9dae17452.png");
             session.getInstituteSettings().setAndroidSentryDns("https://186f9948d5294b4c9c03aa9d2a11c982@sentry.testpress.in/3");
 


### PR DESCRIPTION
- In this commit, we added the `showOfflineExamEndingAlertToast` field to the InstituteSettings model.
- This field enables displaying an exam ending alert toast to the user.