### PR TITLE
fix: Unable to resume the exam after pausing due to no internet connection

### DIFF
--- a/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
@@ -969,6 +969,11 @@ public class TestFragment extends BaseFragment implements
             endExam();
         } else if (action.equals(Action.END_SECTION)) {
             endSection();
+        } else if(action.equals(Action.UPDATE_ANSWER)) {
+            if (progressDialog.isShowing()) {
+                startCountDownTimer(millisRemaining);
+                progressDialog.dismiss();
+            }
         }
     }
 


### PR DESCRIPTION
- In commit 8270379, we removed the code that dismissed the dialog and started the timer. This removal was intended to prevent the timer from being initialized multiple times.
- While we handled the multiple initializations issue, removing this code introduced a new problem where the exam could not resume properly.
- In this commit, we reintroduced the code with a validation to ensure it only triggers during the `UPDATE_ANSWER` process, addressing the issue without reintroducing the original problem.
