### PR TITLE
fix: Prevent NullPointerException in isInstituteUrl method by adding null checks

### DIFF
--- a/core/src/main/java/in/testpress/models/InstituteSettings.java
+++ b/core/src/main/java/in/testpress/models/InstituteSettings.java
@@ -376,7 +376,9 @@ public class InstituteSettings {
     }
 
     public boolean isInstituteUrl(String url) {
-        return url.contains(baseUrl) || url.contains(whiteLabeledHostUrl);
+        return url != null &&
+                (baseUrl != null && url.contains(baseUrl) ||
+                        whiteLabeledHostUrl != null && url.contains(whiteLabeledHostUrl));
     }
 
     public String getCurrentPaymentApp() {


### PR DESCRIPTION
### Issue:
- A NullPointerException occurs when the url, baseUrl, or whiteLabeledHostUrl is null in the isInstituteUrl method.
- This leads to a crash when the String.contains() method is invoked on a null value.
### Cause:
- The contains() method was being called on potentially null objects, causing the exception when any of the arguments is null.
### Fix:
- Added null checks for url, baseUrl, and whiteLabeledHostUrl to ensure that the contains() method is only called when they are not null.
- This prevents the NullPointerException and ensures that the method behaves safely when handling null values.
