### PR TITLE
fix: Prevent crash when seeking in ExoPlayer

### DIFF
--- a/course/src/main/java/in/testpress/course/util/ExoPlayerUtil.java
+++ b/course/src/main/java/in/testpress/course/util/ExoPlayerUtil.java
@@ -355,7 +355,9 @@ public class ExoPlayerUtil implements VideoTimeRangeListener, DrmSessionManagerP
     }
 
     public void seekTo(Long milliSeconds) {
-        player.seekTo(milliSeconds);
+        if (player != null){
+            player.seekTo(milliSeconds);
+        }
     }
 
     private void initResolutionSelector() {


### PR DESCRIPTION
Added a null check for the ExoPlayer instance before calling seekTo(). This prevents crashes caused by attempting to seek when the player is not initialized. The issue occurred when videoWidgetFragment was not properly set up before seeking, leading to a NullPointerException.
