### PR TITLE
fix: User can take the exam even if retake is disabled

### DIFF
--- a/course/src/main/java/in/testpress/course/fragments/AttemptsListFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/AttemptsListFragment.kt
@@ -1,10 +1,12 @@
 package `in`.testpress.course.fragments
 
+import `in`.testpress.core.TestpressSdk
 import `in`.testpress.course.R
 import `in`.testpress.course.domain.getGreenDaoContent
 import `in`.testpress.course.domain.getGreenDaoContentAttempts
 import `in`.testpress.course.ui.ContentActivity
 import `in`.testpress.course.ui.ContentAttemptListAdapter
+import `in`.testpress.util.ViewUtils
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -27,6 +29,10 @@ open class AttemptsListFragment : BaseExamWidgetFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         attemptList = view.findViewById(R.id.attempt_list)
+        ViewUtils.setTypeface(
+            arrayOf(attemptSyncText),
+            TestpressSdk.getRubikRegularFont(requireActivity())
+        )
     }
 
     override fun display() {

--- a/course/src/main/java/in/testpress/course/fragments/BaseExamWidgetFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/BaseExamWidgetFragment.kt
@@ -214,7 +214,7 @@ open class BaseExamWidgetFragment : Fragment() {
 
     private fun hideExamStartButtonsIsAttemptAlreadySynced() {
         offlineExam?.let {
-            if (it.allowRetake == false && it.attemptsCount == 1){
+            if (it.allowRetake == false && it.attemptsCount == 1) {
                 // Show a message when the user has no internet connection
                 startExamOffline.isVisible = false
                 startButton.isVisible = false

--- a/course/src/main/java/in/testpress/course/fragments/BaseExamWidgetFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/BaseExamWidgetFragment.kt
@@ -35,6 +35,7 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import android.widget.Button
+import android.widget.TextView
 import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
 import androidx.core.view.isVisible
@@ -52,6 +53,7 @@ open class BaseExamWidgetFragment : Fragment() {
     lateinit var downloadExam: Button
     lateinit var startExamOffline: Button
     lateinit var resumeExamOffline: Button
+    lateinit var attemptSyncText: TextView
     protected lateinit var viewModel: ExamContentViewModel
     protected lateinit var content: DomainContent
     protected var contentId: Long = -1
@@ -63,6 +65,7 @@ open class BaseExamWidgetFragment : Fragment() {
     var offlineContentAttempt: OfflineCourseAttempt? = null
     var offlineAttemptSectionList: List<OfflineAttemptSection>? = null
     private var isOfflineExamSupportEnables = false
+    var offlineAttemptUploaded = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -93,6 +96,7 @@ open class BaseExamWidgetFragment : Fragment() {
         downloadExam = view.findViewById(R.id.download_exam)
         startExamOffline = view.findViewById(R.id.start_exam_offline)
         resumeExamOffline = view.findViewById(R.id.resume_exam_offline)
+        attemptSyncText = view.findViewById(R.id.attempt_sync_message)
         contentId = requireArguments().getLong(ContentActivity.CONTENT_ID)
 
         viewModel.getContent(contentId).observe(viewLifecycleOwner, Observer {
@@ -114,7 +118,7 @@ open class BaseExamWidgetFragment : Fragment() {
 
     protected fun initializeObserversForOfflineDownload() {
         offlineExamViewModel.syncCompletedAttempt(content.examId!!)
-        offlineExamViewModel.get(contentId).observe(requireActivity()) { offlineExam ->
+        offlineExamViewModel.get(contentId).observe(viewLifecycleOwner) { offlineExam ->
             this.offlineExam = offlineExam
             if (content.exam?.allowRetake == false && (offlineExam?.offlinePausedAttemptsCount ?: 0) > 0){
                 startButton.isVisible = false
@@ -138,7 +142,7 @@ open class BaseExamWidgetFragment : Fragment() {
             }
         }
 
-        offlineExamViewModel.downloadExamResult.observe(requireActivity()) { it ->
+        offlineExamViewModel.downloadExamResult.observe(viewLifecycleOwner) { it ->
             when (it.status){
                 Status.SUCCESS -> {}
                 Status.LOADING -> {}
@@ -149,16 +153,29 @@ open class BaseExamWidgetFragment : Fragment() {
                 else -> {}
             }
         }
-        offlineExamViewModel.offlineAttemptSyncResult.observe(requireActivity()) { it ->
+        offlineExamViewModel.offlineAttemptSyncResult.observe(viewLifecycleOwner) { it ->
             when (it.status){
                 Status.SUCCESS -> {
                     if (!this.isAdded) return@observe
-                    Toast.makeText(requireContext(),"Answers submitted successfully. Results will be available shortly.",Toast.LENGTH_SHORT).show()
+                    offlineAttemptUploaded = true
+                    hideExamStartButtonsIsAttemptAlreadySynced()
                 }
-                Status.LOADING -> {}
+                Status.LOADING -> {
+                    startExamOffline.isVisible = false
+                    startButton.isVisible = false
+                }
                 Status.ERROR -> {
                     if (!this.isAdded) return@observe
-                    Toast.makeText(requireContext(),"Please connect to the internet to view your results.",Toast.LENGTH_SHORT).show()
+                    offlineExam?.let {
+                        if (it.allowRetake == false && it.attemptsCount == 1 && !offlineAttemptUploaded) {
+                            startExamOffline.isVisible = false
+                            startButton.isVisible = false
+                            attemptSyncText.setText(R.string.offline_answers_no_network_message)
+                            attemptSyncText.isVisible = true
+                        } else {
+                            attemptSyncText.isVisible = false
+                        }
+                    }
                 }
                 else -> {}
             }
@@ -191,6 +208,25 @@ open class BaseExamWidgetFragment : Fragment() {
         } else {
             startExamOffline.isVisible = false
             resumeExamOffline.isVisible = true
+        }
+        hideExamStartButtonsIsAttemptAlreadySynced()
+    }
+
+    private fun hideExamStartButtonsIsAttemptAlreadySynced() {
+        offlineExam?.let {
+            if (it.allowRetake == false && it.attemptsCount == 1){
+                startExamOffline.isVisible = false
+                startButton.isVisible = false
+                attemptSyncText.setText(R.string.offline_answers_no_network_message)
+                attemptSyncText.isVisible = true
+            } else if (it.allowRetake == false && offlineAttemptUploaded) {
+                startExamOffline.isVisible = false
+                startButton.isVisible = false
+                attemptSyncText.setText(R.string.offline_answers_submitted_message)
+                attemptSyncText.isVisible = true
+            } else {
+                attemptSyncText.isVisible = false
+            }
         }
     }
 

--- a/course/src/main/java/in/testpress/course/fragments/BaseExamWidgetFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/BaseExamWidgetFragment.kt
@@ -215,11 +215,13 @@ open class BaseExamWidgetFragment : Fragment() {
     private fun hideExamStartButtonsIsAttemptAlreadySynced() {
         offlineExam?.let {
             if (it.allowRetake == false && it.attemptsCount == 1){
+                // Show a message when the user has no internet connection
                 startExamOffline.isVisible = false
                 startButton.isVisible = false
                 attemptSyncText.setText(R.string.offline_answers_no_network_message)
                 attemptSyncText.isVisible = true
             } else if (it.allowRetake == false && offlineAttemptUploaded) {
+                // Show a message when the attempt has already been synced
                 startExamOffline.isVisible = false
                 startButton.isVisible = false
                 attemptSyncText.setText(R.string.offline_answers_submitted_message)

--- a/course/src/main/java/in/testpress/course/fragments/ExamStartScreenFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/ExamStartScreenFragment.kt
@@ -86,7 +86,8 @@ class ExamStartScreenFragment : BaseExamWidgetFragment() {
                 durationLabel,
                 markLabel,
                 negativeMarkLabel,
-                dateLabel
+                dateLabel,
+                attemptSyncText
             ),
             TestpressSdk.getRubikRegularFont(requireActivity())
         )

--- a/course/src/main/java/in/testpress/course/repository/OfflineExamRepository.kt
+++ b/course/src/main/java/in/testpress/course/repository/OfflineExamRepository.kt
@@ -339,6 +339,7 @@ class OfflineExamRepository(val context: Context) {
 
     private suspend fun updateCompletedAttempts(completedOfflineAttempts: List<OfflineAttempt>){
         if(completedOfflineAttempts.isEmpty()) return
+        _offlineAttemptSyncResult.postValue(Resource.loading(null))
         val totalAttempts = completedOfflineAttempts.size
         var currentAttemptSize = 0
         completedOfflineAttempts.forEach { completedOfflineAttempt ->

--- a/course/src/main/res/layout/attempts_list_view.xml
+++ b/course/src/main/res/layout/attempts_list_view.xml
@@ -77,6 +77,20 @@
             android:textColor="@android:color/white"
             android:textSize="16sp" />
 
+        <TextView
+            android:id="@+id/attempt_sync_message"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="30dp"
+            android:visibility="gone"
+            android:textAlignment="center"
+            android:layout_gravity="center"
+            android:gravity="center"
+            android:textColor="@color/testpress_black"
+            android:textSize="@dimen/testpress_text_size_medium"
+            android:textStyle="normal"
+            android:text="@string/offline_answers_submitted_message" />
+
     </LinearLayout>
 
 </LinearLayout>

--- a/course/src/main/res/layout/exam_start_screen.xml
+++ b/course/src/main/res/layout/exam_start_screen.xml
@@ -73,6 +73,19 @@
             android:textColor="@android:color/white"
             android:textSize="16sp" />
 
+        <TextView
+            android:id="@+id/attempt_sync_message"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:visibility="gone"
+            android:textAlignment="center"
+            android:layout_gravity="center"
+            android:gravity="center"
+            android:textColor="@color/testpress_black"
+            android:textSize="@dimen/testpress_text_size_medium"
+            android:textStyle="normal"
+            android:text="@string/offline_answers_submitted_message" />
+
     </LinearLayout>
 
 </LinearLayout>

--- a/course/src/main/res/layout/quiz_start_screen.xml
+++ b/course/src/main/res/layout/quiz_start_screen.xml
@@ -77,5 +77,18 @@
             android:textColor="@android:color/white"
             android:textSize="16sp" />
 
+        <TextView
+            android:id="@+id/attempt_sync_message"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:visibility="gone"
+            android:textAlignment="center"
+            android:layout_gravity="center"
+            android:gravity="center"
+            android:textColor="@color/testpress_black"
+            android:textSize="@dimen/testpress_text_size_medium"
+            android:textStyle="normal"
+            android:text="@string/offline_answers_submitted_message" />
+
     </LinearLayout>
 </LinearLayout>

--- a/course/src/main/res/values/strings.xml
+++ b/course/src/main/res/values/strings.xml
@@ -88,7 +88,7 @@
     <string name="custom_test_unknown_error">Something went wrong, Please try again later</string>
 
     <string name="offline_answers_submitted_message">Your offline answers have been successfully submitted. Swipe down to refresh this page and view your results.</string>
-    <string name="offline_answers_no_network_message">Please connect to the internet to submit your answers.</string>
+    <string name="offline_answers_no_network_message">Please connect to the internet and refresh this page to submit your answers.</string>
 
     <string-array name="exo_speed_values">
         <item>0.5</item>

--- a/course/src/main/res/values/strings.xml
+++ b/course/src/main/res/values/strings.xml
@@ -87,6 +87,9 @@
     <string name="custom_test_page_not_found_error">Exam is no longer available, Create a new exam</string>
     <string name="custom_test_unknown_error">Something went wrong, Please try again later</string>
 
+    <string name="offline_answers_submitted_message">Your offline answers have been successfully submitted. Swipe down to refresh this page and view your results.</string>
+    <string name="offline_answers_no_network_message">Please connect to the internet to submit your answers.</string>
+
     <string-array name="exo_speed_values">
         <item>0.5</item>
         <item>0.75</item>


### PR DESCRIPTION
- Previously, after a user completed an offline exam, we navigated them to the exam detail screen, synced the attempt, and displayed a success toast. However, the Exam Start button remained visible, allowing users to attempt the exam offline again.
- In this commit, we removed the success toast, added a message, and hid the buttons once the exam is completed. If there is no network to sync the attempt, we display a network error message instead.