### PR TITLE
fix: Add option to open exam detail from Offline Exam List view

### DIFF
--- a/course/src/main/java/in/testpress/course/fragments/OfflineExamOptionsBottomSheet.kt
+++ b/course/src/main/java/in/testpress/course/fragments/OfflineExamOptionsBottomSheet.kt
@@ -13,6 +13,7 @@ class OfflineExamOptionsBottomSheet: BottomSheetDialogFragment() {
     private var _binding: OfflineExamOptionsBottomSheetBinding? = null
     private val binding get() = _binding!!
     var offlineExam: OfflineExam? = null
+    private var onOptionClick: OnOptionClick? = null
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -25,10 +26,21 @@ class OfflineExamOptionsBottomSheet: BottomSheetDialogFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         binding.bottomSheetTitle.text = offlineExam?.title
+        binding.openExam.setOnClickListener { onOptionClick?.onOpenExam() }
+        binding.deleteExam.setOnClickListener { onOptionClick?.onDeleteExam() }
     }
 
     override fun onDestroyView() {
         super.onDestroyView()
         _binding = null
+    }
+
+    fun setOptionClickCallBacks(onOptionClick: OnOptionClick) {
+        this.onOptionClick = onOptionClick
+    }
+
+    interface OnOptionClick {
+        fun onOpenExam()
+        fun onDeleteExam()
     }
 }

