### PR TITLE
fix: Chapter content attempts are not being created

### DIFF
--- a/course/src/main/java/in/testpress/course/fragments/LiveStreamFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/LiveStreamFragment.kt
@@ -59,6 +59,7 @@ class LiveStreamFragment : BaseContentDetailFragment(), LiveStreamCallbackListen
         initializePlayerView()
         initializeExoPlayer()
         setupChatWebView()
+        viewModel.createContentAttempt(contentId)
 
         // Disabling swipe to refresh because  it prevents users from scrolling the chat
         // and temporarily hiding the bottom navigation as it hides the chat's send button..


### PR DESCRIPTION
- We had not implemented the attempt creation process for live stream content, which prevented tracking users' live stream consumption.
- In this commit, we added an API call for attempt creation that triggers when a user starts viewing a live stream.