### PR TITLE
feat: Filter product list by category selection 

### DIFF
--- a/core/src/main/java/in/testpress/data/repository/BasePaginatedRepository.kt
+++ b/core/src/main/java/in/testpress/data/repository/BasePaginatedRepository.kt
@@ -51,6 +51,14 @@ abstract class BasePaginatedRepository<NetworkResponseT, DomainEntityT>(
         fetchFromNetwork()
     }
 
+    fun resetPaginationAndFetch() {
+        currentPage = 1
+        isLoading = false
+        hasNextPage = true
+        lastFailedPage = null
+        loadFromDatabase()
+    }
+
     fun cancelScope() {
         scope.cancel()
     }

--- a/core/src/main/java/in/testpress/database/dao/ProductLiteEntityDao.kt
+++ b/core/src/main/java/in/testpress/database/dao/ProductLiteEntityDao.kt
@@ -15,6 +15,12 @@ interface ProductLiteEntityDao {
     @Query("SELECT * FROM productliteentity ORDER BY `order` ASC")
     suspend fun getAll(): List<ProductLiteEntity>
 
+    @Query("SELECT * FROM productliteentity WHERE categoryId=:categoryId ORDER BY `order` ASC")
+    suspend fun getByCategoryId(categoryId: Int): List<ProductLiteEntity>
+
     @Query("DELETE FROM productliteentity")
     suspend fun deleteAll()
+
+    @Query("DELETE FROM productliteentity WHERE categoryId=:categoryId")
+    suspend fun deleteByCategoryId(categoryId: Int)
 }

--- a/store/src/main/java/in/testpress/store/ui/ProductListFragmentV2.kt
+++ b/store/src/main/java/in/testpress/store/ui/ProductListFragmentV2.kt
@@ -65,7 +65,7 @@ class ProductListFragmentV2 : Fragment(), EmptyViewListener {
     private fun setupCategoryList() {
         categoriesAdapter = ProductCategoryAdapter(
             onRetry = { categoriesViewModel.retryNextPage() },
-            onCategorySelected = {/* TODO: Add Filter option on category selection */ }
+            onCategorySelected = { productsViewModel.setCategoryId(it.id!!) }
         )
 
         val layoutManager = LinearLayoutManager(requireContext(), LinearLayoutManager.HORIZONTAL, false)

--- a/store/src/main/java/in/testpress/store/ui/ProductListFragmentV2.kt
+++ b/store/src/main/java/in/testpress/store/ui/ProductListFragmentV2.kt
@@ -65,7 +65,9 @@ class ProductListFragmentV2 : Fragment(), EmptyViewListener {
     private fun setupCategoryList() {
         categoriesAdapter = ProductCategoryAdapter(
             onRetry = { categoriesViewModel.retryNextPage() },
-            onCategorySelected = { productsViewModel.setCategoryId(it.id!!) }
+            onCategorySelected = { category ->
+                category.id?.let { id -> productsViewModel.setCategoryId(id) }
+            }
         )
 
         val layoutManager = LinearLayoutManager(requireContext(), LinearLayoutManager.HORIZONTAL, false)

--- a/store/src/main/java/in/testpress/store/ui/viewmodel/ProductListViewModel.kt
+++ b/store/src/main/java/in/testpress/store/ui/viewmodel/ProductListViewModel.kt
@@ -18,6 +18,11 @@ class ProductListViewModel(private val repository: ProductRepository) : ViewMode
         repository.retryNextPage()
     }
 
+    fun setCategoryId(categoryId: Int) {
+        repository.setCategoryId(categoryId)
+        repository.resetPaginationAndFetch()
+    }
+
     override fun onCleared() {
         super.onCleared()
         // Cancel the repository's scope when the ViewModel is cleared


### PR DESCRIPTION
This PR implements category-based filtering in the product list view.

#### Category Filter Integration:
- Selecting a category now filters the product list accordingly.
- ProductListViewModel.setCategoryId() triggers a reset of pagination and reloads filtered results.

#### Room DB Enhancements:
- Added getByCategoryId() and deleteByCategoryId() in ProductLiteEntityDao to support category-specific offline caching.

#### Repository Enhancements:
- ProductRepository tracks categoryId and dynamically includes it in network requests.
- Local DB operations respect selected category for both retrieval and deletion.
- resetPaginationAndFetch() in BasePaginatedRepository allows a clean refresh when filters change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced category-based filtering for product listings: selecting a category now displays tailored products.
  - Enhanced data handling by refreshing and resetting the product display seamlessly, ensuring up-to-date listings.
  - Improved integration across product views and data sources for a smoother user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->