### PR TITLE
fix: Remove unnecessary storage permission for Android 10 and above

### DIFF
--- a/core/src/main/java/in/testpress/util/PermissionsUtils.java
+++ b/core/src/main/java/in/testpress/util/PermissionsUtils.java
@@ -49,7 +49,7 @@ public class PermissionsUtils {
     }
 
     public boolean isStoragePermissionGranted(){
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && Build.VERSION.SDK_INT <= Build.VERSION_CODES.Q){
+        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.P){
             return ActivityCompat.checkSelfPermission(
                     activity,
                     Manifest.permission.WRITE_EXTERNAL_STORAGE

--- a/exam/src/main/AndroidManifest.xml
+++ b/exam/src/main/AndroidManifest.xml
@@ -1,7 +1,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="in.testpress.exam">
 
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+    <!-- Devices running Android 9 (API level 28) or lower  -->
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="28"/>
 
     <!-- Devices running Android 12L (API level 32) or lower  -->
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />


### PR DESCRIPTION
- The app was requesting storage permissions on Android 10 and higher, where the permission is no longer necessary.
- This permission was used for features allowing users to download attachments and review PDF files directly to the external download directory. However, starting with Android 10, the permission is no longer required.
- The permission check was updated to restrict storage access to devices with SDK <= P (Android 9), and the manifest was revised to request the permission only for devices with SDK <= 28. [Reference](https://developer.android.com/reference/android/app/DownloadManager.Request#setDestinationInExternalPublicDir(java.lang.String,%20java.lang.String))