### PR TITLE
fix: Answers not submitting for numerical and essay type questions

### DIFF
--- a/exam/src/main/java/in/testpress/exam/repository/AttemptRepository.kt
+++ b/exam/src/main/java/in/testpress/exam/repository/AttemptRepository.kt
@@ -233,10 +233,12 @@ class AttemptRepository(val context: Context) {
         if (offlineAttemptItem != null) {
             if (attemptItem.attemptQuestion.type == "E") {
                 offlineAttemptItem.localEssayText = attemptItem.localEssayText
+                offlineAttemptItem.essayText = attemptItem.localEssayText
             } else {
                 offlineAttemptItem.selectedAnswers = attemptItem.savedAnswers
                 offlineAttemptItem.savedAnswers = attemptItem.savedAnswers
                 offlineAttemptItem.currentShortText = attemptItem.currentShortText
+                offlineAttemptItem.shortText = attemptItem.currentShortText
             }
             offlineAttemptItem.unSyncedFiles = attemptItem.unSyncedFiles
             offlineAttemptItem.review = attemptItem.currentReview

--- a/exam/src/main/java/in/testpress/exam/util/OfflineAttemptItemMapping.kt
+++ b/exam/src/main/java/in/testpress/exam/util/OfflineAttemptItemMapping.kt
@@ -16,7 +16,7 @@ fun OfflineAttemptItem.asAttemptItem(subject: String, direction: String?): Attem
         review,
        savedAnswers,
         order,
-        null,
+        review,
         shortText,
         currentShortText,
         attemptSection?.asGreenDoaModel(),


### PR DESCRIPTION
- In this commit, we ensure that local answers are set to the current answers for numerical and essay type questions. These answers will be submitted during the attempt syncing process.