### PR TITLE
fix: User able to retake offline exam even if retake is disabled

### DIFF
--- a/core/src/main/java/in/testpress/database/dao/OfflineExamDao.kt
+++ b/core/src/main/java/in/testpress/database/dao/OfflineExamDao.kt
@@ -33,6 +33,9 @@ interface OfflineExamDao: BaseDao<OfflineExam> {
     @Query("UPDATE OfflineExam SET pausedAttemptsCount = :pausedAttemptsCount WHERE id = :examId")
     suspend fun updatePausedAttemptCount(examId: Long, pausedAttemptsCount: Long)
 
+    @Query("UPDATE OfflineExam SET attemptsCount = attemptsCount + :completedAttemptsCount WHERE id = :examId")
+    suspend fun updateCompletedAttemptCount(examId: Long, completedAttemptsCount: Long)
+
     @Query("SELECT contentId FROM OfflineExam WHERE id = :examId")
     suspend fun getContentIdByExamId(examId: Long): Long
 

--- a/core/src/main/java/in/testpress/database/entities/OfflineExam.kt
+++ b/core/src/main/java/in/testpress/database/entities/OfflineExam.kt
@@ -2,6 +2,7 @@ package `in`.testpress.database.entities
 
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import java.text.ParseException
 import java.text.SimpleDateFormat
 import java.util.*
 
@@ -63,5 +64,42 @@ data class OfflineExam(
             return ((downloadedQuestionCount * 100) / numberOfQuestions).toInt()
         }
         return 0
+    }
+
+    fun canAttemptExam(): Boolean {
+        if (isEnded() || isWebOnly()) {
+            return false
+        }
+        return canRetakeExam() || hasNotAttempted()
+    }
+
+    fun isEnded(): Boolean {
+        val simpleDateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ")
+        simpleDateFormat.timeZone = TimeZone.getTimeZone("UTC")
+        try {
+            if(!endDate.isNullOrEmpty()) {
+                return simpleDateFormat.parse(endDate).before(Date())
+            }
+        } catch (e: ParseException) {
+            e.printStackTrace()
+        }
+        return false
+    }
+
+    private fun isWebOnly(): Boolean {
+        return deviceAccessControl != null && deviceAccessControl == "web"
+    }
+
+    private fun canRetakeExam(): Boolean {
+        if (allowRetake == true) {
+            return (attemptsCount!! <= maxRetakes!!) || (maxRetakes == -1)
+        }
+        return false
+    }
+
+    private fun hasNotAttempted() = !hasAttempted()
+
+    private fun hasAttempted(): Boolean {
+        return (attemptsCount ?: 0) > 0
     }
 }

--- a/course/src/main/java/in/testpress/course/fragments/BaseExamWidgetFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/BaseExamWidgetFragment.kt
@@ -123,7 +123,7 @@ open class BaseExamWidgetFragment : Fragment() {
                         offlineContentAttempt = offlineExamViewModel.getOfflineContentAttempts(it.id)
                     }
                     withContext(Dispatchers.Main) {
-                        if (content.exam?.isEnded() == false){
+                        if (content.exam?.isEnded() == false && offlineExam.canAttemptExam()){
                             showOfflineExamButtons()
                         }
                     }
@@ -144,7 +144,6 @@ open class BaseExamWidgetFragment : Fragment() {
                 else -> {}
             }
         }
-        offlineExamViewModel.syncCompletedAttempt(content.examId!!)
         offlineExamViewModel.offlineAttemptSyncResult.observe(requireActivity()) { it ->
             when (it.status){
                 Status.SUCCESS -> {
@@ -471,4 +470,11 @@ open class BaseExamWidgetFragment : Fragment() {
     }
 
     open fun display() {}
+
+    override fun onResume() {
+        super.onResume()
+        if (::content.isInitialized){
+            offlineExamViewModel.syncCompletedAttempt(content.examId!!)
+        }
+    }
 }

--- a/course/src/main/java/in/testpress/course/ui/OfflineExamListActivity.kt
+++ b/course/src/main/java/in/testpress/course/ui/OfflineExamListActivity.kt
@@ -93,7 +93,7 @@ class OfflineExamListActivity : BaseToolBarActivity() {
                         monitorAndShowExamDownloadProgress(exam.contentId!!)
                         offlineExamViewModel.downloadExam(exam.contentId!!)
                     } else {
-                        startExam()
+                        handleExamAttempt()
                     }
                 }
             }
@@ -241,17 +241,29 @@ class OfflineExamListActivity : BaseToolBarActivity() {
             when (result.status) {
                 Status.SUCCESS -> {
                     hideProgressDialog()
-                    startExam()
+                    handleExamAttempt()
                 }
                 Status.LOADING -> {
                     showProgressDialog()
                 }
                 Status.ERROR -> {
                     hideProgressDialog()
-                    startExam()
+                    handleExamAttempt()
                 }
             }
 
+        }
+    }
+
+    private fun handleExamAttempt() {
+        if (offlineExam!!.canAttemptExam()) {
+            startExam()
+        } else {
+            Toast.makeText(
+                this@OfflineExamListActivity,
+                "You've already used all your attempts for this exam. To review your results, please visit the exam page.",
+                Toast.LENGTH_SHORT
+            ).show()
         }
     }
 

--- a/exam/src/main/java/in/testpress/exam/repository/AttemptRepository.kt
+++ b/exam/src/main/java/in/testpress/exam/repository/AttemptRepository.kt
@@ -295,6 +295,7 @@ class AttemptRepository(val context: Context) {
                 endAllOfflineAttemptSection()
                 offlineAttemptDao.updateAttemptState(attempt.id,Attempt.COMPLETED)
                 offlineExamDao.updatePausedAttemptCount(exam.id, 0L)
+                offlineExamDao.updateCompletedAttemptCount(exam.id, 1L)
                 val offlineCourseAttempt = offlineCourseAttemptDao.getById(attempt.id)
                 _endContentAttemptResource.postValue(Resource.success(offlineCourseAttempt!!.createGreenDoaModel(attempt)))
             }
@@ -319,6 +320,7 @@ class AttemptRepository(val context: Context) {
                 endAllOfflineAttemptSection()
                 offlineAttemptDao.updateAttemptState(attempt.id,Attempt.COMPLETED)
                 offlineExamDao.updatePausedAttemptCount(exam.id, 0L)
+                offlineExamDao.updateCompletedAttemptCount(exam.id, 1L)
                 val offlineAttempt = offlineAttemptDao.getById(attempt.id)
                 val offlineAttemptSections = offlineAttemptSectionDao.getByAttemptId(attempt.id)
                 _endAttemptResource.postValue(Resource.success(offlineAttempt.createGreenDoaModel(offlineAttemptSections.asGreenDoaModels())))


### PR DESCRIPTION
- Previously, we didn't handle the retake option for offline exams correctly, allowing users to retake the exam multiple times even if retakes were disabled. In this commit, we track the attempt count locally each time a user completes an attempt. Based on this count, we now enforce the retake restrictions as per the exam settings. Additionally, we sync the offline attempts after the exam is completed.