### PR TITLE
feat: Open product details on item click in product list

### DIFF
--- a/store/src/main/java/in/testpress/store/ui/ProductListFragmentV2.kt
+++ b/store/src/main/java/in/testpress/store/ui/ProductListFragmentV2.kt
@@ -1,5 +1,6 @@
 package `in`.testpress.store.ui
 
+import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -17,12 +18,14 @@ import `in`.testpress.enums.Status
 import `in`.testpress.fragments.EmptyViewFragment
 import `in`.testpress.fragments.EmptyViewListener
 import `in`.testpress.store.R
+import `in`.testpress.store.TestpressStore
 import `in`.testpress.store.databinding.TestpressProductListFragmentBinding
 import `in`.testpress.store.ui.adapter.FooterState
 import `in`.testpress.store.ui.adapter.ProductCategoryAdapter
 import `in`.testpress.store.ui.adapter.ProductListAdapter
 import `in`.testpress.store.ui.viewmodel.ProductCategoryViewModel
 import `in`.testpress.store.ui.viewmodel.ProductListViewModel
+
 
 class ProductListFragmentV2 : Fragment(), EmptyViewListener {
     private var _binding: TestpressProductListFragmentBinding? = null
@@ -80,9 +83,15 @@ class ProductListFragmentV2 : Fragment(), EmptyViewListener {
 
 
     private fun setupProductList() {
-        productsAdapter = ProductListAdapter(requireContext()) {
-            productsViewModel.retryNextPage()
-        }
+        productsAdapter = ProductListAdapter(
+            requireContext(),
+            onRetry = { productsViewModel.retryNextPage() },
+            onItemClick = { product ->
+                val intent = Intent(requireContext(), ProductDetailsActivity::class.java)
+                intent.putExtra(ProductDetailsActivity.PRODUCT_SLUG, product.slug)
+                activity!!.startActivityForResult(intent, TestpressStore.STORE_REQUEST_CODE)
+            }
+        )
 
         val layoutManager = LinearLayoutManager(requireContext())
         binding.productList.apply {

--- a/store/src/main/java/in/testpress/store/ui/ProductListFragmentV2.kt
+++ b/store/src/main/java/in/testpress/store/ui/ProductListFragmentV2.kt
@@ -89,7 +89,7 @@ class ProductListFragmentV2 : Fragment(), EmptyViewListener {
             onItemClick = { product ->
                 val intent = Intent(requireContext(), ProductDetailsActivity::class.java)
                 intent.putExtra(ProductDetailsActivity.PRODUCT_SLUG, product.slug)
-                activity!!.startActivityForResult(intent, TestpressStore.STORE_REQUEST_CODE)
+                requireActivity().startActivityForResult(intent, TestpressStore.STORE_REQUEST_CODE)
             }
         )
 

--- a/store/src/main/java/in/testpress/store/ui/adapter/ProductListAdapter.kt
+++ b/store/src/main/java/in/testpress/store/ui/adapter/ProductListAdapter.kt
@@ -8,6 +8,7 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.nostra13.universalimageloader.core.ImageLoader
+import `in`.testpress.database.entities.ProductCategoryEntity
 import `in`.testpress.database.entities.ProductLiteEntity
 import `in`.testpress.store.databinding.ListViewFooterLoadingBinding
 import `in`.testpress.store.databinding.TestpressProductListItemBinding
@@ -15,7 +16,8 @@ import `in`.testpress.util.ImageUtils
 
 class ProductListAdapter(
     context: Context,
-    private val onRetry: () -> Unit
+    private val onRetry: () -> Unit,
+    private val onItemClick: (ProductLiteEntity) -> Unit
 ) : ListAdapter<ProductLiteEntity, RecyclerView.ViewHolder>(DIFF_CALLBACK) {
 
     private val imageLoader: ImageLoader? = ImageUtils.initImageLoader(context)
@@ -46,7 +48,7 @@ class ProductListAdapter(
 
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
         when (holder) {
-            is ProductViewHolder -> holder.bind(getItem(position))
+            is ProductViewHolder -> holder.bind(getItem(position), onItemClick)
             is FooterViewHolder -> holder.bind(footerState)
         }
     }
@@ -77,7 +79,7 @@ class ProductListAdapter(
         private val imageLoader: ImageLoader?
     ) : RecyclerView.ViewHolder(binding.root) {
 
-        fun bind(product: ProductLiteEntity) {
+        fun bind(product: ProductLiteEntity, onItemClick: (ProductLiteEntity) -> Unit) {
             binding.title.text = product.title
             binding.price.text = "₹ ${product.price}"
 
@@ -96,6 +98,8 @@ class ProductListAdapter(
                 binding.thumbnailImage,
                 ImageUtils.getPlaceholdersOption()
             )
+
+            binding.root.setOnClickListener { onItemClick(product) }
         }
     }
 


### PR DESCRIPTION
This PR enables navigation to the product details screen when a product is clicked in the product list.

#### Product Click Navigation:
- ProductListAdapter now takes an onItemClick lambda to handle item clicks.
- Clicking a product opens ProductDetailsActivity with the selected product's slug.
- startActivityForResult is used with TestpressStore.STORE_REQUEST_CODE to allow result-based actions (e.g., refresh on return).
#### Adapter Refactor:
- Enhanced bind() method in ProductViewHolder to support click listener.
- Cleaned up the setup in ProductListFragmentV2 to pass both onRetry and onItemClick.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enabled users to tap on products in the list to open detailed views.
	- Added a built-in retry mechanism to enhance the product loading experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->