### PR TITLE
fix: Unable to upload files in File type questions on Android 13 and higher

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,9 +34,9 @@ task clean(type: Delete) {
 }
 
 ext {
-    compileSdkVersion = 33
+    compileSdkVersion = 34
     minSdkVersion = 23
-    targetSdkVersion = 33
+    targetSdkVersion = 34
     minSdkVersionForUITest = 23
     buildToolsVersion = '30.0.3'
     supportLib = '27.1.1'

--- a/core/src/main/java/in/testpress/util/Misc.kt
+++ b/core/src/main/java/in/testpress/util/Misc.kt
@@ -2,7 +2,6 @@ package `in`.testpress.util
 
 import android.content.Context
 import android.net.ConnectivityManager
-import android.os.Build
 import java.net.URL
 import java.util.*
 import android.webkit.MimeTypeMap
@@ -37,6 +36,4 @@ object Misc {
         }
         return type
     }
-
-    fun isAndroid13OrHigher() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
 }

--- a/core/src/main/java/in/testpress/util/extension/Activity.kt
+++ b/core/src/main/java/in/testpress/util/extension/Activity.kt
@@ -1,12 +1,20 @@
 package `in`.testpress.util.extension
 
+import android.Manifest
 import `in`.testpress.RequestCode
 import `in`.testpress.util.Permission
 import `in`.testpress.util.PermissionHandler
 import android.app.Activity
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.os.Build
+import android.provider.Settings
 import android.widget.Toast
 import androidx.annotation.StringRes
 import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
+import com.google.android.material.snackbar.Snackbar
 
 fun Activity.askAllPermissions() {
     val requiredPermission =
@@ -23,4 +31,83 @@ fun Activity.performActionIfPermissionsGranted(
 
 fun Activity.toast(@StringRes resId: Int) {
     Toast.makeText(this, resId, Toast.LENGTH_SHORT).show()
+}
+
+fun Activity.isStoragePermissionGranted(): Boolean {
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+        ContextCompat.checkSelfPermission(this, Manifest.permission.READ_MEDIA_IMAGES) == PackageManager.PERMISSION_GRANTED &&
+                ContextCompat.checkSelfPermission(this, Manifest.permission.READ_MEDIA_VIDEO) == PackageManager.PERMISSION_GRANTED &&
+                ContextCompat.checkSelfPermission(this, Manifest.permission.READ_MEDIA_VISUAL_USER_SELECTED) == PackageManager.PERMISSION_GRANTED
+    } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        ContextCompat.checkSelfPermission(this, Manifest.permission.READ_MEDIA_IMAGES) == PackageManager.PERMISSION_GRANTED &&
+                ContextCompat.checkSelfPermission(this, Manifest.permission.READ_MEDIA_VIDEO) == PackageManager.PERMISSION_GRANTED
+    } else {
+        ContextCompat.checkSelfPermission(this, Manifest.permission.READ_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED
+    }
+}
+
+fun Activity.askStoragePermission(message: String) {
+    if (isStoragePermissionGranted()) return
+    if (shouldShowRequestPermissionRationale()) {
+        requestStoragePermission()
+    } else {
+        Snackbar.make(
+            this.findViewById(android.R.id.content),
+            message,
+            Snackbar.LENGTH_LONG
+        )
+            .setAction("Allow") {
+                goToSettings()
+            }.show()
+    }
+}
+
+fun Activity.requestStoragePermission() {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+        ActivityCompat.requestPermissions(
+            this, arrayOf(
+                Manifest.permission.READ_MEDIA_IMAGES,
+                Manifest.permission.READ_MEDIA_VIDEO,
+                Manifest.permission.READ_MEDIA_VISUAL_USER_SELECTED
+            ), RequestCode.PERMISSION
+        )
+    } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        ActivityCompat.requestPermissions(
+            this, arrayOf(
+                Manifest.permission.READ_MEDIA_IMAGES,
+                Manifest.permission.READ_MEDIA_VIDEO
+            ), RequestCode.PERMISSION
+        )
+    } else {
+        ActivityCompat.requestPermissions(
+            this, arrayOf(
+                Manifest.permission.READ_EXTERNAL_STORAGE
+            ), RequestCode.PERMISSION
+        )
+    }
+}
+
+private fun Activity.shouldShowRequestPermissionRationale(): Boolean {
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+        shouldShowRequestPermissionRationale(Manifest.permission.READ_MEDIA_IMAGES) &&
+                shouldShowRequestPermissionRationale(Manifest.permission.READ_MEDIA_VIDEO) &&
+                shouldShowRequestPermissionRationale(Manifest.permission.READ_MEDIA_VISUAL_USER_SELECTED)
+    } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        shouldShowRequestPermissionRationale(Manifest.permission.READ_MEDIA_IMAGES) &&
+                shouldShowRequestPermissionRationale(Manifest.permission.READ_MEDIA_VIDEO)
+    } else {
+        shouldShowRequestPermissionRationale(Manifest.permission.READ_EXTERNAL_STORAGE)
+    }
+}
+
+private fun Activity.goToSettings() {
+    Intent(
+        Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
+        Uri.parse("package:$packageName")
+    ).apply {
+        addCategory(Intent.CATEGORY_DEFAULT)
+        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+    }.also {
+        startActivity(it)
+    }
 }

