### PR TITLE
enhancement: Add domain URL method in InstituteSettings

### DIFF
--- a/core/src/main/java/in/testpress/models/InstituteSettings.java
+++ b/core/src/main/java/in/testpress/models/InstituteSettings.java
@@ -448,4 +448,8 @@ public class InstituteSettings {
         this.showOfflineExamEndingAlert = showOfflineExamEndingAlert;
         return this;
     }
+
+    public String getDomainUrl() {
+        return (whiteLabeledHostUrl != null && !whiteLabeledHostUrl.isEmpty()) ? whiteLabeledHostUrl : baseUrl;
+    }
 }

--- a/course/src/main/java/in/testpress/course/ui/ChaptersListFragment.java
+++ b/course/src/main/java/in/testpress/course/ui/ChaptersListFragment.java
@@ -246,7 +246,7 @@ public class ChaptersListFragment extends BaseDataBaseFragment<Chapter, Long> {
                 CustomTestGenerationActivity.Companion.createIntent(
                         requireContext(),
                         "Custom Module",
-                        instituteSettings.getBaseUrl()+"/courses/custom_test_generation/?course_id="+courseId+"&testpress_app=android",
+                        instituteSettings.getDomainUrl()+"/courses/custom_test_generation/?course_id="+courseId+"&testpress_app=android",
                         true,
                         CustomTestGenerationActivity.class
                 )

--- a/course/src/main/java/in/testpress/course/ui/MyCoursesFragment.java
+++ b/course/src/main/java/in/testpress/course/ui/MyCoursesFragment.java
@@ -181,7 +181,7 @@ public class MyCoursesFragment extends BaseDataBaseFragment<Course, Long> {
                 CustomTestGenerationActivity.Companion.createIntent(
                         requireContext(),
                         "Custom Module",
-                        instituteSettings.getBaseUrl()+"/courses/custom_test_generation/?"+constrictQueryParamForAvailableCourses()+"&testpress_app=android",
+                        instituteSettings.getDomainUrl()+"/courses/custom_test_generation/?"+constrictQueryParamForAvailableCourses()+"&testpress_app=android",
                         true,
                         CustomTestGenerationActivity.class
                 )

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,7 +22,7 @@ org.gradle.daemon=true
 org.gradle.parallel=true
 
 GROUP=com.github.testpress
-VERSION_NAME=1.4.153
+VERSION_NAME=1.4.152
 
 REPO=android-sdk
 USER_ORG=testpress

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,7 +22,7 @@ org.gradle.daemon=true
 org.gradle.parallel=true
 
 GROUP=com.github.testpress
-VERSION_NAME=1.4.152
+VERSION_NAME=1.4.153
 
 REPO=android-sdk
 USER_ORG=testpress

--- a/samples/src/main/java/in/testpress/samples/course/CourseSampleActivity.java
+++ b/samples/src/main/java/in/testpress/samples/course/CourseSampleActivity.java
@@ -262,7 +262,7 @@ public class CourseSampleActivity extends BaseToolBarActivity {
         startActivity(WebViewWithSSOActivity.Companion.createIntent(
                         CourseSampleActivity.this,
                         "Test WebView",
-                        session.getInstituteSettings().getBaseUrl() + urlPath,
+                        session.getInstituteSettings().getDomainUrl() + urlPath,
                         true,
                         WebViewWithSSOActivity.class
                 )
@@ -287,7 +287,7 @@ public class CourseSampleActivity extends BaseToolBarActivity {
                                                 CustomTestGenerationActivity.Companion.createIntent(
                                                         CourseSampleActivity.this,
                                                         "Custom Module",
-                                                        session.getInstituteSettings().getBaseUrl()+"/courses/custom_test_generation/?course_id="+inputText+"&testpress_app=android",
+                                                        session.getInstituteSettings().getDomainUrl()+"/courses/custom_test_generation/?course_id="+inputText+"&testpress_app=android",
                                                         true,
                                                         CustomTestGenerationActivity.class
                                                 )


### PR DESCRIPTION
- In this commit, we added a new method called `getDomainUrl()` in the InstituteSettings model.
- This method returns the whiteLabeledHostUrl if it is not null; otherwise, it returns the base URL.