### PR TITLE
feat: Add specific handling for unexpected WebView errors

### DIFF
--- a/core/src/main/java/in/testpress/core/TestpressException.java
+++ b/core/src/main/java/in/testpress/core/TestpressException.java
@@ -35,6 +35,10 @@ public class TestpressException extends RuntimeException {
         return new TestpressException(exception.getMessage(), null, Kind.UNEXPECTED, exception);
     }
 
+    public static TestpressException unexpectedWebViewError(Throwable exception) {
+        return new TestpressException(exception.getMessage(), null, Kind.WEBVIEW_UNEXPECTED, exception);
+    }
+
     /** Identifies the event kind which triggered a {@link TestpressException}. */
     public enum Kind {
         /** An {@link IOException} occurred while communicating to the server. */
@@ -45,7 +49,9 @@ public class TestpressException extends RuntimeException {
          * An internal error occurred while attempting to execute a request. It is best practice to
          * re-throw this exception so your application crashes.
          */
-        UNEXPECTED
+        UNEXPECTED,
+        /** An unexpected error occurred within the WebView. */
+        WEBVIEW_UNEXPECTED
     }
 
     private final Response response;
@@ -105,6 +111,10 @@ public class TestpressException extends RuntimeException {
 
     public boolean isNetworkError() {
         return kind == Kind.NETWORK;
+    }
+
+    public boolean isWebViewUnexpected() {
+        return kind == Kind.WEBVIEW_UNEXPECTED;
     }
 
     public boolean isPageNotFound() {

--- a/core/src/main/java/in/testpress/core/TestpressException.java
+++ b/core/src/main/java/in/testpress/core/TestpressException.java
@@ -113,7 +113,7 @@ public class TestpressException extends RuntimeException {
         return kind == Kind.NETWORK;
     }
 
-    public boolean isWebViewUnexpected() {
+    public boolean isWebViewUnexpectedError() {
         return kind == Kind.WEBVIEW_UNEXPECTED;
     }
 

--- a/core/src/main/java/in/testpress/fragments/EmptyViewFragment.kt
+++ b/core/src/main/java/in/testpress/fragments/EmptyViewFragment.kt
@@ -71,7 +71,7 @@ class EmptyViewFragment : Fragment() {
             exception.isForbidden -> handleForbidden(exception)
             exception.isNetworkError -> handleNetworkError()
             exception.isPageNotFound -> handleIsPageNotFound()
-            exception.isWebViewUnexpected -> handleWebViewUnknownError(exception)
+            exception.isWebViewUnexpectedError -> handleWebViewUnknownError(exception)
             else -> handleUnknownError()
         }
     }

--- a/core/src/main/java/in/testpress/fragments/EmptyViewFragment.kt
+++ b/core/src/main/java/in/testpress/fragments/EmptyViewFragment.kt
@@ -71,6 +71,7 @@ class EmptyViewFragment : Fragment() {
             exception.isForbidden -> handleForbidden(exception)
             exception.isNetworkError -> handleNetworkError()
             exception.isPageNotFound -> handleIsPageNotFound()
+            exception.isWebViewUnexpected -> handleWebViewUnknownError(exception)
             else -> handleUnknownError()
         }
     }
@@ -131,6 +132,13 @@ class EmptyViewFragment : Fragment() {
         setEmptyText(R.string.testpress_content_not_available,
                 R.string.testpress_content_not_available_description,
                 R.drawable.ic_error_outline_black_18dp)
+    }
+
+    private fun handleWebViewUnknownError(exception: TestpressException) {
+        val message = exception.message ?: "Unknown WebView Error"
+        setEmptyText(R.string.testpress_error_loading_contents,
+            message,
+            R.drawable.ic_error_outline_black_18dp)
     }
 
     private fun handleUnknownError() {

--- a/core/src/main/java/in/testpress/util/webview/CustomWebViewClient.kt
+++ b/core/src/main/java/in/testpress/util/webview/CustomWebViewClient.kt
@@ -4,6 +4,7 @@ import `in`.testpress.core.TestpressException
 import `in`.testpress.fragments.WebViewFragment
 import `in`.testpress.util.extension.openUrlInBrowser
 import android.graphics.Bitmap
+import android.util.Log
 import android.webkit.*
 
 class CustomWebViewClient(val fragment: WebViewFragment) : WebViewClient() {
@@ -50,10 +51,11 @@ class CustomWebViewClient(val fragment: WebViewFragment) : WebViewClient() {
         request: WebResourceRequest?,
         error: WebResourceError?
     ) {
+        Log.d("TAG", "onReceivedError: ")
         val requestUrl = request?.url.toString()
         val currentWebViewUrl = fragment.webView.url.toString()
         if (requestUrl == currentWebViewUrl) {
-            fragment.showErrorView(TestpressException.unexpectedError(Exception("WebView error")))
+            fragment.showErrorView(TestpressException.unexpectedWebViewError(Exception("WebView error ${error?.errorCode}")))
         }
     }
 

--- a/core/src/main/java/in/testpress/util/webview/CustomWebViewClient.kt
+++ b/core/src/main/java/in/testpress/util/webview/CustomWebViewClient.kt
@@ -4,7 +4,6 @@ import `in`.testpress.core.TestpressException
 import `in`.testpress.fragments.WebViewFragment
 import `in`.testpress.util.extension.openUrlInBrowser
 import android.graphics.Bitmap
-import android.util.Log
 import android.webkit.*
 
 class CustomWebViewClient(val fragment: WebViewFragment) : WebViewClient() {
@@ -51,7 +50,6 @@ class CustomWebViewClient(val fragment: WebViewFragment) : WebViewClient() {
         request: WebResourceRequest?,
         error: WebResourceError?
     ) {
-        Log.d("TAG", "onReceivedError: ")
         val requestUrl = request?.url.toString()
         val currentWebViewUrl = fragment.webView.url.toString()
         if (requestUrl == currentWebViewUrl) {


### PR DESCRIPTION
Improved error handling for WebView to differentiate and debug unexpected errors effectively.

The following changes were made:
- Added a new `Kind.WEBVIEW_UNEXPECTED` type in `TestpressException` to classify unexpected WebView errors separately.
- Created a new method `unexpectedWebViewError()` in `TestpressException` for generating exceptions of this kind.
- Introduced the `isWebViewUnexpectedError()` helper method to identify WebView-specific unexpected errors.
- Updated `EmptyViewFragment` to handle `WEBVIEW_UNEXPECTED` errors explicitly with a dedicated `handleWebViewUnknownError()` method.
- Modified `CustomWebViewClient` to provide error details (e.g., error code) in the exception message for better debugging.

This change ensures that WebView errors are not conflated with other unexpected errors, making it easier to identify and resolve issues related to WebView interactions.