### PR TITLE
fix: Optimize chapter fetching to load only required chapters

### DIFF
--- a/core/src/main/java/in/testpress/models/greendao/Chapter.java
+++ b/core/src/main/java/in/testpress/models/greendao/Chapter.java
@@ -416,6 +416,14 @@ public class Chapter {
         return chapters.get(0);
     }
 
+    public static List<Chapter> getChildrenChapters(Context context, String parentId) {
+        ChapterDao chapterDao = TestpressSDKDatabase.getChapterDao(context);
+        return chapterDao.queryBuilder()
+                .where(ChapterDao.Properties.ParentId.eq(parentId))
+                .orderAsc(ChapterDao.Properties.Order)
+                .list();
+    }
+
     public String getChapterContentsUrl() {
         return url + "contents/";
     }

--- a/core/src/main/java/in/testpress/models/greendao/Chapter.java
+++ b/core/src/main/java/in/testpress/models/greendao/Chapter.java
@@ -3,8 +3,6 @@ package in.testpress.models.greendao;
 import org.greenrobot.greendao.annotation.*;
 
 import java.util.List;
-
-import in.testpress.BuildConfig;
 import in.testpress.models.greendao.DaoSession;
 import org.greenrobot.greendao.DaoException;
 
@@ -12,8 +10,6 @@ import org.greenrobot.greendao.DaoException;
 
 // KEEP INCLUDES - put your custom includes here
 import android.content.Context;
-import android.os.Build;
-
 import org.greenrobot.greendao.query.QueryBuilder;
 import org.greenrobot.greendao.query.WhereCondition;
 

--- a/core/src/main/java/in/testpress/models/greendao/Chapter.java
+++ b/core/src/main/java/in/testpress/models/greendao/Chapter.java
@@ -3,6 +3,8 @@ package in.testpress.models.greendao;
 import org.greenrobot.greendao.annotation.*;
 
 import java.util.List;
+
+import in.testpress.BuildConfig;
 import in.testpress.models.greendao.DaoSession;
 import org.greenrobot.greendao.DaoException;
 
@@ -10,6 +12,8 @@ import org.greenrobot.greendao.DaoException;
 
 // KEEP INCLUDES - put your custom includes here
 import android.content.Context;
+import android.os.Build;
+
 import org.greenrobot.greendao.query.QueryBuilder;
 import org.greenrobot.greendao.query.WhereCondition;
 
