### PR TITLE
fix: Handle unauthenticated errors for ended exams

### DIFF
--- a/exam/src/main/java/in/testpress/exam/repository/AttemptRepository.kt
+++ b/exam/src/main/java/in/testpress/exam/repository/AttemptRepository.kt
@@ -1,5 +1,6 @@
 package `in`.testpress.exam.repository
 
+import `in`.testpress.core.ErrorDetail
 import `in`.testpress.core.TestpressCallback
 import `in`.testpress.core.TestpressException
 import `in`.testpress.database.TestpressDatabase
@@ -215,7 +216,11 @@ class AttemptRepository(val context: Context) {
                 }
 
                 override fun onException(exception: TestpressException) {
-                    if (exception.isUnauthenticated && isExamEnded(exception.message)) {
+                    val errorDetail = exception.getErrorBodyAs(
+                        exception.response,
+                        ErrorDetail::class.java
+                    )
+                    if (exception.isUnauthenticated && isExamEnded(errorDetail.message)) {
                         updateAttemptItem()
                         _saveResultResource.postValue(
                             Resource.success(

--- a/exam/src/main/java/in/testpress/exam/repository/AttemptRepository.kt
+++ b/exam/src/main/java/in/testpress/exam/repository/AttemptRepository.kt
@@ -18,7 +18,6 @@ import `in`.testpress.models.greendao.CourseAttempt
 import `in`.testpress.models.greendao.Exam
 import `in`.testpress.network.Resource
 import android.content.Context
-import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import `in`.testpress.exam.models.UserUploadedFile
@@ -36,9 +35,6 @@ class AttemptRepository(val context: Context) {
     val attemptItem = mutableListOf<AttemptItem>()
     private var _totalQuestions = 0
     val totalQuestions get() = _totalQuestions
-    var currentAttemptItemId = -1
-    var apiCount = 0
-    val maxApiCount = 3
 
     private val database = TestpressDatabase.invoke(context)
     private val examQuestionDao = database.examQuestionDao()


### PR DESCRIPTION
- If the "Enforce Continuous Timer" option is enabled in the exam, the timer is handled on the backend. On Android, the timer often experiences delays, causing a time gap.
- When the exam timer ends on the mobile device, the app attempts to save the last answer. However, if the backend has already marked the exam as ended, the API returns a 403 error.
- This PR introduces a condition to handle 403 errors with an "exam already ended" message from the API.
- If this condition is satisfied, the app updates the last attempt item locally and ends the exam gracefully.
