### PR TITLE
fix: Remove unnecessary error display for watch duration API failure

### DIFF
--- a/course/src/main/java/in/testpress/course/util/ExoPlayerUtil.java
+++ b/course/src/main/java/in/testpress/course/util/ExoPlayerUtil.java
@@ -134,7 +134,6 @@ public class ExoPlayerUtil implements VideoTimeRangeListener, DrmSessionManagerP
     private MediaRouteSelector mediaRouteSelector;
     private MediaRouter.Callback mediaRouterCallback;
     private boolean fullscreen = false;
-    private boolean errorOnVideoAttemptUpdate;
     private int drmLicenseRetries = 0;
 
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
@@ -706,7 +705,6 @@ public class ExoPlayerUtil implements VideoTimeRangeListener, DrmSessionManagerP
                         if (videoAttempt != null) {
                             updateVideoWatchedPercentage(videoAttempt);
                         }
-                        errorOnVideoAttemptUpdate = false;
                     }
 
                     @Override
@@ -714,7 +712,6 @@ public class ExoPlayerUtil implements VideoTimeRangeListener, DrmSessionManagerP
                         if (videoWatchDataRepository != null) {
                             videoWatchDataRepository.save(content, getVideoAttemptParameters());
                         }
-                        errorOnVideoAttemptUpdate = true;
                     }
                 });
     }
@@ -833,9 +830,7 @@ public class ExoPlayerUtil implements VideoTimeRangeListener, DrmSessionManagerP
                 displayError(R.string.testpress_usb_connected);
             } else {
                 hideError(R.string.testpress_usb_connected);
-                if (errorOnVideoAttemptUpdate) {
-                    errorMessageTextView.setVisibility(View.GONE);
-                } else if (playbackState == Player.STATE_READY) {
+                if (playbackState == Player.STATE_READY) {
                     errorMessageTextView.setVisibility(View.GONE);
                 }
             }


### PR DESCRIPTION
- This fix ensures that playback errors are not shown to users when the watch duration update API fails, as it is not critical to the playback experience.
- Removed the errorOnVideoAttemptUpdate flag and associated logic.
- Updated the condition to only handle errors relevant to playback state.
- This change improves the user experience by preventing irrelevant errors from being displayed on the player.