--- a/course/src/main/java/in/testpress/course/fragments/OfflineExamOptionsBottomSheet.kt
+++ b/course/src/main/java/in/testpress/course/fragments/OfflineExamOptionsBottomSheet.kt
@@ -13,7 +13,7 @@ class OfflineExamOptionsBottomSheet: BottomSheetDialogFragment() {
     private var _binding: OfflineExamOptionsBottomSheetBinding? = null
     private val binding get() = _binding!!
     var offlineExam: OfflineExam? = null
-    private var onOptionClick: OnOptionClick? = null
+    private var bottomSheetListener: BottomSheetListener? = null
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -26,8 +26,8 @@ class OfflineExamOptionsBottomSheet: BottomSheetDialogFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         binding.bottomSheetTitle.text = offlineExam?.title
-        binding.openExam.setOnClickListener { onOptionClick?.onOpenExam() }
-        binding.deleteExam.setOnClickListener { onOptionClick?.onDeleteExam() }
+        binding.openExam.setOnClickListener { bottomSheetListener?.onOpenExam() }
+        binding.deleteExam.setOnClickListener { bottomSheetListener?.onDeleteExam() }
     }
 
     override fun onDestroyView() {
@@ -35,11 +35,11 @@ class OfflineExamOptionsBottomSheet: BottomSheetDialogFragment() {
         _binding = null
     }
 
-    fun setOptionClickCallBacks(onOptionClick: OnOptionClick) {
-        this.onOptionClick = onOptionClick
+    fun setBottomSheetListener(bottomSheetListener: BottomSheetListener) {
+        this.bottomSheetListener = bottomSheetListener
     }
 
-    interface OnOptionClick {
+    interface BottomSheetListener {
         fun onOpenExam()
         fun onDeleteExam()
     }

--- a/course/src/main/java/in/testpress/course/fragments/OfflineExamOptionsBottomSheet.kt
+++ b/course/src/main/java/in/testpress/course/fragments/OfflineExamOptionsBottomSheet.kt
@@ -1,0 +1,34 @@
+package `in`.testpress.course.fragments
+
+import `in`.testpress.course.databinding.OfflineExamOptionsBottomSheetBinding
+import `in`.testpress.database.entities.OfflineExam
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+
+class OfflineExamOptionsBottomSheet: BottomSheetDialogFragment() {
+
+    private var _binding: OfflineExamOptionsBottomSheetBinding? = null
+    private val binding get() = _binding!!
+    var offlineExam: OfflineExam? = null
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = OfflineExamOptionsBottomSheetBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        binding.bottomSheetTitle.text = offlineExam?.title
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/course/src/main/java/in/testpress/course/ui/OfflineExamListActivity.kt
+++ b/course/src/main/java/in/testpress/course/ui/OfflineExamListActivity.kt
@@ -328,7 +328,7 @@ class OfflineExamListActivity : BaseToolBarActivity() {
             private fun showBottomSheet(exam: OfflineExam) {
                 val bottomSheetFragment = OfflineExamOptionsBottomSheet()
                 bottomSheetFragment.offlineExam = exam
-                bottomSheetFragment.setOptionClickCallBacks(object :OfflineExamOptionsBottomSheet.OnOptionClick{
+                bottomSheetFragment.setBottomSheetListener(object :OfflineExamOptionsBottomSheet.BottomSheetListener{
                     override fun onOpenExam() {
                         startActivity(
                             ContentActivity.createIntent(

--- a/course/src/main/java/in/testpress/course/ui/OfflineExamListActivity.kt
+++ b/course/src/main/java/in/testpress/course/ui/OfflineExamListActivity.kt
@@ -328,6 +328,24 @@ class OfflineExamListActivity : BaseToolBarActivity() {
             private fun showBottomSheet(exam: OfflineExam) {
                 val bottomSheetFragment = OfflineExamOptionsBottomSheet()
                 bottomSheetFragment.offlineExam = exam
+                bottomSheetFragment.setOptionClickCallBacks(object :OfflineExamOptionsBottomSheet.OnOptionClick{
+                    override fun onOpenExam() {
+                        startActivity(
+                            ContentActivity.createIntent(
+                                exam.contentId,
+                                this@OfflineExamListActivity,
+                                ""
+                            )
+                        )
+                        bottomSheetFragment.dismiss()
+                    }
+
+                    override fun onDeleteExam() {
+                        offlineExamViewModel.deleteOfflineExam(exam.id!!)
+                        bottomSheetFragment.dismiss()
+                    }
+
+                })
                 bottomSheetFragment.show((itemView.context as AppCompatActivity).supportFragmentManager, bottomSheetFragment.tag)
             }
         }

--- a/course/src/main/java/in/testpress/course/ui/OfflineExamListActivity.kt
+++ b/course/src/main/java/in/testpress/course/ui/OfflineExamListActivity.kt
@@ -4,6 +4,7 @@ import `in`.testpress.core.TestpressSdk
 import `in`.testpress.course.R
 import `in`.testpress.course.databinding.OfflineExamListActivityBinding
 import `in`.testpress.course.databinding.OfflineExamListItemBinding
+import `in`.testpress.course.fragments.OfflineExamOptionsBottomSheet
 import `in`.testpress.course.util.ProgressDialog
 import `in`.testpress.course.util.SwipeToDeleteCallback
 import `in`.testpress.course.viewmodels.OfflineExamViewModel
@@ -16,6 +17,7 @@ import android.view.*
 import android.view.animation.LinearInterpolator
 import android.view.animation.RotateAnimation
 import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.*
@@ -311,6 +313,9 @@ class OfflineExamListActivity : BaseToolBarActivity() {
                 itemView.setOnClickListener {
                     clickListener.onItemClick(exam)
                 }
+                binding.menuButton.setOnClickListener {
+                    showBottomSheet(exam)
+                }
             }
 
             private fun updateExamDetails(exam: OfflineExam) {
@@ -318,6 +323,12 @@ class OfflineExamListActivity : BaseToolBarActivity() {
                 binding.duration.text = exam.duration
                 binding.numberOfQuestions.text = exam.numberOfQuestions.toString()
                 binding.examResumeState.isVisible = ((exam.pausedAttemptsCount ?: 0) > 0)
+            }
+
+            private fun showBottomSheet(exam: OfflineExam) {
+                val bottomSheetFragment = OfflineExamOptionsBottomSheet()
+                bottomSheetFragment.offlineExam = exam
+                bottomSheetFragment.show((itemView.context as AppCompatActivity).supportFragmentManager, bottomSheetFragment.tag)
             }
         }
     }

--- a/course/src/main/res/drawable/bottom_sheet_background.xml
+++ b/course/src/main/res/drawable/bottom_sheet_background.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@android:color/white" />
+    <corners android:topLeftRadius="16dp" android:topRightRadius="16dp" />
+</shape>

--- a/course/src/main/res/drawable/ic_baseline_delete_forever_24.xml
+++ b/course/src/main/res/drawable/ic_baseline_delete_forever_24.xml
@@ -1,4 +1,4 @@
-<vector android:height="24dp" android:tint="#FFFFFF"
+<vector android:height="24dp" android:tint="@color/cb_dark_grey"
     android:viewportHeight="24" android:viewportWidth="24"
     android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
     <path android:fillColor="@android:color/white" android:pathData="M6,19c0,1.1 0.9,2 2,2h8c1.1,0 2,-0.9 2,-2L18,7L6,7v12zM8.46,11.88l1.41,-1.41L12,12.59l2.12,-2.12 1.41,1.41L13.41,14l2.12,2.12 -1.41,1.41L12,15.41l-2.12,2.12 -1.41,-1.41L10.59,14l-2.13,-2.12zM15.5,4l-1,-1h-5l-1,1L5,4v2h14L19,4z"/>

--- a/course/src/main/res/drawable/ic_baseline_more_vert_24.xml
+++ b/course/src/main/res/drawable/ic_baseline_more_vert_24.xml
@@ -1,4 +1,4 @@
-<vector android:height="24dp" android:tint="#999999"
+<vector android:height="24dp" android:tint="@color/cb_dark_grey"
     android:viewportHeight="24" android:viewportWidth="24"
     android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
     <path android:fillColor="@android:color/white" android:pathData="M12,8c1.1,0 2,-0.9 2,-2s-0.9,-2 -2,-2 -2,0.9 -2,2 0.9,2 2,2zM12,10c-1.1,0 -2,0.9 -2,2s0.9,2 2,2 2,-0.9 2,-2 -0.9,-2 -2,-2zM12,16c-1.1,0 -2,0.9 -2,2s0.9,2 2,2 2,-0.9 2,-2 -0.9,-2 -2,-2z"/>

--- a/course/src/main/res/drawable/ic_baseline_open_in_new_24.xml
+++ b/course/src/main/res/drawable/ic_baseline_open_in_new_24.xml
@@ -1,0 +1,5 @@
+<vector android:autoMirrored="true" android:height="24dp"
+    android:tint="@color/cb_dark_grey" android:viewportHeight="24"
+    android:viewportWidth="24" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M19,19H5V5h7V3H5c-1.11,0 -2,0.9 -2,2v14c0,1.1 0.89,2 2,2h14c1.1,0 2,-0.9 2,-2v-7h-2v7zM14,3v2h3.59l-9.83,9.83 1.41,1.41L19,6.41V10h2V3h-7z"/>
+</vector>

--- a/course/src/main/res/layout/offline_exam_list_item.xml
+++ b/course/src/main/res/layout/offline_exam_list_item.xml
@@ -95,6 +95,6 @@
         android:layout_height="wrap_content"
         android:layout_alignParentRight="true"
         android:layout_centerVertical="true"
-        android:src="@drawable/ic_more" />
+        android:src="@drawable/ic_baseline_more_vert_24" />
 
 </RelativeLayout>

--- a/course/src/main/res/layout/offline_exam_list_item.xml
+++ b/course/src/main/res/layout/offline_exam_list_item.xml
@@ -84,8 +84,17 @@
         android:layout_width="5dp"
         android:layout_height="5dp"
         android:visibility="gone"
-        android:layout_alignParentRight="true"
+        android:layout_marginRight="16dp"
+        android:layout_toLeftOf="@id/menu_button"
         android:background="@drawable/green_circle"
         android:layout_centerVertical="true"/>
+
+    <ImageView
+        android:id="@+id/menu_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentRight="true"
+        android:layout_centerVertical="true"
+        android:src="@drawable/ic_more" />
 
 </RelativeLayout>

--- a/course/src/main/res/layout/offline_exam_options_bottom_sheet.xml
+++ b/course/src/main/res/layout/offline_exam_options_bottom_sheet.xml
@@ -27,6 +27,7 @@
             android:background="@color/testpress_gray_light" />
 
         <TextView
+            android:id="@+id/open_exam"
             style="@style/selectableTextView"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -35,6 +36,7 @@
             android:text="Open Exam"/>
 
         <TextView
+            android:id="@+id/delete_exam"
             style="@style/selectableTextView"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/course/src/main/res/layout/offline_exam_options_bottom_sheet.xml
+++ b/course/src/main/res/layout/offline_exam_options_bottom_sheet.xml
@@ -1,40 +1,47 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/standard_bottom_sheet"
+    style="@style/Widget.Material3.BottomSheet"
+    android:background="#00000000"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:background="@drawable/bottom_sheet_background"
-    android:orientation="vertical">
+    app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior">
 
-    <!-- Title -->
-    <TextView
-        android:id="@+id/bottom_sheet_title"
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:padding="16dp"
-        android:text="Bottom Sheet Title"
-        android:textAppearance="?attr/textAppearanceHeadline6" />
+        android:orientation="vertical">
 
-    <!-- Divider -->
-    <View
-        android:layout_width="match_parent"
-        android:layout_height="1dp"
-        android:background="?attr/colorOnSurface" />
+        <TextView
+            android:id="@+id/bottom_sheet_title"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:padding="16dp"
+            android:text="Bottom Sheet Title"
+            android:textAppearance="?attr/textAppearanceHeadline6" />
 
-    <TextView
-        android:id="@+id/option_1"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:padding="16dp"
-        android:text="Option 1"
-        android:textAppearance="?attr/textAppearanceListItem" />
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:background="@color/testpress_gray_light" />
 
-    <TextView
-        android:id="@+id/option_2"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:padding="16dp"
-        android:text="Option 2"
-        android:textAppearance="?attr/textAppearanceListItem" />
-</LinearLayout>
+        <TextView
+            style="@style/selectableTextView"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:drawableLeftCompat="@drawable/ic_baseline_open_in_new_24"
+            app:drawableStartCompat="@drawable/ic_baseline_open_in_new_24"
+            android:text="Open Exam"/>
 
+        <TextView
+            style="@style/selectableTextView"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:drawableLeftCompat="@drawable/ic_baseline_delete_forever_24"
+            app:drawableStartCompat="@drawable/ic_baseline_delete_forever_24"
+            android:text="Delete Exam"/>
 
+    </LinearLayout>
+
+</RelativeLayout>

--- a/course/src/main/res/layout/offline_exam_options_bottom_sheet.xml
+++ b/course/src/main/res/layout/offline_exam_options_bottom_sheet.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@drawable/bottom_sheet_background"
+    android:orientation="vertical">
+
+    <!-- Title -->
+    <TextView
+        android:id="@+id/bottom_sheet_title"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="16dp"
+        android:text="Bottom Sheet Title"
+        android:textAppearance="?attr/textAppearanceHeadline6" />
+
+    <!-- Divider -->
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:background="?attr/colorOnSurface" />
+
+    <TextView
+        android:id="@+id/option_1"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="16dp"
+        android:text="Option 1"
+        android:textAppearance="?attr/textAppearanceListItem" />
+
+    <TextView
+        android:id="@+id/option_2"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="16dp"
+        android:text="Option 2"
+        android:textAppearance="?attr/textAppearanceListItem" />
+</LinearLayout>
+
+

--- a/course/src/main/res/layout/offline_exam_options_bottom_sheet.xml
+++ b/course/src/main/res/layout/offline_exam_options_bottom_sheet.xml
@@ -2,7 +2,6 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/standard_bottom_sheet"
-    style="@style/Widget.Material3.BottomSheet"
     android:background="#00000000"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"

--- a/course/src/main/res/values/style.xml
+++ b/course/src/main/res/values/style.xml
@@ -6,4 +6,13 @@
         <item name="android:textStyle">bold</item>
     </style>
 
+    <style name="selectableTextView" parent="@android:style/Widget.TextView">
+        <item name="android:textSize">16sp</item>
+        <item name="android:gravity">center_vertical</item>
+        <item name="android:clickable">true</item>
+        <item name="android:padding">16dp</item>
+        <item name="android:textColor">@color/cb_dark_grey</item>
+        <item name="android:drawablePadding">16dp</item>
+        <item name="android:background">?attr/selectableItemBackground</item>
+    </style>
 </resources>


### PR DESCRIPTION
- In this commit, we added an option to open exam details from the Offline Exam List. When the user clicks the More button in the list item, a bottom sheet will open with options to open the exam and delete the exam.