### PR TITLE
fix: Prevent redundant API calls during ExoPlayer initialization

### DIFF
--- a/course/src/main/java/in/testpress/course/util/ExoPlayerUtil.java
+++ b/course/src/main/java/in/testpress/course/util/ExoPlayerUtil.java
@@ -148,6 +148,7 @@ public class ExoPlayerUtil implements VideoTimeRangeListener, DrmSessionManagerP
     private LiveStreamCallbackListener liveStreamCallbackListener;
     boolean isDynamic = false;
     private TestpressSession session;
+    boolean firstSeekCalled = false;
 
     public ExoPlayerUtil(Activity activity, FrameLayout exoPlayerMainFrame, String url,
                          float startPosition, LiveStreamCallbackListener liveStreamCallbackListener) {
@@ -891,6 +892,14 @@ public class ExoPlayerUtil implements VideoTimeRangeListener, DrmSessionManagerP
 
         @Override
         public void onSeekProcessed() {
+            // This method is triggered automatically during ExoPlayer initialization when the start position is set.
+            // Since the initial API call is unnecessary and redundant at this stage,
+            // we skip processing during the first invocation by checking if it is the first seek
+            // and proceed only with subsequent calls to update the user watching status.
+            if (!firstSeekCalled){
+                firstSeekCalled = true;
+                return;
+            }
             // Cancel any pending seek-related operations
             seekHandler.removeCallbacksAndMessages(null);
 

--- a/course/src/main/java/in/testpress/course/util/ExoPlayerUtil.java
+++ b/course/src/main/java/in/testpress/course/util/ExoPlayerUtil.java
@@ -148,7 +148,7 @@ public class ExoPlayerUtil implements VideoTimeRangeListener, DrmSessionManagerP
     private LiveStreamCallbackListener liveStreamCallbackListener;
     boolean isDynamic = false;
     private TestpressSession session;
-    boolean firstSeekCalled = false;
+    private boolean firstSeekCalled = false;
 
     public ExoPlayerUtil(Activity activity, FrameLayout exoPlayerMainFrame, String url,
                          float startPosition, LiveStreamCallbackListener liveStreamCallbackListener) {


### PR DESCRIPTION
- This update addresses the issue of redundant API calls triggered during ExoPlayer initialization due to the seek callback being invoked when the start time is set.
- Introduced a firstSeekCalled flag to skip the API call during the first invocation of onSeekProcessed.
Ensured the seek callback only triggers the user attempt API call on subsequent seeks, avoiding unnecessary calls during initialization.
- Preserved the existing behavior for user interactions while improving efficiency.
- These changes optimize the initialization process and reduce unnecessary server requests, enhancing the overall app performance.