### PR TITLE
feat: Add free course preview for product list items

### DIFF
--- a/course/src/main/java/in/testpress/course/AvailableCourseListAdapter.java
+++ b/course/src/main/java/in/testpress/course/AvailableCourseListAdapter.java
@@ -1,7 +1,5 @@
 package in.testpress.course;
 
-import static in.testpress.store.TestpressStore.STORE_REQUEST_CODE;
-
 import android.app.Activity;
 import android.content.Intent;
 import android.view.View;
@@ -101,11 +99,8 @@ public class AvailableCourseListAdapter extends SingleTypeAdapter<Product> {
         } else {
             Intent intent = new Intent(activity, ProductDetailsActivity.class);
             intent.putExtra(ProductDetailsActivity.PRODUCT_SLUG, product.getSlug());
-            activity.startActivityForResult(intent, STORE_REQUEST_CODE);
+            activity.startActivityForResult(intent, TestpressStore.STORE_REQUEST_CODE);
         }
-//        Intent intent = new Intent(activity, ProductDetailsActivity.class);
-//        intent.putExtra(ProductDetailsActivity.PRODUCT_SLUG, product.getSlug());
-//        activity.startActivityForResult(intent, TestpressStore.STORE_REQUEST_CODE);
     }
 
     private void openChapters(Product product, Activity activity) {

--- a/course/src/main/java/in/testpress/course/AvailableCourseListAdapter.java
+++ b/course/src/main/java/in/testpress/course/AvailableCourseListAdapter.java
@@ -1,5 +1,7 @@
 package in.testpress.course;
 
+import static in.testpress.store.TestpressStore.STORE_REQUEST_CODE;
+
 import android.app.Activity;
 import android.content.Intent;
 import android.view.View;
@@ -12,6 +14,8 @@ import java.util.List;
 
 import in.testpress.core.TestpressSDKDatabase;
 import in.testpress.core.TestpressSdk;
+import in.testpress.course.ui.ChapterDetailActivity;
+import in.testpress.course.ui.CoursePreviewActivity;
 import in.testpress.models.greendao.Course;
 import in.testpress.models.greendao.CourseDao;
 import in.testpress.models.greendao.Product;
@@ -90,9 +94,25 @@ public class AvailableCourseListAdapter extends SingleTypeAdapter<Product> {
     }
 
     private void showProductDetail(Product product) {
-        Intent intent = new Intent(activity, ProductDetailsActivity.class);
-        intent.putExtra(ProductDetailsActivity.PRODUCT_SLUG, product.getSlug());
-        activity.startActivityForResult(intent, TestpressStore.STORE_REQUEST_CODE);
+        if (product.getCourseIds().size() > 1) {
+            activity.startActivity(CoursePreviewActivity.createIntent(product.getCourseIds(), activity, product.getSlug()));
+        } else if (product.getCourseIds().size() == 1 ) {
+            openChapters(product, activity);
+        } else {
+            Intent intent = new Intent(activity, ProductDetailsActivity.class);
+            intent.putExtra(ProductDetailsActivity.PRODUCT_SLUG, product.getSlug());
+            activity.startActivityForResult(intent, STORE_REQUEST_CODE);
+        }
+//        Intent intent = new Intent(activity, ProductDetailsActivity.class);
+//        intent.putExtra(ProductDetailsActivity.PRODUCT_SLUG, product.getSlug());
+//        activity.startActivityForResult(intent, TestpressStore.STORE_REQUEST_CODE);
+    }
+
+    private void openChapters(Product product, Activity activity) {
+        activity.startActivity(ChapterDetailActivity.createIntent(
+                product.getTitle(),
+                product.getCourseIds().get(0).toString(),
+                activity, product.getSlug()));
     }
 
 }

--- a/course/src/main/java/in/testpress/course/ui/ChapterDetailActivity.java
+++ b/course/src/main/java/in/testpress/course/ui/ChapterDetailActivity.java
@@ -82,6 +82,10 @@ public class ChapterDetailActivity extends BaseToolBarActivity {
     }
 
     public static Intent createIntent(String chaptersUrl, Context context, String productSlug) {
+        return ChapterDetailActivity.createIntent(chaptersUrl, context, productSlug, false);
+    }
+
+    public static Intent createIntent(String chaptersUrl, Context context, String productSlug, boolean showBuyNowButton) {
         Intent intent = new Intent(context, ChapterDetailActivity.class);
         intent.putExtra(CHAPTER_URL, chaptersUrl);
         intent.putExtra(PRODUCT_SLUG, productSlug);

--- a/course/src/main/java/in/testpress/course/ui/ChaptersListAdapter.java
+++ b/course/src/main/java/in/testpress/course/ui/ChaptersListAdapter.java
@@ -100,7 +100,8 @@ class ChaptersListAdapter extends SingleTypeAdapter<Chapter> {
                     activity.startActivity(ChapterDetailActivity.createIntent(
                             chapter.getUrl(),
                             activity,
-                            productSlug)
+                            productSlug,
+                            !productSlug.isEmpty())
                     );
                 }
             });


### PR DESCRIPTION
- Implemented free preview for courses when users click on a product from the product list.
- If a product has multiple courses, it navigates to CoursePreviewActivity.
- If a product has only one course, it directly opens ChapterDetailActivity.
- Added an overload method in ChapterDetailActivity.createIntent to handle the "Buy Now" button visibility.
- Ensured that clicking a chapter correctly passes the product slug and shows the "Buy Now" button when applicable.
