### PR TITLE
enhancement: Add option to open non-institute URLs with authentication enabled

### DIFF
--- a/core/src/main/java/in/testpress/ui/AbstractWebViewActivity.kt
+++ b/core/src/main/java/in/testpress/ui/AbstractWebViewActivity.kt
@@ -15,7 +15,7 @@ abstract class AbstractWebViewActivity: BaseToolBarActivity(), WebViewFragment.L
     private lateinit var title: String
     private lateinit var urlPath: String
     private var isAuthenticationRequired: Boolean = true
-    private var allowNonInstituteUrl: Boolean = !isAuthenticationRequired
+    private var allowNonInstituteUrl: Boolean = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -38,7 +38,7 @@ abstract class AbstractWebViewActivity: BaseToolBarActivity(), WebViewFragment.L
         title = intent.getStringExtra(TITLE)!!
         urlPath = intent.getStringExtra(URL_TO_OPEN)!!
         isAuthenticationRequired = intent.getBooleanExtra(IS_AUTHENTICATION_REQUIRED,true)
-        allowNonInstituteUrl = intent.getBooleanExtra(ALLOW_NON_INSTITUTE_URL_IN_WEB_VIEW, !isAuthenticationRequired)
+        allowNonInstituteUrl = intent.getBooleanExtra(ALLOW_NON_INSTITUTE_URL_IN_WEB_VIEW, false)
     }
 
     private fun initializeWebViewFragment() {
@@ -71,31 +71,14 @@ abstract class AbstractWebViewActivity: BaseToolBarActivity(), WebViewFragment.L
             title: String,
             urlPath: String,
             isAuthenticationRequired: Boolean,
-            activityToOpen: Class<out AbstractWebViewActivity>
-        ): Intent {
-            return createIntent(
-                currentContext,
-                title,
-                urlPath,
-                isAuthenticationRequired,
-                false,
-                activityToOpen
-            )
-        }
-
-        fun createIntent(
-            currentContext: Context,
-            title: String,
-            urlPath: String,
-            isAuthenticationRequired: Boolean,
-            allow_non_institute_url: Boolean,
+            allowNonInstituteUrl: Boolean = false,
             activityToOpen: Class<out AbstractWebViewActivity>
         ): Intent {
             return Intent(currentContext, activityToOpen).apply {
                 putExtra(TITLE, title)
                 putExtra(URL_TO_OPEN, urlPath)
                 putExtra(IS_AUTHENTICATION_REQUIRED, isAuthenticationRequired)
-                putExtra(ALLOW_NON_INSTITUTE_URL_IN_WEB_VIEW, allow_non_institute_url)
+                putExtra(ALLOW_NON_INSTITUTE_URL_IN_WEB_VIEW, allowNonInstituteUrl)
             }
         }
     }

--- a/core/src/main/java/in/testpress/ui/AbstractWebViewActivity.kt
+++ b/core/src/main/java/in/testpress/ui/AbstractWebViewActivity.kt
@@ -15,6 +15,7 @@ abstract class AbstractWebViewActivity: BaseToolBarActivity(), WebViewFragment.L
     private lateinit var title: String
     private lateinit var urlPath: String
     private var isAuthenticationRequired: Boolean = true
+    private var allowNonInstituteUrl: Boolean = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -37,6 +38,7 @@ abstract class AbstractWebViewActivity: BaseToolBarActivity(), WebViewFragment.L
         title = intent.getStringExtra(TITLE)!!
         urlPath = intent.getStringExtra(URL_TO_OPEN)!!
         isAuthenticationRequired = intent.getBooleanExtra(IS_AUTHENTICATION_REQUIRED,true)
+        allowNonInstituteUrl = intent.getBooleanExtra(IS_AUTHENTICATION_REQUIRED,false)
     }
 
     private fun initializeWebViewFragment() {
@@ -51,13 +53,8 @@ abstract class AbstractWebViewActivity: BaseToolBarActivity(), WebViewFragment.L
     private fun getWebViewArguments(): Bundle {
         return Bundle().apply {
             this.putString(WebViewFragment.URL_TO_OPEN, urlPath)
-            if (isAuthenticationRequired) {
-                this.putBoolean(WebViewFragment.IS_AUTHENTICATION_REQUIRED, true)
-                this.putBoolean(WebViewFragment.ALLOW_NON_INSTITUTE_URL_IN_WEB_VIEW, false)
-            } else {
-                this.putBoolean(WebViewFragment.IS_AUTHENTICATION_REQUIRED, false)
-                this.putBoolean(WebViewFragment.ALLOW_NON_INSTITUTE_URL_IN_WEB_VIEW, true)
-            }
+            this.putBoolean(WebViewFragment.IS_AUTHENTICATION_REQUIRED, isAuthenticationRequired)
+            this.putBoolean(WebViewFragment.ALLOW_NON_INSTITUTE_URL_IN_WEB_VIEW, allowNonInstituteUrl)
         }
     }
 
@@ -67,6 +64,7 @@ abstract class AbstractWebViewActivity: BaseToolBarActivity(), WebViewFragment.L
         const val TITLE = "TITLE"
         const val URL_TO_OPEN = "URL"
         const val IS_AUTHENTICATION_REQUIRED = "IS_AUTHENTICATION_REQUIRED"
+        const val ALLOW_NON_INSTITUTE_URL_IN_WEB_VIEW = "ALLOW_NON_INSTITUTE_URL_IN_WEB_VIEW"
 
         fun createIntent(
             currentContext: Context,
@@ -75,10 +73,29 @@ abstract class AbstractWebViewActivity: BaseToolBarActivity(), WebViewFragment.L
             isAuthenticationRequired: Boolean,
             activityToOpen: Class<out AbstractWebViewActivity>
         ): Intent {
+            return createIntent(
+                currentContext,
+                title,
+                urlPath,
+                isAuthenticationRequired,
+                false,
+                activityToOpen
+            )
+        }
+
+        fun createIntent(
+            currentContext: Context,
+            title: String,
+            urlPath: String,
+            isAuthenticationRequired: Boolean,
+            allow_non_institute_url: Boolean,
+            activityToOpen: Class<out AbstractWebViewActivity>
+        ): Intent {
             return Intent(currentContext, activityToOpen).apply {
                 putExtra(TITLE, title)
                 putExtra(URL_TO_OPEN, urlPath)
                 putExtra(IS_AUTHENTICATION_REQUIRED, isAuthenticationRequired)
+                putExtra(ALLOW_NON_INSTITUTE_URL_IN_WEB_VIEW, allow_non_institute_url)
             }
         }
     }

