### PR TITLE
fix: Resolve GitHub Actions build failures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
         uses: android-actions/setup-android@v2
 
       - name: Caching Gradle packages
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.gradle/caches
@@ -31,7 +31,7 @@ jobs:
             ${{ runner.os }}-gradle-
 
       - name: Checkout the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Cache Zoom SDK files
         id: zoom-cache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,11 +31,11 @@ jobs:
             ${{ runner.os }}-gradle-
 
       - name: Checkout the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v2
 
       - name: Cache Zoom SDK files
         id: zoom-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ./mobilertc


### PR DESCRIPTION
- Build actions were failing due to the deprecated `actions/cache@v2`.
- In this commit, we updated the action to `actions/cache@v3`, which resolves the issue.