--- a/exam/src/main/AndroidManifest.xml
+++ b/exam/src/main/AndroidManifest.xml
@@ -1,8 +1,18 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="in.testpress.exam">
 
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+
+    <!-- Devices running Android 12L (API level 32) or lower  -->
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
+
+    <!-- Devices running Android 13 (API level 33) or higher -->
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
+
+    <!-- To handle the reselection within the app on devices running Android 14
+         or higher if your app targets Android 14 (API level 34) or higher.  -->
+    <uses-permission android:name="android.permission.READ_MEDIA_VISUAL_USER_SELECTED" />
 
     <application
         android:allowBackup="true"

--- a/exam/src/main/java/in/testpress/exam/ui/TestQuestionFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestQuestionFragment.java
@@ -46,13 +46,11 @@ import in.testpress.models.FileDetails;
 import in.testpress.models.InstituteSettings;
 import in.testpress.models.greendao.Exam;
 import in.testpress.models.greendao.Language;
-import in.testpress.util.Misc;
-import in.testpress.util.PermissionHandler;
 import in.testpress.util.ProgressDialog;
 import in.testpress.util.WebViewUtils;
+import in.testpress.util.extension.ActivityKt;
 import pub.devrel.easypermissions.AppSettingsDialog;
 import pub.devrel.easypermissions.EasyPermissions;
-import pub.devrel.easypermissions.PermissionRequest;
 
 public class TestQuestionFragment extends Fragment implements PickiTCallbacks, EasyPermissions.PermissionCallbacks {
 
@@ -347,25 +345,10 @@ public class TestQuestionFragment extends Fragment implements PickiTCallbacks, E
         @JavascriptInterface
         public void onFileUploadClick() {
             Log.d("TAG", "onFileUploadClick: ");
-            if (Misc.INSTANCE.isAndroid13OrHigher()) {
+            if (ActivityKt.isStoragePermissionGranted(getActivity())) {
                 pickFile();
             } else {
-                handlePermissionsForFilePick();
-            }
-        }
-
-        void handlePermissionsForFilePick() {
-            if (PermissionHandler.Companion.hasPermissions(
-                    requireActivity(),
-                    Arrays.asList(READ_EXTERNAL_STORAGE, WRITE_EXTERNAL_STORAGE)
-            )) {
-                pickFile();
-            } else {
-                PermissionHandler.Companion.requestPermissionWithRationale(
-                        requireActivity(),
-                        Arrays.asList(READ_EXTERNAL_STORAGE, WRITE_EXTERNAL_STORAGE),
-                        "This app needs access to your storage to upload files."
-                );
+                ActivityKt.askStoragePermission(getActivity(),getString(R.string.storage_permission_to_upload_file));
             }
         }
 

--- a/exam/src/main/res/values/strings.xml
+++ b/exam/src/main/res/values/strings.xml
@@ -264,4 +264,5 @@
     <string name="testpress_advanced_analytics">Advanced Analytics</string>
 
     <string name="rank_will_be_published">Rank will be published %s</string>
+    <string name="storage_permission_to_upload_file">The photos and videos permission is required to upload files.</string>
 </resources>

--- a/samples/build.gradle
+++ b/samples/build.gradle
@@ -18,7 +18,7 @@ android {
             storePassword "sample"
         }
     }
-    compileSdkVersion 34
+    compileSdkVersion rootProject.compileSdkVersion
     buildToolsVersion rootProject.buildToolsVersion
     defaultConfig {
         multiDexEnabled true
@@ -30,7 +30,7 @@ android {
         } else {
             minSdkVersion rootProject.minSdkVersion
         }
-        targetSdkVersion 34
+        targetSdkVersion rootProject.targetSdkVersion
         versionCode 1
         versionName "1.0"
     }

--- a/samples/src/main/java/in/testpress/samples/MainActivity.java
+++ b/samples/src/main/java/in/testpress/samples/MainActivity.java
@@ -12,6 +12,7 @@ import in.testpress.samples.core.TestpressCoreSampleActivity;
 import in.testpress.samples.exam.ExamSampleActivity;
 import in.testpress.samples.course.CourseSampleActivity;
 import in.testpress.samples.store.StoreSampleActivity;
+import in.testpress.util.extension.ActivityKt;
 
 import static in.testpress.samples.core.TestpressCoreSampleActivity.AUTHENTICATE_REQUEST_CODE;
 import static in.testpress.util.extension.ActivityKt.askAllPermissions;
@@ -22,7 +23,7 @@ public class MainActivity extends BaseToolBarActivity {
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
-        askAllPermissions(this);
+        ActivityKt.requestStoragePermission(this);
         findViewById(R.id.core).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {


### PR DESCRIPTION
- On Android 13 and higher, users were unable to upload files in File type questions due to missing permissions. Specifically, `READ_MEDIA_IMAGES` and `READ_MEDIA_VIDEO` permissions were required, and for Android 14, the `READ_MEDIA_VISUAL_USER_SELECTED` permission was needed to access files and photos.
- In this commit, we added runtime permission requests for these permissions when users attempt to upload files.
- If the user denies the permission, a snackbar message is displayed to inform them that permission is required to perform the action.