### PR TITLE
fix: show empty view when product list is empty

### DIFF
--- a/store/src/main/java/in/testpress/store/ui/ProductListFragmentV2.kt
+++ b/store/src/main/java/in/testpress/store/ui/ProductListFragmentV2.kt
@@ -190,6 +190,7 @@ class ProductListFragmentV2 : Fragment(), EmptyViewListener {
 
         if (products.isNullOrEmpty()) {
             showEmptyState()
+            binding.productsLayout.isVisible = false
         } else {
             binding.productList.isVisible = true
         }


### PR DESCRIPTION
## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced the product listing interface: The display area for products now automatically hides when there are no products available, providing a cleaner and more streamlined viewing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->