### PR TITLE
fix: Resolve GitHub Actions build failures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,11 +11,11 @@ jobs:
       GITHUB_USERNAME: ${{ secrets.GH_USERNAME }}
 
     steps:
-      - name: Setup JDK 11
+      - name: Setup JDK 17
         uses: actions/setup-java@v3
         with:
-          distribution: "corretto"
-          java-version: 11
+          distribution: "temurin"
+          java-version: 17
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@v2


### PR DESCRIPTION
- Updated GitHub Actions workflows to use JDK 17 with the Temurin distribution. The change resolves build failures caused by incompatibility between the Android SDK's command-line tools (requiring JDK 17) and the previously configured JDK 11.