### PR TITLE
fix: Prevent null productSlug from affecting chapter detail navigation

### DIFF
--- a/course/src/main/java/in/testpress/course/ui/ChaptersListAdapter.java
+++ b/course/src/main/java/in/testpress/course/ui/ChaptersListAdapter.java
@@ -101,7 +101,7 @@ class ChaptersListAdapter extends SingleTypeAdapter<Chapter> {
                             chapter.getUrl(),
                             activity,
                             productSlug,
-                            !productSlug.isEmpty())
+                            productSlug != null && !productSlug.isEmpty())
                     );
                 }
             });


### PR DESCRIPTION
- Updated the product slug check to ensure `productSlug != null && !productSlug.isEmpty()` before determining whether to show the "Buy Now" button.
- Prevents potential NullPointerException issues when navigating to `ChapterDetailActivity`.