### PR TITLE
refactor: Extract base paginated repository for reusability

### DIFF
--- a/core/src/main/java/in/testpress/data/repository/BasePaginatedRepository.kt
+++ b/core/src/main/java/in/testpress/data/repository/BasePaginatedRepository.kt
@@ -65,7 +65,7 @@ abstract class BasePaginatedRepository<NetworkResponseT, DomainEntityT>(
     private fun fetchFromNetwork() {
         scope.launch {
             stateMutex.withLock {
-                if (isLoading || !hasNextPage) return
+                if (isLoading || !hasNextPage) return@launch
                 isLoading = true
             }
         }

--- a/core/src/main/java/in/testpress/data/repository/BasePaginatedRepository.kt
+++ b/core/src/main/java/in/testpress/data/repository/BasePaginatedRepository.kt
@@ -63,10 +63,9 @@ abstract class BasePaginatedRepository<NetworkResponseT, DomainEntityT>(
     }
 
     private fun fetchFromNetwork() {
-        if (isLoading || !hasNextPage) return
-
         scope.launch {
             stateMutex.withLock {
+                if (isLoading || !hasNextPage) return
                 isLoading = true
             }
         }

--- a/core/src/main/java/in/testpress/data/repository/BasePaginatedRepository.kt
+++ b/core/src/main/java/in/testpress/data/repository/BasePaginatedRepository.kt
@@ -9,15 +9,17 @@ import `in`.testpress.database.TestpressDatabase
 import `in`.testpress.network.Resource
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 abstract class BasePaginatedRepository<NetworkResponseT, DomainEntityT>(
-    private val context: Context
+    private val context: Context,
+    private val scope: CoroutineScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
 ) {
 
-    private val scope = CoroutineScope(Dispatchers.IO)
-    protected val database = TestpressDatabase.invoke(context)
+    protected val database = TestpressDatabase.invoke(context.applicationContext)
     private var currentPage = 1
     private var isLoading = false
     private var hasNextPage = true
@@ -47,6 +49,10 @@ abstract class BasePaginatedRepository<NetworkResponseT, DomainEntityT>(
 
     fun retryNextPage() {
         fetchFromNetwork()
+    }
+
+    fun cancelScope() {
+        scope.cancel()
     }
 
     private fun fetchFromNetwork() {

--- a/core/src/main/java/in/testpress/data/repository/BasePaginatedRepository.kt
+++ b/core/src/main/java/in/testpress/data/repository/BasePaginatedRepository.kt
@@ -70,10 +70,10 @@ abstract class BasePaginatedRepository<NetworkResponseT, DomainEntityT>(
                 scope.launch { handleSuccess(result as NetworkResponseT) }
             }
 
-            override fun onException(exception: TestpressException?) {
+            override fun onException(exception: TestpressException) {
                 isLoading = false
                 lastFailedPage = currentPage
-                _resource.postValue(Resource.error(exception!!, _resource.value?.data))
+                _resource.postValue(Resource.error(exception, _resource.value?.data))
             }
         })
     }

--- a/core/src/main/java/in/testpress/data/repository/BasePaginatedRepository.kt
+++ b/core/src/main/java/in/testpress/data/repository/BasePaginatedRepository.kt
@@ -1,0 +1,95 @@
+package `in`.testpress.data.repository
+
+import android.content.Context
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import `in`.testpress.core.TestpressCallback
+import `in`.testpress.core.TestpressException
+import `in`.testpress.database.TestpressDatabase
+import `in`.testpress.network.Resource
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+abstract class BasePaginatedRepository<NetworkResponseT, DomainEntityT>(
+    private val context: Context
+) {
+
+    private val scope = CoroutineScope(Dispatchers.IO)
+    protected val database = TestpressDatabase.invoke(context)
+    private var currentPage = 1
+    private var isLoading = false
+    private var hasNextPage = true
+    private var lastFailedPage: Int? = null
+
+    protected val _resource = MutableLiveData<Resource<List<DomainEntityT>>>()
+    val resource: LiveData<Resource<List<DomainEntityT>>> get() = _resource
+
+    init {
+        loadFromDatabase()
+    }
+
+    private fun loadFromDatabase() {
+        _resource.value = Resource.loading(null)
+        scope.launch {
+            val cached = getFromDb()
+            if (cached.isNotEmpty()) {
+                withContext(Dispatchers.Main) {
+                    _resource.value = Resource.success(cached)
+                }
+            }
+            fetchFromNetwork()
+        }
+    }
+
+    fun fetchNextPage() {
+        if (isLoading || !hasNextPage || lastFailedPage == currentPage) return
+        currentPage++
+        fetchFromNetwork()
+    }
+
+    fun retryNextPage() {
+        fetchFromNetwork()
+    }
+
+    private fun fetchFromNetwork() {
+        if (isLoading || !hasNextPage) return
+
+        isLoading = true
+        _resource.postValue(Resource.loading(null))
+
+        val queryParams = hashMapOf<String, Any>("page" to currentPage)
+        makeNetworkCall(queryParams, object : TestpressCallback<Any>() {
+            override fun onSuccess(result: Any) {
+                isLoading = false
+                lastFailedPage = null
+                hasNextPage = extractNextPageAvailable(result)
+                scope.launch { handleSuccess(result as NetworkResponseT) }
+            }
+
+            override fun onException(exception: TestpressException?) {
+                isLoading = false
+                lastFailedPage = currentPage
+                _resource.postValue(Resource.error(exception!!, _resource.value?.data))
+            }
+        })
+    }
+
+    private suspend fun handleSuccess(response: NetworkResponseT) {
+        if (currentPage == 1) clearLocalDb()
+        saveToDb(response)
+        updateLiveDataFromDb()
+    }
+
+    protected abstract suspend fun getFromDb(): List<DomainEntityT>
+    protected abstract suspend fun clearLocalDb()
+    protected abstract suspend fun saveToDb(response: NetworkResponseT)
+    protected abstract suspend fun updateLiveDataFromDb()
+    protected abstract fun makeNetworkCall(
+        queryParams: Map<String, Any>,
+        callback: TestpressCallback<*>
+    )
+
+    protected abstract fun extractNextPageAvailable(response: Any): Boolean
+}

--- a/core/src/main/java/in/testpress/data/repository/BasePaginatedRepository.kt
+++ b/core/src/main/java/in/testpress/data/repository/BasePaginatedRepository.kt
@@ -26,11 +26,7 @@ abstract class BasePaginatedRepository<NetworkResponseT, DomainEntityT>(
     protected val _resource = MutableLiveData<Resource<List<DomainEntityT>>>()
     val resource: LiveData<Resource<List<DomainEntityT>>> get() = _resource
 
-    init {
-        loadFromDatabase()
-    }
-
-    private fun loadFromDatabase() {
+    protected fun loadFromDatabase() {
         _resource.value = Resource.loading(null)
         scope.launch {
             val cached = getFromDb()

--- a/store/src/main/java/in/testpress/store/data/repository/ProductCategoryRepository.kt
+++ b/store/src/main/java/in/testpress/store/data/repository/ProductCategoryRepository.kt
@@ -1,115 +1,43 @@
 package `in`.testpress.store.data.repository
 
 import android.content.Context
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
 import `in`.testpress.core.TestpressCallback
-import `in`.testpress.core.TestpressException
-import `in`.testpress.database.TestpressDatabase
+import `in`.testpress.data.repository.BasePaginatedRepository
 import `in`.testpress.database.entities.ProductCategoryEntity
 import `in`.testpress.network.Resource
 import `in`.testpress.store.data.model.NetworkProductCategory
 import `in`.testpress.store.data.model.asDomain
 import `in`.testpress.store.network.StoreApiClient
 import `in`.testpress.v2_4.models.ApiResponse
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
-class ProductCategoryRepository(val context: Context) {
+class ProductCategoryRepository(context: Context) :
+    BasePaginatedRepository<ApiResponse<List<NetworkProductCategory>>, ProductCategoryEntity>(context) {
 
-    private val storeApiClient = StoreApiClient(context)
-    private val database = TestpressDatabase.invoke(context)
+    private val apiClient = StoreApiClient(context)
 
-    private var currentPage = 1
-    private var isLoading = false
-    private var hasNextPage = true
-    private var lastFailedPage: Int? = null
+    override suspend fun getFromDb() = database.productCategoryDao().getAll()
 
-    private var _categoriesResource: MutableLiveData<Resource<List<ProductCategoryEntity>>> =
-        MutableLiveData()
-    val categoriesResource: LiveData<Resource<List<ProductCategoryEntity>>>
-        get() = _categoriesResource
-
-    init {
-        loadFromDatabase()
-    }
-
-    private fun loadFromDatabase() {
-        _categoriesResource.value = Resource.loading(null)
-        CoroutineScope(Dispatchers.IO).launch {
-            val cachedCategories = database.productCategoryDao().getAll()
-            if (cachedCategories.isNotEmpty()) {
-                cachedCategories.add(0,ProductCategoryEntity(id = -1,name = "All Products"))
-                withContext(Dispatchers.Main) {
-                    _categoriesResource.value = Resource.success(cachedCategories)
-                }
-            }
-            fetchFromNetwork()
-        }
-    }
-
-    fun fetchNextPage() {
-        if (isLoading || !hasNextPage || lastFailedPage == currentPage) return
-        currentPage++
-        fetchFromNetwork()
-    }
-
-    fun retryNextPage() {
-        fetchFromNetwork()
-    }
-
-    private fun fetchFromNetwork() {
-        if (isLoading || !hasNextPage) return
-
-        isLoading = true
-        _categoriesResource.postValue(Resource.loading(null))
-
-        val queryParams = hashMapOf<String, Any>("page" to currentPage)
-
-        storeApiClient.getProductsCategories(queryParams)
-            .enqueue(object : TestpressCallback<ApiResponse<List<NetworkProductCategory>>>() {
-
-                override fun onSuccess(result: ApiResponse<List<NetworkProductCategory>>) {
-                    isLoading = false
-                    hasNextPage = result.next != null
-                    lastFailedPage = null
-                    CoroutineScope(Dispatchers.IO).launch {
-                        handleSuccessfulResponse(result)
-                    }
-                }
-
-                override fun onException(exception: TestpressException?) {
-                    isLoading = false
-                    lastFailedPage = currentPage
-
-                    val currentData = _categoriesResource.value?.data
-                    _categoriesResource.postValue(Resource.error(exception!!, currentData))
-                }
-            })
-    }
-
-    private suspend fun handleSuccessfulResponse(response: ApiResponse<List<NetworkProductCategory>>) {
-        if (currentPage == 1) {
-            clearLocalProducts()
-        }
-        saveProductsToDatabase(response.results.asDomain())
-        updateProductsResourceFromDatabase()
-    }
-
-    private suspend fun clearLocalProducts() {
+    override suspend fun clearLocalDb() {
         database.productCategoryDao().deleteAll()
     }
 
-    private suspend fun saveProductsToDatabase(category: List<ProductCategoryEntity>) {
-        database.productCategoryDao().insertAll(category)
+    override suspend fun saveToDb(response: ApiResponse<List<NetworkProductCategory>>) {
+        database.productCategoryDao().insertAll(response.results.asDomain())
     }
 
-    private suspend fun updateProductsResourceFromDatabase() {
-        val updatedProducts = database.productCategoryDao().getAll()
-        updatedProducts.add(0,ProductCategoryEntity(id = -1,name = "All Products"))
-        _categoriesResource.postValue(Resource.success(updatedProducts))
+    override suspend fun updateLiveDataFromDb() {
+        val updated = database.productCategoryDao().getAll().toMutableList()
+        updated.add(0, ProductCategoryEntity(id = -1, name = "All Products"))
+        _resource.postValue(Resource.success(updated))
     }
 
+    override fun makeNetworkCall(queryParams: Map<String, Any>, callback: TestpressCallback<*>) {
+        @Suppress("UNCHECKED_CAST")
+        apiClient.getProductsCategories(queryParams)
+            .enqueue(callback as TestpressCallback<ApiResponse<List<NetworkProductCategory>>>)
+    }
+
+    override fun extractNextPageAvailable(response: Any): Boolean {
+        return (response as ApiResponse<*>).next != null
+    }
 }

--- a/store/src/main/java/in/testpress/store/data/repository/ProductCategoryRepository.kt
+++ b/store/src/main/java/in/testpress/store/data/repository/ProductCategoryRepository.kt
@@ -15,7 +15,17 @@ class ProductCategoryRepository(context: Context) :
 
     private val apiClient = StoreApiClient(context)
 
-    override suspend fun getFromDb() = database.productCategoryDao().getAll()
+    init {
+        loadFromDatabase()
+    }
+
+    override suspend fun getFromDb(): List<ProductCategoryEntity> {
+        val data = database.productCategoryDao().getAll()
+        if (data.isNotEmpty()) {
+            data.add(0, ProductCategoryEntity(id = -1, name = "All Products"))
+        }
+        return data
+    }
 
     override suspend fun clearLocalDb() {
         database.productCategoryDao().deleteAll()
@@ -26,9 +36,7 @@ class ProductCategoryRepository(context: Context) :
     }
 
     override suspend fun updateLiveDataFromDb() {
-        val updated = database.productCategoryDao().getAll().toMutableList()
-        updated.add(0, ProductCategoryEntity(id = -1, name = "All Products"))
-        _resource.postValue(Resource.success(updated))
+        _resource.postValue(Resource.success(getFromDb()))
     }
 
     override fun makeNetworkCall(queryParams: Map<String, Any>, callback: TestpressCallback<*>) {

--- a/store/src/main/java/in/testpress/store/data/repository/ProductCategoryRepository.kt
+++ b/store/src/main/java/in/testpress/store/data/repository/ProductCategoryRepository.kt
@@ -9,9 +9,18 @@ import `in`.testpress.store.data.model.NetworkProductCategory
 import `in`.testpress.store.data.model.asDomain
 import `in`.testpress.store.network.StoreApiClient
 import `in`.testpress.v2_4.models.ApiResponse
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 
-class ProductCategoryRepository(context: Context) :
-    BasePaginatedRepository<ApiResponse<List<NetworkProductCategory>>, ProductCategoryEntity>(context) {
+class ProductCategoryRepository(
+    context: Context,
+    scope: CoroutineScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+) :
+    BasePaginatedRepository<ApiResponse<List<NetworkProductCategory>>, ProductCategoryEntity>(
+        context,
+        scope
+    ) {
 
     private val apiClient = StoreApiClient(context)
 

--- a/store/src/main/java/in/testpress/store/data/repository/ProductRepository.kt
+++ b/store/src/main/java/in/testpress/store/data/repository/ProductRepository.kt
@@ -8,9 +8,15 @@ import `in`.testpress.network.Resource
 import `in`.testpress.store.data.model.NetworkProductListResponse
 import `in`.testpress.store.data.model.asDomain
 import `in`.testpress.store.network.StoreApiClient
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 
-class ProductRepository(context: Context) :
-    BasePaginatedRepository<NetworkProductListResponse, ProductLiteEntity>(context) {
+class ProductRepository(
+    context: Context,
+    scope: CoroutineScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+) :
+    BasePaginatedRepository<NetworkProductListResponse, ProductLiteEntity>(context, scope) {
 
     private val apiClient = StoreApiClient(context)
 

--- a/store/src/main/java/in/testpress/store/data/repository/ProductRepository.kt
+++ b/store/src/main/java/in/testpress/store/data/repository/ProductRepository.kt
@@ -1,113 +1,41 @@
 package `in`.testpress.store.data.repository
 
 import android.content.Context
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
 import `in`.testpress.core.TestpressCallback
-import `in`.testpress.core.TestpressException
-import `in`.testpress.database.TestpressDatabase
+import `in`.testpress.data.repository.BasePaginatedRepository
 import `in`.testpress.database.entities.ProductLiteEntity
 import `in`.testpress.network.Resource
 import `in`.testpress.store.data.model.NetworkProductListResponse
-import `in`.testpress.store.data.model.NetworkProductLite
 import `in`.testpress.store.data.model.asDomain
 import `in`.testpress.store.network.StoreApiClient
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
-class ProductRepository(val context: Context) {
+class ProductRepository(context: Context) :
+    BasePaginatedRepository<NetworkProductListResponse, ProductLiteEntity>(context) {
 
-    private val storeApiClient = StoreApiClient(context)
-    private val database = TestpressDatabase.invoke(context)
+    private val apiClient = StoreApiClient(context)
 
-    private var currentPage = 1
-    private var isLoading = false
-    private var hasNextPage = true
-    private var lastFailedPage: Int? = null
+    override suspend fun getFromDb() = database.productLiteEntityDao().getAll()
 
-    private var _productsResource: MutableLiveData<Resource<List<ProductLiteEntity>>> =
-        MutableLiveData()
-    val productsResource: LiveData<Resource<List<ProductLiteEntity>>>
-        get() = _productsResource
-
-    init {
-        loadFromDatabase()
-    }
-
-    private fun loadFromDatabase() {
-        _productsResource.value = Resource.loading(null)
-        CoroutineScope(Dispatchers.IO).launch {
-            val cachedProducts = database.productLiteEntityDao().getAll()
-            if (cachedProducts.isNotEmpty()) {
-                withContext(Dispatchers.Main) {
-                    _productsResource.value = Resource.success(cachedProducts)
-                }
-            }
-            fetchFromNetwork()
-        }
-    }
-
-    fun fetchNextPage() {
-        if (isLoading || !hasNextPage || lastFailedPage == currentPage) return
-        currentPage++
-        fetchFromNetwork()
-    }
-
-    fun retryNextPage() {
-        fetchFromNetwork()
-    }
-
-    private fun fetchFromNetwork() {
-        if (isLoading || !hasNextPage) return
-
-        isLoading = true
-        _productsResource.postValue(Resource.loading(null))
-
-        val queryParams = hashMapOf<String, Any>("page" to currentPage)
-
-        storeApiClient.getProductsV3(queryParams)
-            .enqueue(object : TestpressCallback<NetworkProductListResponse>() {
-
-                override fun onSuccess(result: NetworkProductListResponse) {
-                    isLoading = false
-                    hasNextPage = result.next != null
-                    lastFailedPage = null
-                    CoroutineScope(Dispatchers.IO).launch {
-                        handleSuccessfulResponse(result)
-                    }
-                }
-
-                override fun onException(exception: TestpressException?) {
-                    isLoading = false
-                    lastFailedPage = currentPage
-
-                    val currentData = _productsResource.value?.data
-                    _productsResource.postValue(Resource.error(exception!!, currentData))
-                }
-            })
-    }
-
-    private suspend fun handleSuccessfulResponse(response: NetworkProductListResponse) {
-        if (currentPage == 1) {
-            clearLocalProducts()
-        }
-        saveProductsToDatabase(response.results.products)
-        updateProductsResourceFromDatabase()
-    }
-
-    private suspend fun clearLocalProducts() {
+    override suspend fun clearLocalDb() {
         database.productLiteEntityDao().deleteAll()
     }
 
-    private suspend fun saveProductsToDatabase(products: List<NetworkProductLite>) {
-        database.productLiteEntityDao().insertAll(products.asDomain())
+    override suspend fun saveToDb(response: NetworkProductListResponse) {
+        database.productLiteEntityDao().insertAll(response.results.products.asDomain())
     }
 
-    private suspend fun updateProductsResourceFromDatabase() {
-        val updatedProducts = database.productLiteEntityDao().getAll()
-        _productsResource.postValue(Resource.success(updatedProducts))
+    override suspend fun updateLiveDataFromDb() {
+        _resource.postValue(Resource.success(database.productLiteEntityDao().getAll()))
     }
 
+    override fun makeNetworkCall(queryParams: Map<String, Any>, callback: TestpressCallback<*>) {
+        @Suppress("UNCHECKED_CAST")
+        apiClient.getProductsV3(queryParams)
+            .enqueue(callback as TestpressCallback<NetworkProductListResponse>)
+    }
+
+    override fun extractNextPageAvailable(response: Any): Boolean {
+        return (response as NetworkProductListResponse).next != null
+    }
 }
+

--- a/store/src/main/java/in/testpress/store/data/repository/ProductRepository.kt
+++ b/store/src/main/java/in/testpress/store/data/repository/ProductRepository.kt
@@ -14,6 +14,10 @@ class ProductRepository(context: Context) :
 
     private val apiClient = StoreApiClient(context)
 
+    init {
+        loadFromDatabase()
+    }
+
     override suspend fun getFromDb() = database.productLiteEntityDao().getAll()
 
     override suspend fun clearLocalDb() {
@@ -25,7 +29,7 @@ class ProductRepository(context: Context) :
     }
 
     override suspend fun updateLiveDataFromDb() {
-        _resource.postValue(Resource.success(database.productLiteEntityDao().getAll()))
+        _resource.postValue(Resource.success(getFromDb()))
     }
 
     override fun makeNetworkCall(queryParams: Map<String, Any>, callback: TestpressCallback<*>) {

--- a/store/src/main/java/in/testpress/store/ui/viewmodel/ProductCategoryViewModel.kt
+++ b/store/src/main/java/in/testpress/store/ui/viewmodel/ProductCategoryViewModel.kt
@@ -7,7 +7,7 @@ import `in`.testpress.store.data.repository.ProductCategoryRepository
 
 class ProductCategoryViewModel(private val repository: ProductCategoryRepository) : ViewModel() {
 
-    val categories = repository.categoriesResource
+    val categories = repository.resource
 
     fun fetchNextPage() {
         repository.fetchNextPage()

--- a/store/src/main/java/in/testpress/store/ui/viewmodel/ProductCategoryViewModel.kt
+++ b/store/src/main/java/in/testpress/store/ui/viewmodel/ProductCategoryViewModel.kt
@@ -17,6 +17,12 @@ class ProductCategoryViewModel(private val repository: ProductCategoryRepository
         repository.retryNextPage()
     }
 
+    override fun onCleared() {
+        super.onCleared()
+        // Cancel the repository's scope when the ViewModel is cleared
+        repository.cancelScope()
+    }
+
     companion object {
         fun init(context: FragmentActivity): ProductCategoryViewModel {
             return ViewModelProvider(context, object : ViewModelProvider.Factory {

--- a/store/src/main/java/in/testpress/store/ui/viewmodel/ProductListViewModel.kt
+++ b/store/src/main/java/in/testpress/store/ui/viewmodel/ProductListViewModel.kt
@@ -18,6 +18,12 @@ class ProductListViewModel(private val repository: ProductRepository) : ViewMode
         repository.retryNextPage()
     }
 
+    override fun onCleared() {
+        super.onCleared()
+        // Cancel the repository's scope when the ViewModel is cleared
+        repository.cancelScope()
+    }
+
     companion object {
         fun init(context: FragmentActivity): ProductListViewModel {
             return ViewModelProvider(context, object : ViewModelProvider.Factory {

--- a/store/src/main/java/in/testpress/store/ui/viewmodel/ProductListViewModel.kt
+++ b/store/src/main/java/in/testpress/store/ui/viewmodel/ProductListViewModel.kt
@@ -8,7 +8,7 @@ import `in`.testpress.store.data.repository.ProductRepository
 
 class ProductListViewModel(private val repository: ProductRepository) : ViewModel() {
 
-    val products = repository.productsResource
+    val products = repository.resource
 
     fun fetchNextPage() {
         repository.fetchNextPage()


### PR DESCRIPTION
What
This PR introduces a generic BasePaginatedRepository to encapsulate common logic for paginated, offline-first repositories. The product and product category repositories are refactored to extend this new base class.

Why
The existing ProductRepository and ProductCategoryRepository shared significant duplicated logic for managing paginated API calls, offline caching with Room, and network state management. This duplication was error-prone and hard to maintain. Extracting this logic into a reusable base class improves maintainability and enforces consistency across repositories.

Changes
Added BasePaginatedRepository, a generic abstract class handling:

Pagination state (page count, hasNextPage, etc.)

Offline-first data loading

Coroutine-based DB and network coordination

Refactored ProductRepository and ProductCategoryRepository to extend this base class and implement specific DB/API methods.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Product category listings now include a default "All Products" option for a more intuitive browsing experience.

- **Refactor**
  - Streamlined data retrieval and pagination for products and categories to enhance performance and reliability.
  - Improved asynchronous data processing to ensure smoother and more consistent content updates.
  - Enhanced resource management within ViewModels for better lifecycle handling.
  - Generalized resource access in ViewModels for improved data handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->