### PR TITLE
fix: Pass JWT token for authentication in live stream chat WebView

### DIFF
--- a/course/src/main/java/in/testpress/course/fragments/LiveStreamFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/LiveStreamFragment.kt
@@ -108,7 +108,7 @@ class LiveStreamFragment : BaseContentDetailFragment(), LiveStreamCallbackListen
             val webViewFragment = WebViewFragment()
             val bundle = Bundle().apply {
                 this.putString(URL_TO_OPEN,embedUrl)
-                this.putBoolean(IS_AUTHENTICATION_REQUIRED,false)
+                this.putBoolean(IS_AUTHENTICATION_REQUIRED,true)
             }
             webViewFragment.arguments = bundle
             childFragmentManager.beginTransaction()


### PR DESCRIPTION
- This PR resolves the issue where users were required to manually enter their name every time they accessed the live stream chat. This was caused by not passing the JWT token in the WebView request, which prevented automatic user authentication.
- Updating the IS_AUTHENTICATION_REQUIRED flag to true when opening the WebView for the live stream chat.
- With this change, users will no longer need to re-enter their details, and the chat screen will validate and load automatically, enhancing the user experience.