### PR TITLE
fix: Paused attempts not submitted after exam ended

### DIFF
--- a/core/src/main/java/in/testpress/database/entities/OfflineAttempt.kt
+++ b/core/src/main/java/in/testpress/database/entities/OfflineAttempt.kt
@@ -10,7 +10,7 @@ data class OfflineAttempt(
     val date: String,
     val totalQuestions: Int,
     val lastStartedTime: String,
-    val remainingTime: String,
+    var remainingTime: String,
     val timeTaken: String,
     val state: String,
     val attemptType: Int,

--- a/course/src/main/java/in/testpress/course/fragments/BaseExamWidgetFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/BaseExamWidgetFragment.kt
@@ -113,6 +113,7 @@ open class BaseExamWidgetFragment : Fragment() {
     }
 
     protected fun initializeObserversForOfflineDownload() {
+        offlineExamViewModel.syncCompletedAttempt(content.examId!!)
         offlineExamViewModel.get(contentId).observe(requireActivity()) { offlineExam ->
             this.offlineExam = offlineExam
             if (offlineExam != null && offlineExam.downloadComplete) {

--- a/course/src/main/java/in/testpress/course/repository/OfflineExamRepository.kt
+++ b/course/src/main/java/in/testpress/course/repository/OfflineExamRepository.kt
@@ -36,10 +36,12 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.*
+import java.text.SimpleDateFormat
 import java.time.ZoneId
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 import java.util.*
+import java.util.concurrent.TimeUnit
 import kotlin.collections.HashMap
 
 class OfflineExamRepository(val context: Context) {
@@ -308,8 +310,10 @@ class OfflineExamRepository(val context: Context) {
     private suspend fun updateAttemptStatusForEndedExam(pausedAttempts: List<OfflineAttempt>) {
         pausedAttempts.forEach { pausedAttempt ->
             val exam = offlineExamDao.getById(pausedAttempt.examId)
-            if (exam?.isEnded() == true) {
+            if (exam != null && exam.isEnded()) {
                 offlineAttemptDao.updateAttemptState(pausedAttempt.id, Attempt.COMPLETED)
+                offlineExamDao.updatePausedAttemptCount(exam.id!!, 0L)
+                offlineExamDao.updateCompletedAttemptCount(exam.id!!, 1L)
             }
         }
     }
@@ -402,6 +406,7 @@ class OfflineExamRepository(val context: Context) {
             ?.let { offlineAttempt ->
                 val offlineAttemptSectionList = getOfflineAttemptSectionList(offlineAttempt.id)
                 val offlineContentAttempt = getOfflineContentAttempts(offlineAttempt.id)
+                offlineAttempt.remainingTime = calculateRemainingTime(offlineExamDao.getById(examId)!!,offlineAttempt.remainingTime)
                 return offlineContentAttempt?.createGreenDoaModel(
                     offlineAttempt.createGreenDoaModel(
                         offlineAttemptSectionList.asGreenDoaModels()
@@ -409,6 +414,28 @@ class OfflineExamRepository(val context: Context) {
                 )
             }
         return null
+    }
+
+    private fun calculateRemainingTime(exam: OfflineExam, remainingTime: String): String {
+        if (exam.endDate.isNullOrEmpty()) return remainingTime
+        val dateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ")
+        val examEndDate = dateFormat.parse(exam.endDate!!) ?: return remainingTime
+        val currentDate = Date()
+
+        val timeDiffMillis = examEndDate.time - currentDate.time
+
+        val (hours, minutes, seconds) = remainingTime.split(":").map { it.toInt() }
+        val examDurationMillis = TimeUnit.HOURS.toMillis(hours.toLong()) +
+                TimeUnit.MINUTES.toMillis(minutes.toLong()) +
+                TimeUnit.SECONDS.toMillis(seconds.toLong())
+
+        val remainingTimeMillis = minOf(timeDiffMillis, examDurationMillis)
+
+        val remainingHours = TimeUnit.MILLISECONDS.toHours(remainingTimeMillis)
+        val remainingMinutes = TimeUnit.MILLISECONDS.toMinutes(remainingTimeMillis) % 60
+        val remainingSeconds = TimeUnit.MILLISECONDS.toSeconds(remainingTimeMillis) % 60
+
+        return String.format("%02d:%02d:%02d", remainingHours, remainingMinutes, remainingSeconds)
     }
 
     private fun getContentFromDB(contentId: Long): Content? {


### PR DESCRIPTION
- In this commit, we added validation to complete paused attempts for ended exams. This operation is performed before the attempt sync starts, ensuring that all completed exams are properly synced.