### PR TITLE
fix: Apply throttling for failed user video API requests

### DIFF
--- a/course/src/main/java/in/testpress/course/util/ExoPlayerUtil.java
+++ b/course/src/main/java/in/testpress/course/util/ExoPlayerUtil.java
@@ -734,8 +734,10 @@ public class ExoPlayerUtil implements VideoTimeRangeListener, DrmSessionManagerP
                         }
                         if (exception.isTooManyRequest()){
                             throttleTimeRemaining = exception.getThrottleTime();
-                            lastApiCallTime = System.currentTimeMillis() / 1000;
+                        } else {
+                            throttleTimeRemaining = 60;
                         }
+                        lastApiCallTime = System.currentTimeMillis() / 1000;
                     }
                 });
     }


### PR DESCRIPTION
Updated the throttling mechanism to apply even when an API request fails. Previously, throttling was only set for successful responses, which caused repeated API calls in case of failures. Now, a default throttling time of 60 seconds is applied when an API request fails, preventing excessive retries.