@@ -398,11 +402,7 @@ public class Chapter {
     }
 
     public boolean hasChildren() {
-        if (childrenCount != null) {
-            return getChildrenCount() > 0;
-        }
-
-        return getChildren().size() > 0;
+        return !leaf;
     }
 
     public static Chapter get(Context context, String chapterId) {

--- a/core/src/main/java/in/testpress/models/greendao/Course.java
+++ b/core/src/main/java/in/testpress/models/greendao/Course.java
@@ -453,6 +453,14 @@ public class Course {
                 .list();
     }
 
+    public List<Chapter> getChildrenChapters(String parentId) {
+        ChapterDao chapterDao = daoSession.getChapterDao();
+        return chapterDao.queryBuilder()
+                .where(ChapterDao.Properties.CourseId.eq(getId()), ChapterDao.Properties.ParentId.eq(parentId))
+                .orderAsc(ChapterDao.Properties.Order)
+                .list();
+    }
+
     public boolean containsTags(List<String> expectedTags) {
         return tags != null && !Collections.disjoint(tags, expectedTags);
     }

--- a/core/src/main/java/in/testpress/models/greendao/Course.java
+++ b/core/src/main/java/in/testpress/models/greendao/Course.java
@@ -453,14 +453,6 @@ public class Course {
                 .list();
     }
 
-    public List<Chapter> getChildrenChapters(String parentId) {
-        ChapterDao chapterDao = daoSession.getChapterDao();
-        return chapterDao.queryBuilder()
-                .where(ChapterDao.Properties.CourseId.eq(getId()), ChapterDao.Properties.ParentId.eq(parentId))
-                .orderAsc(ChapterDao.Properties.Order)
-                .list();
-    }
-
     public boolean containsTags(List<String> expectedTags) {
         return tags != null && !Collections.disjoint(tags, expectedTags);
     }

--- a/course/src/main/java/in/testpress/course/pagers/ChapterPager.java
+++ b/course/src/main/java/in/testpress/course/pagers/ChapterPager.java
@@ -39,6 +39,8 @@ public class ChapterPager extends BaseDatabaseModelPager<Chapter> {
         queryParams.put(TestpressApiClient.PAGE, page);
         if (parentId != null) {
             queryParams.put(PARENT, parentId);
+        } else {
+            queryParams.put(PARENT, "null");
         }
         return apiClient.getChapters(courseId, queryParams, latestModifiedDate).execute();
     }

--- a/course/src/main/java/in/testpress/course/ui/ChapterDetailActivity.java
+++ b/course/src/main/java/in/testpress/course/ui/ChapterDetailActivity.java
@@ -40,8 +40,6 @@ import static in.testpress.course.TestpressCourse.COURSE_ID;
 import static in.testpress.course.TestpressCourse.PARENT_ID;
 import static in.testpress.course.TestpressCourse.PRODUCT_SLUG;
 import static in.testpress.course.TestpressCourse.SHOW_BUY_NOW_BUTTON;
-import static in.testpress.course.api.TestpressCourseApiClient.CHAPTERS_PATH;
-import static in.testpress.course.api.TestpressCourseApiClient.COURSE_LIST_PATH;
 import static in.testpress.course.fragments.CourseContentListFragment.COURSE_CONTENT_TYPE;
 import static in.testpress.course.ui.ContentActivity.FORCE_REFRESH;
 import static in.testpress.course.ui.ContentActivity.GO_TO_MENU;

--- a/course/src/main/java/in/testpress/course/ui/ChapterDetailActivity.java
+++ b/course/src/main/java/in/testpress/course/ui/ChapterDetailActivity.java
@@ -396,7 +396,7 @@ public class ChapterDetailActivity extends BaseToolBarActivity {
     }
 
     private String getParentChapterUrl() {
-        return instituteSettings.getBaseUrl() + "/api/2.4/chapters" + chapter.getSlug();
+        return instituteSettings.getBaseUrl() + "/api/2.4/chapters/" + chapter.getSlug();
     }
 
     @Override

--- a/course/src/main/java/in/testpress/course/ui/ChapterDetailActivity.java
+++ b/course/src/main/java/in/testpress/course/ui/ChapterDetailActivity.java
@@ -40,6 +40,8 @@ import static in.testpress.course.TestpressCourse.COURSE_ID;
 import static in.testpress.course.TestpressCourse.PARENT_ID;
 import static in.testpress.course.TestpressCourse.PRODUCT_SLUG;
 import static in.testpress.course.TestpressCourse.SHOW_BUY_NOW_BUTTON;
+import static in.testpress.course.api.TestpressCourseApiClient.CHAPTERS_PATH;
+import static in.testpress.course.api.TestpressCourseApiClient.COURSE_LIST_PATH;
 import static in.testpress.course.fragments.CourseContentListFragment.COURSE_CONTENT_TYPE;
 import static in.testpress.course.ui.ContentActivity.FORCE_REFRESH;
 import static in.testpress.course.ui.ContentActivity.GO_TO_MENU;
@@ -380,7 +382,7 @@ public class ChapterDetailActivity extends BaseToolBarActivity {
         if (chapter != null) {
             Long parentId = chapter.getParentId();
             if (parentId != null) {
-                data.putString(CHAPTER_URL, chapter.getParentUrl());
+                data.putString(CHAPTER_URL, getParentChapterUrl());
             } else {
                 data.putInt(COURSE_ID, chapter.getCourseId().intValue());
             }
@@ -393,6 +395,10 @@ public class ChapterDetailActivity extends BaseToolBarActivity {
             data.putBoolean(SHOW_BUY_NOW_BUTTON, showBuyNowButton);
         }
         return data;
+    }
+
+    private String getParentChapterUrl() {
+        return instituteSettings.getBaseUrl() + "/api/2.4/chapters" + chapter.getSlug();
     }
 
     @Override

--- a/course/src/main/java/in/testpress/course/ui/ChaptersListAdapter.java
+++ b/course/src/main/java/in/testpress/course/ui/ChaptersListAdapter.java
@@ -40,9 +40,7 @@ class ChaptersListAdapter extends SingleTypeAdapter<Chapter> {
 
     private void loadChapters() {
         if (parentId != null) {
-            Chapter parentChapter = Chapter.get(activity, parentId);
-            parentChapter.resetChildren();
-            this.chapters = parentChapter.getChildren();
+            this.chapters = course.getChildrenChapters(parentId);
         } else if (course != null) {
             this.chapters = course.getRootChapters();
         }

--- a/course/src/main/java/in/testpress/course/ui/ChaptersListAdapter.java
+++ b/course/src/main/java/in/testpress/course/ui/ChaptersListAdapter.java
@@ -40,7 +40,7 @@ class ChaptersListAdapter extends SingleTypeAdapter<Chapter> {
 
     private void loadChapters() {
         if (parentId != null) {
-            this.chapters = course.getChildrenChapters(parentId);
+            this.chapters = Chapter.getChildrenChapters(activity, parentId);
         } else if (course != null) {
             this.chapters = course.getRootChapters();
         }

--- a/course/src/main/java/in/testpress/course/ui/ChaptersListFragment.java
+++ b/course/src/main/java/in/testpress/course/ui/ChaptersListFragment.java
@@ -185,11 +185,9 @@ public class ChaptersListFragment extends BaseDataBaseFragment<Chapter, Long> {
     @Override
     protected BaseResourcePager<Chapter> getPager() {
         if (pager == null) {
-            if (parentId != null){
-                pager = new ChapterPager(courseId, parentId, apiClient);
-            } else {
-                pager = new ChapterPager(courseId, apiClient);
-            }
+            pager = (parentId != null)
+                    ? new ChapterPager(courseId, parentId, apiClient)
+                    : new ChapterPager(courseId, apiClient);
         }
         return pager;
     }
@@ -199,33 +197,25 @@ public class ChaptersListFragment extends BaseDataBaseFragment<Chapter, Long> {
         if (getCourse() == null) {
             return true;
         }
-        boolean a = false;
 
-        if (parentId != null){
-            a = Chapter.getChildrenChapters(requireActivity(), parentId).isEmpty();
-        } else {
-            a = getCourse().getRootChapters().isEmpty();
+        if (parentId != null) {
+            return Chapter.getChildrenChapters(requireActivity(), parentId).isEmpty();
         }
 
-        return a;
+        return getCourse().getRootChapters().isEmpty();
     }
 
     private void deleteExistingChapters() {
-        if (parentId != null){
-            getDao().queryBuilder()
-                    .where(ChapterDao.Properties.CourseId.eq(courseId))
-                    .where(ChapterDao.Properties.ParentId.eq(parentId))
-                    .buildDelete()
-                    .executeDeleteWithoutDetachingEntities();
-            getDao().detachAll();
-        } else {
-            getDao().queryBuilder()
-                    .where(ChapterDao.Properties.CourseId.eq(courseId))
-                    .where(ChapterDao.Properties.ParentId.isNull())
-                    .buildDelete()
-                    .executeDeleteWithoutDetachingEntities();
-            getDao().detachAll();
-        }
+        getDao().queryBuilder()
+                .where(ChapterDao.Properties.CourseId.eq(courseId))
+                .where(
+                        parentId != null
+                                ? ChapterDao.Properties.ParentId.eq(parentId)
+                                : ChapterDao.Properties.ParentId.isNull()
+                )
+                .buildDelete()
+                .executeDeleteWithoutDetachingEntities();
+        getDao().detachAll();
     }
 
     @Override

--- a/course/src/main/java/in/testpress/course/ui/ChaptersListFragment.java
+++ b/course/src/main/java/in/testpress/course/ui/ChaptersListFragment.java
@@ -202,7 +202,7 @@ public class ChaptersListFragment extends BaseDataBaseFragment<Chapter, Long> {
         boolean a = false;
 
         if (parentId != null){
-            a = getCourse().getChildrenChapters(parentId).isEmpty();
+            a = Chapter.getChildrenChapters(requireActivity(), parentId).isEmpty();
         } else {
             a = getCourse().getRootChapters().isEmpty();
         }

--- a/course/src/main/java/in/testpress/course/ui/ChaptersListFragment.java
+++ b/course/src/main/java/in/testpress/course/ui/ChaptersListFragment.java
@@ -185,7 +185,11 @@ public class ChaptersListFragment extends BaseDataBaseFragment<Chapter, Long> {
     @Override
     protected BaseResourcePager<Chapter> getPager() {
         if (pager == null) {
-            pager = new ChapterPager(courseId, apiClient);
+            if (parentId != null){
+                pager = new ChapterPager(courseId, parentId, apiClient);
+            } else {
+                pager = new ChapterPager(courseId, apiClient);
+            }
         }
         return pager;
     }
@@ -195,15 +199,33 @@ public class ChaptersListFragment extends BaseDataBaseFragment<Chapter, Long> {
         if (getCourse() == null) {
             return true;
         }
-        return getCourse().getRootChapters().isEmpty();
+        boolean a = false;
+
+        if (parentId != null){
+            a = getCourse().getChildrenChapters(parentId).isEmpty();
+        } else {
+            a = getCourse().getRootChapters().isEmpty();
+        }
+
+        return a;
     }
 
     private void deleteExistingChapters() {
-        getDao().queryBuilder()
-                .where(ChapterDao.Properties.CourseId.eq(courseId))
-                .buildDelete()
-                .executeDeleteWithoutDetachingEntities();
-        getDao().detachAll();
+        if (parentId != null){
+            getDao().queryBuilder()
+                    .where(ChapterDao.Properties.CourseId.eq(courseId))
+                    .where(ChapterDao.Properties.ParentId.eq(parentId))
+                    .buildDelete()
+                    .executeDeleteWithoutDetachingEntities();
+            getDao().detachAll();
+        } else {
+            getDao().queryBuilder()
+                    .where(ChapterDao.Properties.CourseId.eq(courseId))
+                    .where(ChapterDao.Properties.ParentId.isNull())
+                    .buildDelete()
+                    .executeDeleteWithoutDetachingEntities();
+            getDao().detachAll();
+        }
     }
 
     @Override


### PR DESCRIPTION
- This PR addresses the inefficiency in fetching chapters for the chapter list. Previously, all chapters were fetched, and only the required root or child chapters were displayed to the user. This led to performance issues, especially with large datasets.
#### The implemented solution optimizes the process by:
- Fetching only the necessary chapters (root or child) from the database or API.
- Introducing methods to retrieve child chapters directly based on the parent ID.
- Modifying the logic in chapter-related classes (Chapter, ChapterPager, etc.) to support the optimized fetching.
