### PR TITLE
fix: App crash when quickly opening and closing Video Conference screen

### DIFF
--- a/course/src/main/java/in/testpress/course/fragments/VideoConferenceFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/VideoConferenceFragment.kt
@@ -78,6 +78,7 @@ class VideoConferenceFragment : BaseContentDetailFragment() {
     }
 
     private fun hideLoadingAndEnableStartButton() {
+        if (!isVisible) return
         startButton.isEnabled = true
         startButton.text = "START"
         startButton.setBackgroundColor(ContextCompat.getColor(requireContext(), R.color.testpress_color_primary))


### PR DESCRIPTION
- The app crashes when the user rapidly opens and closes the Video Conference screen because the asynchronous Zoom SDK initialization attempts to update the UI after the fragment is closed.
- Added a visibility check in `hideLoadingAndEnableStartButton` to ensure the fragment is still visible before updating the UI.