### PR TITLE
fix: Test Report details are showing zero

### DIFF
--- a/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
@@ -1157,6 +1157,7 @@ public class TestFragment extends BaseFragment implements
             public void onChanged(Resource<CourseAttempt> courseAttemptResource) {
                 switch (courseAttemptResource.getStatus()){
                     case SUCCESS:{
+                        courseAttempt = courseAttemptResource.getData();
                         if (getActivity() == null) {
                             return;
                         }
@@ -1200,6 +1201,7 @@ public class TestFragment extends BaseFragment implements
             public void onChanged(Resource<Attempt> attemptResource) {
                 switch (attemptResource.getStatus()){
                     case SUCCESS:{
+                        attempt = attemptResource.getData();
                         if (getActivity() == null) {
                             return;
                         }
@@ -1211,7 +1213,6 @@ public class TestFragment extends BaseFragment implements
                             returnToHistory();
                             return;
                         }
-                        TestFragment.this.attempt = attempt;
                         showReview(attempt);
                         break;
                     }


### PR DESCRIPTION
- In commit 1d43aa6, we added a Repository pattern to end the attempt. After ending the attempt, the response value was not being updated, which caused the test results to show zero.
- This commit ensures the response value is updated correctly to display the test results.