### PR TITLE
fix: Handle quizOperationsCallback reinitialization after activity recreation

### DIFF
--- a/course/src/main/java/in/testpress/course/fragments/QuizQuestionFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/QuizQuestionFragment.kt
@@ -44,7 +44,7 @@ class QuizQuestionFragment : Fragment() {
     private lateinit var webViewUtils: WebViewUtils
     lateinit var viewModel: QuizViewModel
     private lateinit var userSelectedAnswer: DomainUserSelectedAnswer
-    lateinit var quizOperationsCallback: QuizOperationsCallback
+    var quizOperationsCallback: QuizOperationsCallback? = null
     private lateinit var instituteSettings: InstituteSettings
 
     private var examId: Long = -1
@@ -383,7 +383,7 @@ class QuizQuestionFragment : Fragment() {
 
         @JavascriptInterface
         fun onSkip() {
-            quizOperationsCallback.onSkip()
+            quizOperationsCallback?.onSkip()
         }
 
         @JavascriptInterface

--- a/course/src/main/java/in/testpress/course/fragments/RootQuizFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/RootQuizFragment.kt
@@ -13,7 +13,7 @@ class RootQuizFragment: Fragment() {
     private lateinit var reviewFragment: QuizReviewFragment
 
     lateinit var nextQuizHandler: NextQuizHandler
-    lateinit var quizOperationsCallback: QuizOperationsCallback
+    var quizOperationsCallback: QuizOperationsCallback? = null
     private var position: Int = 0
     private var examId: Long = -1
     private var attemptId: Long = -1


### PR DESCRIPTION
Fixed a crash occurring during activity recreation in low-memory conditions due to `quizOperationsCallback` being uninitialized. Changed it from `lateinit var` to a nullable variable and updated its usage to prevent `UninitializedPropertyAccessException`. This ensures the app gracefully handles callback availability after activity recreation.