### PR TITLE
fix: Prevent user from taking attempts in exam when Retake is disabled

### DIFF
--- a/core/src/main/java/in/testpress/database/dao/OfflineExamDao.kt
+++ b/core/src/main/java/in/testpress/database/dao/OfflineExamDao.kt
@@ -44,4 +44,7 @@ interface OfflineExamDao: BaseDao<OfflineExam> {
 
     @Query("UPDATE OfflineExam SET downloadComplete = :downloadComplete WHERE id = :examId")
     suspend fun updateDownloadedState(examId: Long, downloadComplete: Boolean)
+
+    @Query("UPDATE OfflineExam SET attemptsCount = :attemptsCount, pausedAttemptsCount = :pausedAttemptsCount WHERE id = :examId")
+    suspend fun updateAttemptsCount(examId: Long, attemptsCount: Long, pausedAttemptsCount: Long)
 }

--- a/core/src/main/java/in/testpress/database/entities/OfflineExam.kt
+++ b/core/src/main/java/in/testpress/database/entities/OfflineExam.kt
@@ -97,7 +97,7 @@ data class OfflineExam(
         return false
     }
 
-    private fun hasNotAttempted() = !hasAttempted()
+    fun hasNotAttempted() = !hasAttempted()
 
     private fun hasAttempted(): Boolean {
         return (attemptsCount ?: 0) > 0

--- a/course/src/main/java/in/testpress/course/repository/OfflineExamRepository.kt
+++ b/course/src/main/java/in/testpress/course/repository/OfflineExamRepository.kt
@@ -410,4 +410,8 @@ class OfflineExamRepository(val context: Context) {
         }
         return contents[0]
     }
+
+    suspend fun updateAttemptsCount(examId: Long, attemptsCount: Long, pausedAttemptsCount: Long) {
+        offlineExamDao.updateAttemptsCount(examId, attemptsCount, pausedAttemptsCount)
+    }
 }

--- a/course/src/main/java/in/testpress/course/viewmodels/OfflineExamViewModel.kt
+++ b/course/src/main/java/in/testpress/course/viewmodels/OfflineExamViewModel.kt
@@ -81,6 +81,12 @@ class OfflineExamViewModel(private val repository: OfflineExamRepository) : View
         return repository.getOfflinePausedAttempt(examId)
     }
 
+    fun updateAttemptsCount(examId: Long, attemptsCount: Long, pausedAttemptsCount: Long){
+        viewModelScope.launch {
+            repository.updateAttemptsCount(examId, attemptsCount, pausedAttemptsCount)
+        }
+    }
+
     companion object {
         fun initializeViewModel(activity: FragmentActivity): OfflineExamViewModel {
             return ViewModelProvider(activity, object : ViewModelProvider.Factory {

--- a/exam/src/main/java/in/testpress/exam/repository/AttemptRepository.kt
+++ b/exam/src/main/java/in/testpress/exam/repository/AttemptRepository.kt
@@ -304,6 +304,9 @@ class AttemptRepository(val context: Context) {
                 .enqueue(object : TestpressCallback<CourseAttempt>() {
                     override fun onSuccess(result: CourseAttempt) {
                         _endContentAttemptResource.postValue(Resource.success(result))
+                        CoroutineScope(Dispatchers.IO).launch {
+                            offlineExamDao.updateCompletedAttemptCount(exam!!.id, 1L)
+                        }
                     }
 
                     override fun onException(exception: TestpressException) {
@@ -330,6 +333,9 @@ class AttemptRepository(val context: Context) {
                 .enqueue(object : TestpressCallback<Attempt>() {
                     override fun onSuccess(response: Attempt) {
                         _endAttemptResource.postValue(Resource.success(response))
+                        CoroutineScope(Dispatchers.IO).launch {
+                            offlineExamDao.updateCompletedAttemptCount(exam!!.id, 1L)
+                        }
                     }
 
                     override fun onException(exception: TestpressException) {


### PR DESCRIPTION
- Previously, users could attend exams in either offline or online mode even if Retake was disabled. The exam attempt count was not synced correctly, allowing users to take the exam offline after attempting it online.
- In this commit, we added attempt syncing in the Exam detail screen. Whenever the user opens the exam detail screen, the attempt count is synced with the downloaded offline exam. This ensures the attempt count is consistent across both online and offline modes.
