### PR TITLE
fix: App crash when quickly opening and closing PDF Content

### DIFF
--- a/course/src/main/java/in/testpress/course/fragments/DocumentViewerFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/DocumentViewerFragment.kt
@@ -47,6 +47,12 @@ class DocumentViewerFragment : BaseContentDetailFragment(), PdfDownloadListener,
         return binding.root
     }
 
+    override fun onBackPressed() {
+        super.onBackPressed()
+        pdfDownloadManager.cancel()
+        pdfDownloadManager.cleanup()
+    }
+
     override fun onDestroyView() {
         super.onDestroyView()
         _binding = null


### PR DESCRIPTION
- Fixed a crash that occurred when closing the PDF viewer before the download was complete.
- Added logic to cancel the PDF download and clean up partially downloaded files when the back button is pressed.