### PR TITLE
enhancement: Add force fetch parameter to reload content

### DIFF
--- a/course/src/main/java/in/testpress/course/fragments/BaseContentDetailFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/BaseContentDetailFragment.kt
@@ -9,8 +9,6 @@ import `in`.testpress.course.di.InjectorUtils
 import `in`.testpress.course.domain.DomainContent
 import `in`.testpress.course.ui.ContentActivity
 import `in`.testpress.enums.Status
-import `in`.testpress.course.ui.ContentActivity.CONTENT_ID
-import `in`.testpress.course.ui.ContentActivity.HIDE_BOTTOM_NAVIGATION
 import `in`.testpress.course.viewmodels.ContentViewModel
 import `in`.testpress.fragments.EmptyViewFragment
 import `in`.testpress.fragments.EmptyViewListener
@@ -29,6 +27,7 @@ import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+import `in`.testpress.course.ui.ContentActivity.*
 
 abstract class BaseContentDetailFragment : Fragment(), BookmarkListener, ContentActivity.OnBackPressedListener,
     EmptyViewListener {
@@ -48,6 +47,7 @@ abstract class BaseContentDetailFragment : Fragment(), BookmarkListener, Content
     @VisibleForTesting(otherwise = VisibleForTesting.PROTECTED)
     open lateinit var viewModel: ContentViewModel
     private var hideBottomNavigation: Boolean = false
+    private var forceReloadContent: Boolean = false
 
     override val bookmarkId: Long?
         get() = if (!::content.isInitialized) null else content.bookmarkId
@@ -94,7 +94,7 @@ abstract class BaseContentDetailFragment : Fragment(), BookmarkListener, Content
 
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     fun loadContentAndInitializeBoomarkFragment() {
-        viewModel.getContent(contentId).observe(viewLifecycleOwner, Observer { resource ->
+        viewModel.getContent(contentId, forceReloadContent).observe(viewLifecycleOwner, Observer { resource ->
             when (resource.status) {
                 Status.SUCCESS -> {
                     content = resource.data!!
@@ -126,6 +126,7 @@ abstract class BaseContentDetailFragment : Fragment(), BookmarkListener, Content
         contentId = requireArguments().getLong(CONTENT_ID, -1)
         productSlug = requireArguments().getString(PRODUCT_SLUG)
         hideBottomNavigation = requireArguments().getBoolean(HIDE_BOTTOM_NAVIGATION, false)
+        forceReloadContent = requireArguments().getBoolean(FORCE_REFRESH_CONTENT, false)
     }
 
     @VisibleForTesting(otherwise = VisibleForTesting.PROTECTED)

--- a/course/src/main/java/in/testpress/course/ui/ContentActivity.java
+++ b/course/src/main/java/in/testpress/course/ui/ContentActivity.java
@@ -30,6 +30,7 @@ public class ContentActivity extends BaseToolBarActivity implements ContentFragm
     public static final String CHAPTER_ID = "chapterId";
     public static final String POSITION = "position";
     public static final String HIDE_BOTTOM_NAVIGATION = "hideBottomNavigation";
+    public static final String FORCE_REFRESH_CONTENT = "forceRefreshContent";
 
     public static Intent createIntent(Long contentId, Context context, String productSlug) {
         Intent intent = new Intent(context, ContentActivity.class);
@@ -43,6 +44,15 @@ public class ContentActivity extends BaseToolBarActivity implements ContentFragm
         intent.putExtra(CONTENT_ID, contentId);
         intent.putExtra(PRODUCT_SLUG, productSlug);
         intent.putExtra(HIDE_BOTTOM_NAVIGATION,hideBottomNavigation);
+        return intent;
+    }
+
+    public static Intent createIntent(Long contentId, Context context, String productSlug,Boolean hideBottomNavigation,Boolean forceRefreshContent) {
+        Intent intent = new Intent(context, ContentActivity.class);
+        intent.putExtra(CONTENT_ID, contentId);
+        intent.putExtra(PRODUCT_SLUG, productSlug);
+        intent.putExtra(HIDE_BOTTOM_NAVIGATION,hideBottomNavigation);
+        intent.putExtra(FORCE_REFRESH_CONTENT,forceRefreshContent);
         return intent;
     }
 


### PR DESCRIPTION
Added a new parameter `forceRefreshContent` in `ContentActivity` to allow forced content fetching. This ensures that content is refreshed explicitly when needed. Updated `BaseContentDetailFragment` to handle this new parameter while loading content.
