### PR TITLE
fix: App crash while navigating back from review stats page

### DIFF
--- a/exam/src/main/java/in/testpress/exam/ui/TestActivity.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestActivity.java
@@ -341,6 +341,8 @@ public class TestActivity extends BaseToolBarActivity  {
             if (exam == null) {
                 exam = courseContent.getRawExam();
                 examViewModel.setExam(exam);
+            } else {
+                examViewModel.setExam(exam);
             }
             if (courseAttempt == null && permission == null) {
                 checkPermission();
@@ -373,6 +375,7 @@ public class TestActivity extends BaseToolBarActivity  {
                     @Override
                     public void onSuccess(Exam exam) {
                         TestActivity.this.exam = exam;
+                        examViewModel.setExam(TestActivity.this.exam);
                         if (exam.getPausedAttemptsCount() > 0) {
                             loadAttempts(exam.getAttemptsUrl());
                         } else {

--- a/exam/src/main/java/in/testpress/exam/ui/TestActivity.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestActivity.java
@@ -375,7 +375,6 @@ public class TestActivity extends BaseToolBarActivity  {
                     @Override
                     public void onSuccess(Exam exam) {
                         TestActivity.this.exam = exam;
-                        examViewModel.setExam(TestActivity.this.exam);
                         if (exam.getPausedAttemptsCount() > 0) {
                             loadAttempts(exam.getAttemptsUrl());
                         } else {


### PR DESCRIPTION
- Fixed a crash that occurred when pressing the back button on the Review Stats screen in low-memory scenarios. 
- The issue arose because TestActivity was recreated, and while the Exam object was restored from savedInstanceState, it was not reassigned to examViewModel.
- This commit ensures the examViewModel is updated during activity recreation, preventing the crash and maintaining consistent state.