### PR TITLE
fix: Preserve fullscreen mode for embedded content in WebView

### DIFF
--- a/course/src/main/java/in/testpress/course/fragments/WebViewVideoFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/WebViewVideoFragment.kt
@@ -88,7 +88,7 @@ open class WebViewVideoFragment : BaseVideoWidgetFragment() {
     }
 
     open fun loadVideo(content: DomainContent) {
-        val html = if (video?.embedCode?.contains("class=\"fullscreenContent\"") == true) {
+        val html = if (video?.embedCode?.contains("class=\"fullscreen\"") == true) {
             video?.embedCode
         } else {
             "<div style='margin-top: 15px padding-left: 20px padding-right: 20px'" +

--- a/course/src/main/java/in/testpress/course/fragments/WebViewVideoFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/WebViewVideoFragment.kt
@@ -88,7 +88,7 @@ open class WebViewVideoFragment : BaseVideoWidgetFragment() {
     }
 
     open fun loadVideo(content: DomainContent) {
-        val html = if (video?.embedCode?.contains("class=\"fullscreen\"") == true) {
+        val html = if (video?.embedCode?.contains("class=\"fullscreenContent\"") == true) {
             video?.embedCode
         } else {
             "<div style='margin-top: 15px padding-left: 20px padding-right: 20px'" +

--- a/course/src/main/java/in/testpress/course/fragments/WebViewVideoFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/WebViewVideoFragment.kt
@@ -88,8 +88,12 @@ open class WebViewVideoFragment : BaseVideoWidgetFragment() {
     }
 
     open fun loadVideo(content: DomainContent) {
-        val html = "<div style='margin-top: 15px padding-left: 20px padding-right: 20px'" +
-            "class='videoWrapper'>" + video?.embedCode + "</div>"
+        val html = if (video?.embedCode?.contains("class=\"fullscreenContent\"") == true) {
+            video?.embedCode
+        } else {
+            "<div style='margin-top: 15px padding-left: 20px padding-right: 20px'" +
+                    "class='videoWrapper'>" + video?.embedCode + "</div>"
+        }
 
         webViewUtils.initWebView(html, activity)
         webView.webChromeClient = fullScreenChromeClient


### PR DESCRIPTION
- Updated loadVideo method in WebViewVideoFragment to differentiate between video and non-video embedded content based on the fullscreen class.
- Video Embed Content: Wrapped in a videoWrapper to maintain a 16:9 aspect ratio.
- Non-Video Embed Content: Displayed in fullscreen without additional wrapping.