### PR TITLE
fix: Preserve fullscreen mode for embedded content in WebView

### DIFF
--- a/course/src/main/java/in/testpress/course/fragments/WebViewVideoFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/WebViewVideoFragment.kt
@@ -88,7 +88,7 @@ open class WebViewVideoFragment : BaseVideoWidgetFragment() {
     }
 
     open fun loadVideo(content: DomainContent) {
-        val html = if (video?.embedCode?.contains("class=\"fullscreenContent\"") == true) {
+        val html = if (video?.embedCode?.contains("class=\"fullscreen\"") == true) {
             video?.embedCode
         } else {
             "<div style='margin-top: 15px padding-left: 20px padding-right: 20px'" +

--- a/course/src/main/java/in/testpress/course/fragments/WebViewVideoFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/WebViewVideoFragment.kt
@@ -88,7 +88,7 @@ open class WebViewVideoFragment : BaseVideoWidgetFragment() {
     }
 
     open fun loadVideo(content: DomainContent) {
-        val html = if (video?.embedCode?.contains("class=\"fullscreen\"") == true) {
+        val html = if (video?.embedCode?.contains("class=\"fullscreenContent\"") == true) {
             video?.embedCode
         } else {
             "<div style='margin-top: 15px padding-left: 20px padding-right: 20px'" +

--- a/course/src/main/java/in/testpress/course/fragments/WebViewVideoFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/WebViewVideoFragment.kt
@@ -17,6 +17,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.webkit.CookieManager
 import android.webkit.WebView
 import android.widget.ProgressBar
 import androidx.lifecycle.Observer
@@ -82,6 +83,8 @@ open class WebViewVideoFragment : BaseVideoWidgetFragment() {
         webView.scrollBarStyle = WebView.SCROLLBARS_OUTSIDE_OVERLAY
         webView.setOnLongClickListener { true }
         webView.isLongClickable = false
+        // Enable third-party cookies for embedded code content
+        CookieManager.getInstance().setAcceptThirdPartyCookies(webView, true)
     }
 
     open fun loadVideo(content: DomainContent) {

--- a/course/src/main/java/in/testpress/course/fragments/WebViewVideoFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/WebViewVideoFragment.kt
@@ -88,8 +88,12 @@ open class WebViewVideoFragment : BaseVideoWidgetFragment() {
     }
 
     open fun loadVideo(content: DomainContent) {
-        val html = "<div style='margin-top: 15px padding-left: 20px padding-right: 20px'" +
-            "class='videoWrapper'>" + video?.embedCode + "</div>"
+        val html = if (video?.embedCode?.contains("class=\"fullscreenContent\"") == true) {
+            video?.embedCode
+        } else {
+            "<div style='margin-top: 15px padding-left: 20px padding-right: 20px'" +
+                    "class='videoWrapper'>" + video?.embedCode + "</div>"
+        }
 
         webViewUtils.initWebView(html, activity)
         webView.webChromeClient = fullScreenChromeClient


### PR DESCRIPTION
- Updated loadVideo method in WebViewVideoFragment to differentiate between video and non-video embedded content based on the fullscreen class.
- Video Embed Content: Wrapped in a videoWrapper to maintain a 16:9 aspect ratio.
- Non-Video Embed Content: Displayed in fullscreen without additional wrapping.
