### PR TITLE
feat: Add network models for product and image mapping in store module

### DIFF
--- a/store/src/main/java/in/testpress/store/data/model/NetworkImage.kt
+++ b/store/src/main/java/in/testpress/store/data/model/NetworkImage.kt
@@ -1,0 +1,16 @@
+package `in`.testpress.store.data.model
+
+import `in`.testpress.database.entities.Image
+
+
+data class NetworkImage(
+    val original: String?,
+    val medium: String?,
+    val small: String?
+)
+
+fun NetworkImage.asDomain(): Image {
+    return Image(this.original, this.medium, this.small)
+}
+
+fun List<NetworkImage>.asDomain(): List<Image> = this.map { it.asDomain() }

--- a/store/src/main/java/in/testpress/store/data/model/NetworkProductListResponse.kt
+++ b/store/src/main/java/in/testpress/store/data/model/NetworkProductListResponse.kt
@@ -1,0 +1,13 @@
+package `in`.testpress.store.data.model
+
+data class NetworkProductListResponse(
+    val count: Int,
+    val next: String?,
+    val previous: String?,
+    val perPage: Int,
+    val results: Results
+)
+
+data class Results(
+    val products: List<NetworkProductLite>
+)

--- a/store/src/main/java/in/testpress/store/data/model/NetworkProductLite.kt
+++ b/store/src/main/java/in/testpress/store/data/model/NetworkProductLite.kt
@@ -1,0 +1,32 @@
+package `in`.testpress.store.data.model
+
+import `in`.testpress.database.entities.ProductLiteEntity
+
+
+data class NetworkProductLite(
+    val id: Int?,
+    val title: String?,
+    val slug: String?,
+    val images: List<NetworkImage>? = null,
+    val categoryId: Int?,
+    val contentsCount: Int = 0,
+    val chaptersCount: Int = 0,
+    val order: Int?,
+    val price: String?
+)
+
+fun NetworkProductLite.asDomain(): ProductLiteEntity {
+    return ProductLiteEntity(
+        this.id ?: -1,
+        this.title ?: "",
+        this.slug ?: "",
+        this.images?.asDomain(),
+        this.categoryId,
+        this.contentsCount,
+        this.chaptersCount,
+        this.order ?: -1,
+        this.price ?: ""
+    )
+}
+
+fun List<NetworkProductLite>.asDomain(): List<ProductLiteEntity> = this.map { it.asDomain() }


### PR DESCRIPTION
- Introduced NetworkImage, NetworkProductLite, and NetworkProductListResponse models for handling API responses in the store module.
- Added extension functions to map network models to domain entities (asDomain() for NetworkImage and NetworkProductLite).
- Ensures a structured approach for transforming API responses into database-compatible models.
- Lays the groundwork for a more scalable and maintainable data layer in the store module.
