### PR TITLE
fix: Retain cached data during pagination and initial load

### DIFF
--- a/core/src/main/java/in/testpress/data/repository/BasePaginatedRepository.kt
+++ b/core/src/main/java/in/testpress/data/repository/BasePaginatedRepository.kt
@@ -29,7 +29,7 @@ abstract class BasePaginatedRepository<NetworkResponseT, DomainEntityT>(
     val resource: LiveData<Resource<List<DomainEntityT>>> get() = _resource
 
     protected fun loadFromDatabase() {
-        _resource.value = Resource.loading(null)
+        _resource.value = Resource.loading(_resource.value?.data)
         scope.launch {
             val cached = getFromDb()
             if (cached.isNotEmpty()) {
@@ -59,7 +59,7 @@ abstract class BasePaginatedRepository<NetworkResponseT, DomainEntityT>(
         if (isLoading || !hasNextPage) return
         isLoading = true
 
-        _resource.postValue(Resource.loading(null))
+        _resource.postValue(Resource.loading(_resource.value?.data))
 
         val queryParams = hashMapOf<String, Any>("page" to currentPage)
         makeNetworkCall(queryParams, object : TestpressCallback<Any>() {

--- a/store/src/main/java/in/testpress/store/ui/ProductListFragmentV2.kt
+++ b/store/src/main/java/in/testpress/store/ui/ProductListFragmentV2.kt
@@ -124,7 +124,7 @@ class ProductListFragmentV2 : Fragment(), EmptyViewListener {
     private fun observeCategories() {
         categoriesViewModel.categories.observe(viewLifecycleOwner) { resource ->
             when (resource?.status) {
-                Status.LOADING -> showCategoryLoading()
+                Status.LOADING -> showCategoryLoading(resource.data)
                 Status.SUCCESS -> showCategorySuccess(resource.data)
                 Status.ERROR -> showCategoryError()
                 else -> Unit
@@ -135,7 +135,7 @@ class ProductListFragmentV2 : Fragment(), EmptyViewListener {
     private fun observeProducts() {
         productsViewModel.products.observe(viewLifecycleOwner) { resource ->
             when (resource?.status) {
-                Status.LOADING -> showProductLoading()
+                Status.LOADING -> showProductLoading(resource.data)
                 Status.SUCCESS -> showProductSuccess(resource.data)
                 Status.ERROR -> showProductError(resource.exception)
                 else -> Unit
@@ -143,8 +143,9 @@ class ProductListFragmentV2 : Fragment(), EmptyViewListener {
         }
     }
 
-    private fun showCategoryLoading() {
+    private fun showCategoryLoading(categories: List<ProductCategoryEntity>?) {
         binding.productCategoriesLayout.isVisible = true
+        categoriesAdapter.submitList(categories)
         if (categoriesAdapter.itemCount > 0) {
             categoriesAdapter.updateFooterState(FooterState.LOADING)
         } else {
@@ -170,8 +171,9 @@ class ProductListFragmentV2 : Fragment(), EmptyViewListener {
         }
     }
 
-    private fun showProductLoading() {
+    private fun showProductLoading(products: List<ProductLiteEntity>?) {
         binding.productsLayout.isVisible = true
+        productsAdapter.submitList(products)
         binding.emptyViewContainer.isVisible = false
         if (productsAdapter.itemCount > 0) {
             productsAdapter.updateFooterState(FooterState.LOADING)


### PR DESCRIPTION
- This PR improves the user experience during pagination and initial data loading by displaying cached content (if available) instead of showing a blank or flickering UI.
- Updated `loadFromDatabase()` and `loadNextPage()` to emit loading state with cached data (Resource.loading(data)) instead of null.
- Modified `showProductLoading()` and `showCategoryLoading()` to accept and render cached data.
- `productsAdapter` and `categoriesAdapter` now submit cached data immediately during loading.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the loading experience so that previously displayed data remains visible during refresh.
  - Enhanced the update process for product and category listings, ensuring smoother transitions while new content loads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->