### PR TITLE
fix: Prevent multiple initializations of exam countdown timer

### DIFF
--- a/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
@@ -969,11 +969,6 @@ public class TestFragment extends BaseFragment implements
             endExam();
         } else if (action.equals(Action.END_SECTION)) {
             endSection();
-        } else {
-            if (progressDialog.isShowing()) {
-                startCountDownTimer(millisRemaining);
-                progressDialog.dismiss();
-            }
         }
     }
 
@@ -1404,6 +1399,11 @@ public class TestFragment extends BaseFragment implements
 
     void startCountDownTimer(long millisInFuture) {
         updateTimeRemaining(millisInFuture);
+
+        if (countDownTimer != null){
+            countDownTimer.cancel();
+            countDownTimer = null;
+        }
         countDownTimer = new CountDownTimer(millisInFuture, 1000) {
 
             public void onTick(long millisUntilFinished) {


### PR DESCRIPTION
- Previously, the exam countdown timer was initialized multiple times on every successful questions API call for a different page. As a result, multiple timers were active simultaneously, causing multiple sections to end at the same time.
- To resolve this, we're now checking for an existing timer and canceling it before creating a new instance, preventing multiple countdowns from running simultaneously. This change ensures that each section's timer functions correctly and independently, aligning with the exam's intended flow.