### PR TITLE
fix: Prevent crash when product images list is empty in ProductDetailsActivity

### DIFF
--- a/store/src/main/java/in/testpress/store/ui/ProductDetailsActivity.java
+++ b/store/src/main/java/in/testpress/store/ui/ProductDetailsActivity.java
@@ -41,6 +41,7 @@ import in.testpress.core.TestpressSession;
 import in.testpress.exam.TestpressExam;
 import in.testpress.models.InstituteSettings;
 import in.testpress.store.R;
+import in.testpress.store.models.Images;
 import in.testpress.store.models.Order;
 import in.testpress.store.models.OrderItem;
 import in.testpress.store.models.Product;
@@ -227,8 +228,10 @@ public class ProductDetailsActivity extends BaseToolBarActivity {
 
         ImageLoader imageLoader = ImageUtils.initImageLoader(this);
         DisplayImageOptions options = ImageUtils.getPlaceholdersOption();
-        imageLoader.displayImage(product.getImages().get(0).getOriginal(), image, options);
-
+        String productImageURL = (product.getImages() != null && !product.getImages().isEmpty())
+                ? product.getImages().get(0).getOriginal()
+                : "";
+        imageLoader.displayImage(productImageURL, image, options);
         titleText.setText(product.getTitle());
         buyButton.setText(product.getBuyNowText());
 

--- a/store/src/main/java/in/testpress/store/ui/ProductDetailsActivity.java
+++ b/store/src/main/java/in/testpress/store/ui/ProductDetailsActivity.java
@@ -41,7 +41,6 @@ import in.testpress.core.TestpressSession;
 import in.testpress.exam.TestpressExam;
 import in.testpress.models.InstituteSettings;
 import in.testpress.store.R;
-import in.testpress.store.models.Images;
 import in.testpress.store.models.Order;
 import in.testpress.store.models.OrderItem;
 import in.testpress.store.models.Product;


### PR DESCRIPTION
- Added a null and empty check for product.getImages() before accessing the first image URL.
- Prevents potential crashes when the product does not have any images.
- Ensures the displayImage method receives a valid (even if empty) URL instead of causing an IndexOutOfBoundsException.