### PR TITLE
refactor: Rename ProductRepository to ProductListRepository for clarity

### DIFF
--- a/store/src/main/java/in/testpress/store/data/repository/ProductListRepository.kt
+++ b/store/src/main/java/in/testpress/store/data/repository/ProductListRepository.kt
@@ -12,7 +12,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 
-class ProductRepository(
+class ProductListRepository(
     context: Context,
     scope: CoroutineScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
 ) :

--- a/store/src/main/java/in/testpress/store/ui/viewmodel/ProductListViewModel.kt
+++ b/store/src/main/java/in/testpress/store/ui/viewmodel/ProductListViewModel.kt
@@ -3,10 +3,10 @@ package `in`.testpress.store.ui.viewmodel
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
-import `in`.testpress.store.data.repository.ProductRepository
+import `in`.testpress.store.data.repository.ProductListRepository
 
 
-class ProductListViewModel(private val repository: ProductRepository) : ViewModel() {
+class ProductListViewModel(private val repository: ProductListRepository) : ViewModel() {
 
     val products = repository.resource
 
@@ -34,7 +34,7 @@ class ProductListViewModel(private val repository: ProductRepository) : ViewMode
             return ViewModelProvider(context, object : ViewModelProvider.Factory {
                 override fun <T : ViewModel> create(modelClass: Class<T>): T {
                     return ProductListViewModel(
-                        ProductRepository(context)
+                        ProductListRepository(context)
                     ) as T
                 }
             }).get(ProductListViewModel::class.java)


### PR DESCRIPTION
- This refactor improves naming clarity by renaming ProductRepository to ProductListRepository


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Standardized naming conventions in the product data flow to ensure consistency.
  - Adjusted component initialization while maintaining the same user experience and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->