### PR TITLE
fix: Unable to take screenshots even with prevent screenshots disabled in the portal.

### DIFF
--- a/course/src/main/java/in/testpress/course/util/ExoPlayerUtil.java
+++ b/course/src/main/java/in/testpress/course/util/ExoPlayerUtil.java
@@ -223,8 +223,15 @@ public class ExoPlayerUtil implements VideoTimeRangeListener, DrmSessionManagerP
         if(isLandscapeModeEnabled()){
             openFullscreenDialog();
         }
-        activity.getWindow().setFlags(FLAG_SECURE, FLAG_SECURE);
+        preventScreenshot();
         hideLiveStreamNotStartedScreen();
+    }
+
+    private void preventScreenshot() {
+        TestpressSession session = TestpressSdk.getTestpressSession(activity);
+        if (session != null && session.getInstituteSettings().isScreenshotDisabled()) {
+            activity.getWindow().setFlags(FLAG_SECURE, FLAG_SECURE);
+        }
     }
 
     private boolean isLandscapeModeEnabled() {


### PR DESCRIPTION
- Previously, the secure window was applied to all video content by default, preventing screenshots regardless of the institute settings.
- In this commit, we modified the behavior to enable or disable the secure window based on the `ScreenshotDisabled` field in the `InstituteSettings` model.