### PR TITLE
fix: Add option to hide Buy Now button in chapter list view

### DIFF
--- a/course/src/main/java/in/testpress/course/TestpressCourse.java
+++ b/course/src/main/java/in/testpress/course/TestpressCourse.java
@@ -31,6 +31,7 @@ public class TestpressCourse {
     public static final String PARENT_ID = "parentId";
     public static final String CHAPTER_URL = "chapterUrl";
     public static final String PRODUCT_SLUG = "productSlug";
+    public static final String SHOW_BUY_NOW_BUTTON = "showBuyNowButton";
     public static final String COURSE_IDS = "courseIds";
     public static final String CONTENT_TYPE = "contentType";
     public static final String CHAPTER_ID = "chapterId";

--- a/course/src/main/java/in/testpress/course/ui/ChapterDetailActivity.java
+++ b/course/src/main/java/in/testpress/course/ui/ChapterDetailActivity.java
@@ -39,6 +39,7 @@ import static in.testpress.course.TestpressCourse.CHAPTER_URL;
 import static in.testpress.course.TestpressCourse.COURSE_ID;
 import static in.testpress.course.TestpressCourse.PARENT_ID;
 import static in.testpress.course.TestpressCourse.PRODUCT_SLUG;
+import static in.testpress.course.TestpressCourse.SHOW_BUY_NOW_BUTTON;
 import static in.testpress.course.fragments.CourseContentListFragment.COURSE_CONTENT_TYPE;
 import static in.testpress.course.ui.ContentActivity.FORCE_REFRESH;
 import static in.testpress.course.ui.ContentActivity.GO_TO_MENU;
@@ -64,13 +65,19 @@ public class ChapterDetailActivity extends BaseToolBarActivity {
     private RetrofitCall<Chapter> chapterApiRequest;
     private RetrofitCall<Course> courseApiRequest;
     private String productSlug;
+    private Boolean showBuyNowButton;
     InstituteSettings instituteSettings;
 
     public static Intent createIntent(String title, String courseId, Context context, String productSlug) {
+        return createIntent(title, courseId, context, productSlug, true);
+    }
+
+    public static Intent createIntent(String title, String courseId, Context context, String productSlug, boolean showBuyNowButton) {
         Intent intent = new Intent(context, ChapterDetailActivity.class);
         intent.putExtra(ACTIONBAR_TITLE, title);
         intent.putExtra(COURSE_ID, courseId);
         intent.putExtra(PRODUCT_SLUG, productSlug);
+        intent.putExtra(SHOW_BUY_NOW_BUTTON, showBuyNowButton);
         return intent;
     }
 
@@ -89,6 +96,7 @@ public class ChapterDetailActivity extends BaseToolBarActivity {
         prefs.edit().clear().apply();
         courseDao = TestpressSDKDatabase.getCourseDao(this);
         productSlug = getIntent().getStringExtra(PRODUCT_SLUG);
+        showBuyNowButton = getIntent().getBooleanExtra(SHOW_BUY_NOW_BUTTON,false);
         //noinspection ConstantConditions
         instituteSettings = TestpressSdk.getTestpressSession(this).getInstituteSettings();
         final String chapterUrl = getIntent().getStringExtra(CHAPTER_URL);
@@ -247,6 +255,7 @@ public class ChapterDetailActivity extends BaseToolBarActivity {
             getIntent().putExtra(COURSE_ID, chapter.getCourseId().toString());
             getIntent().putExtra(PARENT_ID, chapter.getId().toString());
             getIntent().putExtra(PRODUCT_SLUG, productSlug);
+            getIntent().putExtra(SHOW_BUY_NOW_BUTTON, showBuyNowButton);
             loadChildChapters();
         } else  {
             getIntent().putExtra(CONTENTS_URL_FRAG, chapter.getChapterContentsUrl());
@@ -379,6 +388,9 @@ public class ChapterDetailActivity extends BaseToolBarActivity {
 
         if(productSlug != null) {
             data.putString(PRODUCT_SLUG, productSlug);
+        }
+        if (showBuyNowButton != null){
+            data.putBoolean(SHOW_BUY_NOW_BUTTON, showBuyNowButton);
         }
         return data;
     }

--- a/course/src/main/java/in/testpress/course/ui/ChaptersListFragment.java
+++ b/course/src/main/java/in/testpress/course/ui/ChaptersListFragment.java
@@ -45,6 +45,7 @@ import kotlin.jvm.functions.Function0;
 import static in.testpress.course.TestpressCourse.COURSE_ID;
 import static in.testpress.course.TestpressCourse.PARENT_ID;
 import static in.testpress.course.TestpressCourse.PRODUCT_SLUG;
+import static in.testpress.course.TestpressCourse.SHOW_BUY_NOW_BUTTON;
 
 public class ChaptersListFragment extends BaseDataBaseFragment<Chapter, Long> {
 
@@ -54,6 +55,7 @@ public class ChaptersListFragment extends BaseDataBaseFragment<Chapter, Long> {
     private ChapterDao chapterDao;
     private CourseDao courseDao;
     private String productSlug;
+    private boolean showBuyNowButton;
     private Course course;
     private RetrofitCall<Course> courseApiRequest;
     private InstituteSettings instituteSettings;
@@ -81,6 +83,7 @@ public class ChaptersListFragment extends BaseDataBaseFragment<Chapter, Long> {
     private void storeArgs() {
         courseId = getArguments().getString(COURSE_ID);
         productSlug = getArguments().getString(PRODUCT_SLUG);
+        showBuyNowButton = getArguments().getBoolean(SHOW_BUY_NOW_BUTTON);
 
         if (getArguments().getString(PARENT_ID) != null) {
             parentId = getArguments().getString(PARENT_ID);
@@ -97,7 +100,7 @@ public class ChaptersListFragment extends BaseDataBaseFragment<Chapter, Long> {
         super.onViewCreated(view, savedInstanceState);
         swipeRefreshLayout.setEnabled(false);
 
-        if (productSlug != null) {
+        if (productSlug != null && showBuyNowButton) {
             displayBuyNowButton();
         }
 


### PR DESCRIPTION
- Added an option to control the visibility of the 'Buy Now' button in the chapter list view.
- The same chapter list view is used in both the Android and Yukthi Flutter apps. In the Yukthi app, the 'Buy Now' button is not required, so we introduced a new parameter `SHOW_BUY_NOW_BUTTON` to toggle its visibility.
- This ensures flexibility when displaying the button based on app requirements.
