### PR TITLE
fix: Not able to play download DRM video 

### DIFF
--- a/course/src/main/java/in/testpress/course/helpers/VideoDownloadRequestCreationHandler.kt
+++ b/course/src/main/java/in/testpress/course/helpers/VideoDownloadRequestCreationHandler.kt
@@ -142,6 +142,7 @@ class VideoDownloadRequestCreationHandler(
     }
 
     override fun onLicenseFetchSuccess(keySetId: ByteArray) {
+        this.keySetId = keySetId
         CoroutineScope(Dispatchers.Main).launch {
             listener?.onDownloadRequestHandlerPrepared(
                 getMappedTrackInfo(),


### PR DESCRIPTION
- While downloading the drm video for offline playback we have to fetch the DRM licence and store in local but preciseld we are fetching the licence and not storing. so when use try to view the video without internet it ask for internet to download the license