### PR TITLE
fix: App crash on downloading the video on Android 14

### DIFF
--- a/course/src/main/AndroidManifest.xml
+++ b/course/src/main/AndroidManifest.xml
@@ -10,6 +10,7 @@
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
     <uses-permission android:name="android.permission.VIBRATE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC"/>
 
     <uses-sdk tools:overrideLibrary="us.zoom.androidlib,us.zoom.videomeetings" />
 
@@ -111,7 +112,8 @@
 
         <service
             android:name=".services.VideoDownloadService"
-            android:exported="false">
+            android:exported="false"
+            android:foregroundServiceType="dataSync">
             <intent-filter>
                 <action android:name="com.google.android.exoplayer.downloadService.action.RESTART" />
                 <category android:name="android.intent.category.DEFAULT" />

--- a/samples/build.gradle
+++ b/samples/build.gradle
@@ -18,7 +18,7 @@ android {
             storePassword "sample"
         }
     }
-    compileSdkVersion rootProject.compileSdkVersion
+    compileSdkVersion 34
     buildToolsVersion rootProject.buildToolsVersion
     defaultConfig {
         multiDexEnabled true
@@ -30,7 +30,7 @@ android {
         } else {
             minSdkVersion rootProject.minSdkVersion
         }
-        targetSdkVersion rootProject.targetSdkVersion
+        targetSdkVersion 34
         versionCode 1
         versionName "1.0"
     }


### PR DESCRIPTION
- The app crashes when downloading a video on Android 14 because, if the app targets Android 14, it must specify appropriate foreground service types.
- This commit addresses the issue by specifying the required foreground service types. [Foreground service types are required](https://developer.android.com/about/versions/14/changes/fgs-types-required), [Data sync](https://developer.android.com/about/versions/14/changes/fgs-types-required#data-sync).