--- a/core/src/main/java/in/testpress/ui/AbstractWebViewActivity.kt
+++ b/core/src/main/java/in/testpress/ui/AbstractWebViewActivity.kt
@@ -38,7 +38,7 @@ abstract class AbstractWebViewActivity: BaseToolBarActivity(), WebViewFragment.L
         title = intent.getStringExtra(TITLE)!!
         urlPath = intent.getStringExtra(URL_TO_OPEN)!!
         isAuthenticationRequired = intent.getBooleanExtra(IS_AUTHENTICATION_REQUIRED,true)
-        allowNonInstituteUrl = intent.getBooleanExtra(IS_AUTHENTICATION_REQUIRED,false)
+        allowNonInstituteUrl = intent.getBooleanExtra(ALLOW_NON_INSTITUTE_URL_IN_WEB_VIEW, !isAuthenticationRequired)
     }
 
     private fun initializeWebViewFragment() {

--- a/core/src/main/java/in/testpress/ui/AbstractWebViewActivity.kt
+++ b/core/src/main/java/in/testpress/ui/AbstractWebViewActivity.kt
@@ -15,7 +15,7 @@ abstract class AbstractWebViewActivity: BaseToolBarActivity(), WebViewFragment.L
     private lateinit var title: String
     private lateinit var urlPath: String
     private var isAuthenticationRequired: Boolean = true
-    private var allowNonInstituteUrl: Boolean = false
+    private var allowNonInstituteUrl: Boolean = !isAuthenticationRequired
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/course/src/main/java/in/testpress/course/ui/ChaptersListFragment.java
+++ b/course/src/main/java/in/testpress/course/ui/ChaptersListFragment.java
@@ -248,6 +248,7 @@ public class ChaptersListFragment extends BaseDataBaseFragment<Chapter, Long> {
                         "Custom Module",
                         instituteSettings.getDomainUrl()+"/courses/custom_test_generation/?course_id="+courseId+"&testpress_app=android",
                         true,
+                        false,
                         CustomTestGenerationActivity.class
                 )
         );

--- a/course/src/main/java/in/testpress/course/ui/MyCoursesFragment.java
+++ b/course/src/main/java/in/testpress/course/ui/MyCoursesFragment.java
@@ -183,6 +183,7 @@ public class MyCoursesFragment extends BaseDataBaseFragment<Course, Long> {
                         "Custom Module",
                         instituteSettings.getDomainUrl()+"/courses/custom_test_generation/?"+constrictQueryParamForAvailableCourses()+"&testpress_app=android",
                         true,
+                        false,
                         CustomTestGenerationActivity.class
                 )
         );

--- a/exam/src/main/java/in/testpress/exam/ui/ReviewQuestionsFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/ReviewQuestionsFragment.java
@@ -817,6 +817,7 @@ public class ReviewQuestionsFragment extends Fragment {
                                     "PDF Preview",
                                     url,
                                     false,
+                                    true,
                                     WebViewWithSSOActivity.class
                             )
                     );

--- a/samples/src/main/java/in/testpress/samples/course/CourseSampleActivity.java
+++ b/samples/src/main/java/in/testpress/samples/course/CourseSampleActivity.java
@@ -264,6 +264,7 @@ public class CourseSampleActivity extends BaseToolBarActivity {
                         "Test WebView",
                         session.getInstituteSettings().getDomainUrl() + urlPath,
                         true,
+                        false,
                         WebViewWithSSOActivity.class
                 )
         );
@@ -289,6 +290,7 @@ public class CourseSampleActivity extends BaseToolBarActivity {
                                                         "Custom Module",
                                                         session.getInstituteSettings().getDomainUrl()+"/courses/custom_test_generation/?course_id="+inputText+"&testpress_app=android",
                                                         true,
+                                                        false,
                                                         CustomTestGenerationActivity.class
                                                 )
                                         );


### PR DESCRIPTION
- This update allows external URLs (non-institute URLs) to be opened in the webview while keeping authentication enabled.
- This change is needed because the Catking app uses external URLs that require secure access with authentication.