### PR TITLE
fix: Ensure correct content list order in offline mode

### DIFF
--- a/course/src/main/java/in/testpress/course/repository/ContentsRepository.kt
+++ b/course/src/main/java/in/testpress/course/repository/ContentsRepository.kt
@@ -92,6 +92,7 @@ class ContentsRepository(val context: Context, val chapterId: Long = -1) {
     private fun getAll(): MutableList<Content>? {
         return contentDao.queryBuilder()
             .where(ContentDao.Properties.ChapterId.eq(chapterId))
+            .orderAsc(ContentDao.Properties.Order)
             .list()
     }
 


### PR DESCRIPTION
- When users access the content list without an internet connection, the app displays content from the local database. However, the content order was previously not sorted based on the `order` field in the `Content` model.
- This commit resolves the issue by adding a sorting operation to the query that retrieves content from the local database, ensuring the list is properly ordered.
