### PR TITLE
fix: Prevent NullPointerException in refreshAdapter of UserActivityFragment

### DIFF
--- a/core/src/main/java/in/testpress/ui/UserActivityFragment.java
+++ b/core/src/main/java/in/testpress/ui/UserActivityFragment.java
@@ -43,9 +43,11 @@ public class UserActivityFragment extends PagedItemFragment<AccountActivity> {
     protected void setEmptyText() {}
 
     public void refreshAdapter() {
-        items.clear();
-        getListAdapter().getWrappedAdapter().setItems(items);
-        refreshWithProgress();
+        if (getListAdapter() != null && getListAdapter().getWrappedAdapter() != null) {
+            items.clear();
+            getListAdapter().getWrappedAdapter().setItems(items);
+            refreshWithProgress();
+        }
     }
 
     @Override


### PR DESCRIPTION
### Issue:
- A NullPointerException was occurring in UserActivityFragment.refreshAdapter() when calling getWrappedAdapter() on a null getListAdapter().
- This happened when refreshAdapter was called before the adapter was initialized.
### Fix:
- Added a null check to ensure getListAdapter() and getWrappedAdapter() are not null before clearing items and refreshing the adapter.
