### PR TITLE
fix: Enable third-party cookies in WebView for embedded content

### DIFF
--- a/course/src/main/java/in/testpress/course/fragments/WebViewVideoFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/WebViewVideoFragment.kt
@@ -17,6 +17,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.webkit.CookieManager
 import android.webkit.WebView
 import android.widget.ProgressBar
 import androidx.lifecycle.Observer
@@ -82,6 +83,8 @@ open class WebViewVideoFragment : BaseVideoWidgetFragment() {
         webView.scrollBarStyle = WebView.SCROLLBARS_OUTSIDE_OVERLAY
         webView.setOnLongClickListener { true }
         webView.isLongClickable = false
+        // Enable third-party cookies for embedded code content
+        CookieManager.getInstance().setAcceptThirdPartyCookies(webView, true)
     }
 
     open fun loadVideo(content: DomainContent) {


### PR DESCRIPTION
- Used CookieManager.getInstance().setAcceptThirdPartyCookies(webView, true) to ensure third-party cookies are accepted in WebView.
- This change resolves potential issues with authentication and accessing embedded content that relies on third-party cookies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced video playback by supporting third-party cookies, ensuring embedded content that relies on external cookie data displays correctly for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->