### PR TITLE
fix: Add validation for WebView errors

### DIFF
--- a/core/src/main/java/in/testpress/util/webview/CustomWebViewClient.kt
+++ b/core/src/main/java/in/testpress/util/webview/CustomWebViewClient.kt
@@ -50,7 +50,11 @@ class CustomWebViewClient(val fragment: WebViewFragment) : WebViewClient() {
         request: WebResourceRequest?,
         error: WebResourceError?
     ) {
-        fragment.showErrorView(TestpressException.unexpectedError(Exception("WebView error")))
+        val requestUrl = request?.url.toString()
+        val currentWebViewUrl = fragment.webView.url.toString()
+        if (requestUrl == currentWebViewUrl) {
+            fragment.showErrorView(TestpressException.unexpectedError(Exception("WebView error")))
+        }
     }
 
     override fun onReceivedHttpError(


### PR DESCRIPTION
- Previously, errors were displayed for every error that occurred within the WebView, including errors from loading static image URLs and other resources.
- In this commit, we added validation to selectively display errors in the WebView, ensuring that only relevant errors are shown to users.
- This commit does not handle error display for failures related to static image URLs or other non-critical resources.