### PR TITLE
fix: Improve playback error logging with user details

### DIFF
--- a/core/src/main/java/in/testpress/models/ProfileDetails.java
+++ b/core/src/main/java/in/testpress/models/ProfileDetails.java
@@ -482,4 +482,14 @@ public class ProfileDetails implements Parcelable {
         this.phone = phone;
     }
 
+    public String getUsernameOrEmail() {
+        if (username != null && !username.isEmpty()){
+            return username;
+        }
+        if (email != null && !email.isEmpty()) {
+            return email;
+        }
+        return "null";
+    }
+
 }

--- a/course/src/main/java/in/testpress/course/util/ExoPlayerUtil.java
+++ b/course/src/main/java/in/testpress/course/util/ExoPlayerUtil.java
@@ -974,7 +974,7 @@ public class ExoPlayerUtil implements VideoTimeRangeListener, DrmSessionManagerP
     }
 
     private void logPlaybackException(String errorMessage, String playbackId, PlaybackException exception) {
-        String username = getUsername(profileDetails, playbackId);
+        String username = (profileDetails != null) ? profileDetails.getUsernameOrEmail() : "null";
         String packageName = (activity != null) ? activity.getPackageName() : "Package name not available";
         long contentId = (content != null) ? content.getId() : -1;
         String cause = "Cause not found";
@@ -1003,19 +1003,5 @@ public class ExoPlayerUtil implements VideoTimeRangeListener, DrmSessionManagerP
                     }
                 }
         );
-    }
-
-    private String getUsername(ProfileDetails profileDetails, String playbackId) {
-        if (profileDetails == null) return playbackId;
-
-        if (profileDetails.getUsername() != null && !profileDetails.getUsername().isEmpty()) {
-            return profileDetails.getUsername();
-        }
-
-        if (profileDetails.getEmail() != null && !profileDetails.getEmail().isEmpty()) {
-            return profileDetails.getEmail();
-        }
-
-        return playbackId;
     }
 }

--- a/course/src/main/java/in/testpress/course/util/ExoPlayerUtil.java
+++ b/course/src/main/java/in/testpress/course/util/ExoPlayerUtil.java
@@ -978,9 +978,9 @@ public class ExoPlayerUtil implements VideoTimeRangeListener, DrmSessionManagerP
         String packageName = (activity != null) ? activity.getPackageName() : "Package name not available";
         long contentId = (content != null) ? content.getId() : -1;
         String cause = "Cause not found";
-        if (exception.getCause() != null) {
+        try {
             cause = exception.getCause().toString();
-        }
+        } catch (Exception ignored){}
         String finalCause = cause;
         Sentry.captureMessage(
                 errorMessage, new ScopeCallback() {


### PR DESCRIPTION
- Playback error logs lacked user-specific context, such as the username or package name, which would help in filtering and identifying issues.
- So user-specific details such as username and packageName are now included in the playback error logs, making it easier to filter and analyze issues.
