### PR TITLE
feat: Add NetworkProductCategory model and mapping to domain entity

### DIFF
--- a/store/src/main/java/in/testpress/store/data/model/NetworkProductCategory.kt
+++ b/store/src/main/java/in/testpress/store/data/model/NetworkProductCategory.kt
@@ -1,0 +1,15 @@
+package `in`.testpress.store.data.model
+
+import `in`.testpress.database.entities.ProductCategoryEntity
+
+data class NetworkProductCategory(
+    val id: Int?,
+    val name: String?,
+    val slug: String?
+)
+
+fun NetworkProductCategory.asDomain(): ProductCategoryEntity {
+    return ProductCategoryEntity(this.id, this.name, this.slug)
+}
+
+fun List<NetworkProductCategory>.asDomain(): List<ProductCategoryEntity> = this.map { it.asDomain() }


### PR DESCRIPTION
- Introduced NetworkProductCategory data model for handling category responses from the API.
- Added mapping functions to convert network models to ProductCategoryEntity domain entities.
- This lays the groundwork for syncing product categories from the backend to the local database.
