### PR TITLE
fix: Resolve Inheritance Conflict Resolution Error

### DIFF
--- a/core/src/main/java/in/testpress/ui/BaseToolBarActivity.kt
+++ b/core/src/main/java/in/testpress/ui/BaseToolBarActivity.kt
@@ -38,7 +38,7 @@ open class BaseToolBarActivity: AppCompatActivity() {
         setupActionBar()
     }
 
-    override fun setContentView(view: View) {
+    override fun setContentView(view: View?) {
         super.setContentView(view)
         preventScreenshot()
         setupActionBar()


### PR DESCRIPTION
- This PR fixes an issue in `BaseToolBarActivity` where the overridden `setContentView` method did not accept a nullable View. Although `super.setContentView(view)` can handle a nullable `View?`, the previous override enforced a non-nullable View. This caused issues when passing null values, potentially leading to build failures. Ref - [Docs](https://www.jot.fm/issues/issue_2005_03/column2/#:~:text=An%20inheritance%20conflict%20arises%20when,accidental%20and%20recombinant%20inheritance%20conflicts.)
