### PR TITLE
fix: Build fails due to deprecated dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,15 +21,11 @@ allprojects {
 
     repositories {
         google()
-        jcenter() {
-            content {
-                includeModule("com.google.android", "flexbox")
-                includeModule("com.theartofdev.edmodo", "android-image-cropper")
-            }
-        }
+        jcenter()
         mavenCentral()
         maven { url "https://jitpack.io" }
         maven {url "https://phonepe.mycloudrepo.io/public/repositories/phonepe-intentsdk-android"}
+        maven { url "https://github.com/testpress/Android-Image-Cropper/raw/main" }
     }
 }
 
@@ -67,7 +63,7 @@ ext {
     universalImageLoader = 'com.nostra13.universalimageloader:universal-image-loader:1.9.5'
     chart = 'com.github.testpress:MPAndroidChart:v3.0.0-beta2'
     greendao = 'org.greenrobot:greendao:3.2.0'
-    imageCropper = 'com.theartofdev.edmodo:android-image-cropper:2.7.0'
+    imageCropper = 'com.theartofdev.edmodo:android-image-cropper:2.8.0'
     lottie = 'com.airbnb.android:lottie:2.5.4'
     roboelectric = "org.robolectric:robolectric:4.3.1"
     androidxCore = 'androidx.test:core:1.4.0'

--- a/mobilertc/build.gradle
+++ b/mobilertc/build.gradle
@@ -10,7 +10,7 @@ dependencies.add("default","androidx.swiperefreshlayout:swiperefreshlayout:1.1.0
 dependencies.add("default","androidx.appcompat:appcompat:1.3.1")
 dependencies.add("default","androidx.constraintlayout:constraintlayout:2.1.0")
 dependencies.add("default","com.google.android.material:material:1.8.0")
-dependencies.add("default","com.google.android:flexbox:2.0.1")
+dependencies.add("default","com.google.android.flexbox:flexbox:3.0.0")
 dependencies.add("default","androidx.multidex:multidex:2.0.1")
 dependencies.add("default","com.google.code.gson:gson:2.9.1")
 dependencies.add("default","com.github.bumptech.glide:annotations:4.11.0")


### PR DESCRIPTION
- Resolved build failure by addressing issues with deprecated dependencies.
- The `com.theartofdev.edmodo:android-image-cropper:2.8.0` package, which is no longer maintained and removed from repositories, has been temporarily published to our GitHub account and used in the project to resolve the issue.
- Updated the `com.google.android:flexbox:2.0.1` package, which has been removed and replaced with `com.google.android.flexbox:flexbox:3.0.0` in the latest version. This update was applied in the mobilertc `build.gradle` file, following Zoom's suggested changes. More details can be found on the Zoom community issue [here](https://devforum.zoom.us/t/could-not-resolve-com-google-android2-0-1-for-zoom-sdk-android-5-17-11-20433/115918).