### PR TITLE
fix: Remove redundant category API call and add refresh on swipe

### DIFF
--- a/course/src/main/java/in/testpress/course/ui/AvailableCourseListFragment.java
+++ b/course/src/main/java/in/testpress/course/ui/AvailableCourseListFragment.java
@@ -2,6 +2,7 @@ package in.testpress.course.ui;
 
 import android.content.Context;
 import android.os.Bundle;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -119,6 +120,7 @@ public class AvailableCourseListFragment extends BaseListViewFragment<Product> i
     public void refreshWithProgress() {
         pager.reset();
         super.refreshWithProgress();
+        refreshProductCategory();
     }
 
     private void refreshProductCategory(){
@@ -194,7 +196,6 @@ public class AvailableCourseListFragment extends BaseListViewFragment<Product> i
         if(isItemsEmpty()) {
             setEmptyText();
         }
-        refreshProductCategory();
     }
 
 

--- a/course/src/main/java/in/testpress/course/ui/AvailableCourseListFragment.java
+++ b/course/src/main/java/in/testpress/course/ui/AvailableCourseListFragment.java
@@ -2,7 +2,6 @@ package in.testpress.course.ui;
 
 import android.content.Context;
 import android.os.Bundle;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;


### PR DESCRIPTION
This commit removes the unnecessary category API call that was being triggered each time the app came to the foreground. Instead, the category data is now refreshed only when the user performs a swipe-to-refresh action.