### PR TITLE
fix: Clear webview session on logout to prevent session leaks

### DIFF
--- a/core/src/main/java/in/testpress/core/TestpressSdk.java
+++ b/core/src/main/java/in/testpress/core/TestpressSdk.java
@@ -5,6 +5,8 @@ import android.app.ProgressDialog;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.graphics.Typeface;
+import android.webkit.CookieManager;
+import android.webkit.WebStorage;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
@@ -90,6 +92,10 @@ public final class TestpressSdk {
 
         SharedPreferences.Editor editor = getPreferenceEditor(context);
         editor.clear().commit();
+        // Clear webView session
+        CookieManager.getInstance().removeAllCookies(null);
+        CookieManager.getInstance().flush();
+        WebStorage.getInstance().deleteAllData();
     }
 
     public static boolean hasActiveSession(@NonNull Context context) {

--- a/core/src/main/java/in/testpress/fragments/WebViewFragment.kt
+++ b/core/src/main/java/in/testpress/fragments/WebViewFragment.kt
@@ -114,6 +114,10 @@ class WebViewFragment : Fragment(), EmptyViewListener {
         webView.webViewClient = CustomWebViewClient(this)
         webView.webChromeClient = CustomWebChromeClient(this)
         webView.settings.userAgentString += CUSTOM_USER_AGENT
+        webView.apply {
+            clearCache(true)
+            clearHistory()
+        }
     }
 
     private fun populateInstituteSettings() {


### PR DESCRIPTION
Ensures that webview sessions are cleared upon logout to prevent session leakage between users.

The following changes were made:
- Added logic to clear cookies and web storage in the `onLogout()` method in `TestpressSdk.java` to remove session data.
- In `WebViewFragment.kt`, added cache and history clearing for the WebView to prevent previous session data from being reused.
  
This fixes the issue where a second user on the same device could access the first user's session data when navigating to the WebView after logout.