### PR TITLE
fix: Missing Flexbox dependency when Zoom SDK is disabled

### DIFF
--- a/course/build.gradle
+++ b/course/build.gradle
@@ -52,6 +52,7 @@ dependencies {
     api rootProject.shimmer
     api 'com.github.HotBitmapGG:RingProgressBar:V1.2.3'
     api "androidx.viewpager2:viewpager2:1.0.0"
+    api "com.google.android.flexbox:flexbox:3.0.0"
     testImplementation rootProject.junit
     testImplementation rootProject.mockito
     testImplementation rootProject.powermockJunit


### PR DESCRIPTION
- Added the missing `com.google.android.flexbox:flexbox:3.0.0` dependency in `course/build.gradle`.
- The Zoom SDK internally includes Flexbox, so the dependency issue arises only when the Zoom SDK is disabled.
- This fix ensures that Flexbox is available independently of whether the Zoom SDK is enabled or not.
