### PR TITLE
perf: Optimize course running and upcoming list screen

### DIFF
--- a/course/src/main/java/in/testpress/course/repository/CourseContentsRepository.kt
+++ b/course/src/main/java/in/testpress/course/repository/CourseContentsRepository.kt
@@ -16,7 +16,7 @@ class CourseContentsRepository(val context: Context, val courseId: Long = -1,val
 
     @OptIn(ExperimentalPagingApi::class)
     fun courseContentList() = Pager(
-        config = PagingConfig(pageSize = 20,initialLoadSize = 20),
+        config = PagingConfig(pageSize = 10, initialLoadSize = 20),
         remoteMediator = CourseContentsRemoteMediator(courseNetwork,database,courseId,type)
     ) {
         if (type == CourseContentType.RUNNING_CONTENT.ordinal){

--- a/course/src/main/java/in/testpress/course/repository/CourseContentsRepository.kt
+++ b/course/src/main/java/in/testpress/course/repository/CourseContentsRepository.kt
@@ -16,7 +16,7 @@ class CourseContentsRepository(val context: Context, val courseId: Long = -1,val
 
     @OptIn(ExperimentalPagingApi::class)
     fun courseContentList() = Pager(
-        config = PagingConfig(pageSize = 15),
+        config = PagingConfig(pageSize = 20,initialLoadSize = 20),
         remoteMediator = CourseContentsRemoteMediator(courseNetwork,database,courseId,type)
     ) {
         if (type == CourseContentType.RUNNING_CONTENT.ordinal){


### PR DESCRIPTION
- The app was making 3 unnecessary API calls during initial content load on running content and upcoming content list views, causing increased server load. This was happening because Paging library's default behavior loads 3× the page size on initialization. By aligning the initial load size with our API's page size of 20, we now make two API calls, reducing server load while still maintaining smooth content delivery.