### PR TITLE
fix: Not able to take offline Exam if Exam end date is null

### DIFF
--- a/exam/src/main/java/in/testpress/exam/repository/ExamRepository.kt
+++ b/exam/src/main/java/in/testpress/exam/repository/ExamRepository.kt
@@ -143,6 +143,7 @@ class ExamRepository(val context: Context) {
     }
 
     private fun calculateRemainingTime(exam: Exam): String {
+        if (exam.endDate == null) return exam.duration
         val dateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ")
         val examEndDate = dateFormat.parse(exam.endDate) ?: return exam.duration
         val currentDate = Date()


### PR DESCRIPTION
- Previously, we calculated the exam duration based on the exam end date, which caused exceptions if the end date was null.
- We now check if the exam end date is null and, return the exam duration.