### PR TITLE
fix: Prevent stale data display when downloads list is empty

### DIFF
--- a/course/src/main/java/in/testpress/course/fragments/DownloadsFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/DownloadsFragment.kt
@@ -129,6 +129,9 @@ class DownloadsFragment : Fragment(), EmptyViewListener {
                 handler.remove()
             }
 
+            adapter.offlineVideos = it
+            adapter.notifyDataSetChanged()
+
             hideLoadingPlaceholder()
             if (DateUtils.isAutoTimeUpdateDisabledInDevice(requireContext())) {
                 showEnableAutoTimeUpdateScreen()
@@ -138,8 +141,6 @@ class DownloadsFragment : Fragment(), EmptyViewListener {
                 showEmptyScreen()
             } else {
                 hideEmptyScreen()
-                adapter.offlineVideos = it
-                adapter.notifyDataSetChanged()
             }
         })
     }


### PR DESCRIPTION
Previously, deleted videos remained visible for users to attempt deletion again with no effect, because the adapter not update when the list became empty, leading to stale data when reopening the screen. This was caused by the adapter update being placed after the empty screen logic in the observer, causing it to be skipped.

Moved the adapter update to the top of the observer to ensure the UI remains consistent and reflects deletions correctly.