### PR TITLE
fix: Track paused exam attempts to enable resume functionality

### DIFF
--- a/exam/src/main/java/in/testpress/exam/ui/TestActivity.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestActivity.java
@@ -302,7 +302,8 @@ public class TestActivity extends BaseToolBarActivity  {
             Toast.makeText(this,"Please connect to the internet to view your results.",Toast.LENGTH_SHORT).show();
             return;
         }
-        saveCourseAttemptInDB(courseAttempt);
+        saveCourseAttemptInDB(courseAttempt, true);
+        updatePauseAttemptCount();
         Attempt attempt = courseAttempt.getRawAssessment();
         if (attempt.getState().equals("Running") && attempt.getRemainingTime().equals("0:00:00")) {
             attempt.setRemainingTime(exam.getDuration());
@@ -601,8 +602,16 @@ public class TestActivity extends BaseToolBarActivity  {
         }
     }
 
-    private void saveCourseAttemptInDB(CourseAttempt courseAttempt) {
+    private void saveCourseAttemptInDB(CourseAttempt courseAttempt, boolean createdNewAttempt) {
         courseAttempt.saveInDB(this, courseContent);
+        if (createdNewAttempt) {
+            courseContent.setAttemptsCount(courseContent.getAttemptsCount() + 1);
+            ContentDao contentDao = TestpressSDKDatabase.getContentDao(this);
+            contentDao.insertOrReplace(courseContent);
+        }
+    }
+
+    private void updatePauseAttemptCount() {
         if (exam !=  null) {
             ExamDao examDao = TestpressSDKDatabase.getExamDao(this);
             exam.setPausedAttemptsCount(1);

--- a/exam/src/main/java/in/testpress/exam/ui/TestActivity.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestActivity.java
@@ -42,6 +42,7 @@ import in.testpress.models.greendao.Content;
 import in.testpress.models.greendao.ContentDao;
 import in.testpress.models.greendao.CourseAttempt;
 import in.testpress.models.greendao.Exam;
+import in.testpress.models.greendao.ExamDao;
 import in.testpress.models.greendao.Language;
 import in.testpress.network.Resource;
 import in.testpress.network.RetrofitCall;
@@ -301,7 +302,7 @@ public class TestActivity extends BaseToolBarActivity  {
             Toast.makeText(this,"Please connect to the internet to view your results.",Toast.LENGTH_SHORT).show();
             return;
         }
-        saveCourseAttemptInDB(courseAttempt, true);
+        saveCourseAttemptInDB(courseAttempt);
         Attempt attempt = courseAttempt.getRawAssessment();
         if (attempt.getState().equals("Running") && attempt.getRemainingTime().equals("0:00:00")) {
             attempt.setRemainingTime(exam.getDuration());
@@ -600,12 +601,12 @@ public class TestActivity extends BaseToolBarActivity  {
         }
     }
 
-    private void saveCourseAttemptInDB(CourseAttempt courseAttempt, boolean createdNewAttempt) {
+    private void saveCourseAttemptInDB(CourseAttempt courseAttempt) {
         courseAttempt.saveInDB(this, courseContent);
-        if (createdNewAttempt) {
-            courseContent.setAttemptsCount(courseContent.getAttemptsCount() + 1);
-            ContentDao contentDao = TestpressSDKDatabase.getContentDao(this);
-            contentDao.insertOrReplace(courseContent);
+        if (exam !=  null) {
+            ExamDao examDao = TestpressSDKDatabase.getExamDao(this);
+            exam.setPausedAttemptsCount(1);
+            examDao.updateInTx(exam);
         }
     }
 


### PR DESCRIPTION
#### Issue:
- If a user starts an exam and then force-closes the app, there is no way to determine the exam's status.
- As a result, the "Resume" button may not appear correctly on the exam detail screen.
#### Cause:
- The app does not track whether an exam was in progress when the app was closed.
#### Fix:
- When a user starts an exam, the pausedAttemptsCount is set to 1 in the Exam entity.
- This value is then used in the exam detail screen to determine if the "Resume" button should be displayed.
