### PR TITLE
fix: App crash on Custom Test End

### DIFF
--- a/exam/src/main/java/in/testpress/exam/repository/AttemptRepository.kt
+++ b/exam/src/main/java/in/testpress/exam/repository/AttemptRepository.kt
@@ -338,8 +338,11 @@ class AttemptRepository(val context: Context) {
                 .enqueue(object : TestpressCallback<Attempt>() {
                     override fun onSuccess(response: Attempt) {
                         _endAttemptResource.postValue(Resource.success(response))
-                        CoroutineScope(Dispatchers.IO).launch {
-                            offlineExamDao.updateCompletedAttemptCount(exam!!.id, 1L)
+                        // Custom Test does not contain an exam object. If the exam is null, we ignore updating the attempt count.
+                        exam?.let {
+                            CoroutineScope(Dispatchers.IO).launch {
+                                offlineExamDao.updateCompletedAttemptCount(exam!!.id, 1L)
+                            }
                         }
                     }
 

--- a/exam/src/main/java/in/testpress/exam/repository/AttemptRepository.kt
+++ b/exam/src/main/java/in/testpress/exam/repository/AttemptRepository.kt
@@ -308,9 +308,7 @@ class AttemptRepository(val context: Context) {
                 .enqueue(object : TestpressCallback<CourseAttempt>() {
                     override fun onSuccess(result: CourseAttempt) {
                         _endContentAttemptResource.postValue(Resource.success(result))
-                        CoroutineScope(Dispatchers.IO).launch {
-                            offlineExamDao.updateCompletedAttemptCount(exam!!.id, 1L)
-                        }
+                        updateCompletedAttemptCount()
                     }
 
                     override fun onException(exception: TestpressException) {
@@ -338,18 +336,23 @@ class AttemptRepository(val context: Context) {
                 .enqueue(object : TestpressCallback<Attempt>() {
                     override fun onSuccess(response: Attempt) {
                         _endAttemptResource.postValue(Resource.success(response))
-                        // Custom Test does not contain an exam object. If the exam is null, we ignore updating the attempt count.
-                        exam?.let {
-                            CoroutineScope(Dispatchers.IO).launch {
-                                offlineExamDao.updateCompletedAttemptCount(exam!!.id, 1L)
-                            }
-                        }
+                        updateCompletedAttemptCount()
                     }
 
                     override fun onException(exception: TestpressException) {
                         _endAttemptResource.postValue(Resource.error(exception, null))
                     }
                 })
+        }
+    }
+
+    private fun updateCompletedAttemptCount() {
+        exam?.let { exam ->
+            CoroutineScope(Dispatchers.IO).launch {
+                offlineExamDao.getById(exam.id)?.let {
+                    offlineExamDao.updateCompletedAttemptCount(exam.id, 1L)
+                }
+            }
         }
     }
 


### PR DESCRIPTION
- When the user ends the exam, we update the offline exam attempt count to sync the attempt count.
- For custom tests, the same process occurs, but the exam object is null. Without the exam object, we can't update the offline exam attempt count, leading to a crash.
- In this commit, we ensure the offline attempt count is updated only if the exam is downloaded offline.