### PR TITLE
fix: Prevent redundant data load on resume in ChapterDetailActivity

### DIFF
--- a/course/src/main/java/in/testpress/course/ui/ChapterDetailActivity.java
+++ b/course/src/main/java/in/testpress/course/ui/ChapterDetailActivity.java
@@ -363,7 +363,6 @@ public class ChapterDetailActivity extends BaseToolBarActivity {
                 getIntent().getStringExtra(CONTENTS_URL_FRAG) != null) {
 
             prefs.edit().putBoolean(FORCE_REFRESH, false).apply();
-            loadContents();
         }
     }
 


### PR DESCRIPTION
This PR removes the automatic data load in onResume to avoid redundant API calls when returning to the content list view. Users can now manually refresh the data using the swipe-to-refresh option.