### PR TITLE
enhancement: Add course filtering by tags in TestpressCourse

### DIFF
--- a/course/src/main/java/in/testpress/course/TestpressCourse.java
+++ b/course/src/main/java/in/testpress/course/TestpressCourse.java
@@ -18,12 +18,15 @@ import in.testpress.course.ui.DownloadsActivity;
 import in.testpress.course.ui.MyCoursesFragment;
 import in.testpress.course.ui.LeaderboardActivity;
 import in.testpress.course.ui.LeaderboardFragment;
+import in.testpress.network.TestpressApiClient;
 import in.testpress.util.Assert;
 import in.testpress.util.ImageUtils;
 
 import static in.testpress.core.TestpressSdk.COURSE_CHAPTER_REQUEST_CODE;
 import static in.testpress.core.TestpressSdk.COURSE_CONTENT_DETAIL_REQUEST_CODE;
 import static in.testpress.core.TestpressSdk.COURSE_CONTENT_LIST_REQUEST_CODE;
+
+import java.util.ArrayList;
 
 public class TestpressCourse {
 
@@ -85,6 +88,34 @@ public class TestpressCourse {
 
         init(context.getApplicationContext(), testpressSession);
         Intent intent = new Intent(context, CourseListActivity.class);
+        context.startActivity(intent);
+    }
+
+    /**
+     * Use when testpress courses need to be open as a new Activity.
+     *
+     * <p> Usage example:
+     *
+     * <p> TestpressSdk.initialize(this, instituteSettings, "userId", "accessToken", provider,
+     * <p>             new TestpressCallback/<TestpressSession>() {
+     * <p>             @Override
+     * <p>             public void onSuccess(TestpressSession testpressSession) {
+     * <p>                  ArrayList<String> tags = new ArrayList<>();
+     * <p>                  tags.add("UPSC");
+     * <p>                 <b>TestpressCourse.show(this, testpressSession, tags);</b>
+     * <p>             }
+     * <p> });
+     *
+     * @param context Context to start the new activity.
+     * @param testpressSession TestpressSession got from the core module.
+     * @param tags A list of course tags used for filtering.
+     */
+    public static void show(@NonNull Context context, @NonNull TestpressSession testpressSession, @NonNull ArrayList<String> tags) {
+        Assert.assertNotNull("Context must not be null.", context);
+
+        init(context.getApplicationContext(), testpressSession);
+        Intent intent = new Intent(context, CourseListActivity.class);
+        intent.putStringArrayListExtra(TestpressApiClient.TAGS, tags);
         context.startActivity(intent);
     }
 

--- a/course/src/main/java/in/testpress/course/ui/CourseListFragment.java
+++ b/course/src/main/java/in/testpress/course/ui/CourseListFragment.java
@@ -60,7 +60,7 @@ public class CourseListFragment extends BaseFragment {
 
     private void setupViewPager(ViewPager viewPager) {
         adapter = new Adapter(getChildFragmentManager());
-        adapter.addFragment(new MyCoursesFragment(), getString(R.string.my_course_title));
+        adapter.addFragment(getMyCoursesFragment(), getString(R.string.my_course_title));
 
         String storeLabel = "Available Courses";
         if (session.getInstituteSettings().getStoreLabel() != null && !session.getInstituteSettings().getStoreLabel().isEmpty()) {
@@ -78,6 +78,12 @@ public class CourseListFragment extends BaseFragment {
             @Override
             public void onPageScrollStateChanged(int state) {}
         });
+    }
+
+    private MyCoursesFragment getMyCoursesFragment() {
+        MyCoursesFragment myCoursesFragment = new MyCoursesFragment();
+        myCoursesFragment.setArguments(getArguments());
+        return myCoursesFragment;
     }
 
     private void addStoreFragment(String storeLabel) {


### PR DESCRIPTION
- This update introduces the ability to filter courses by tags when opening the `CourseListActivity`. The `TestpressCourse.show()` method has been updated to accept a list of tags as a parameter, which are passed to the `CourseListActivity` via an intent extra. This allows courses to be filtered based on the provided tags when the activity is started.
- Additionally, a helper method `getMyCoursesFragment()` was added to simplify fragment creation in `CourseListFragment`.
