### PR TITLE
refactor: Remove unused products list API from store client

### DIFF
--- a/store/src/main/java/in/testpress/store/network/ProductService.java
+++ b/store/src/main/java/in/testpress/store/network/ProductService.java
@@ -55,9 +55,6 @@ public interface ProductService {
             @Path(value = "order_id", encoded = true) int orderId,
             @Body HashMap<String, Object> arguments);
 
-    @GET(StoreApiClient.V4_PRODUCTS_LIST_PATH)
-    RetrofitCall<NetworkProductResponse> getProductsList();
-
     @POST(PAYU_HASH_GENERATOR_PATH)
     RetrofitCall<NetworkHash> generateHash(@Body HashMap<String, Object> arguments);
 

--- a/store/src/main/java/in/testpress/store/network/StoreApiClient.java
+++ b/store/src/main/java/in/testpress/store/network/StoreApiClient.java
@@ -88,10 +88,6 @@ public class StoreApiClient extends TestpressApiClient {
         return getProductService().orderConfirm(order.getId(), orderParameters);
     }
 
-    public RetrofitCall<NetworkProductResponse> getProductsList() {
-        return getProductService().getProductsList();
-    }
-
     public RetrofitCall<NetworkOrderStatus> refreshOrderStatus(String orderId, Boolean reconciliation) {
         HashMap<String, Boolean> parameters = new HashMap<>();
         parameters.put("trigger_payment_reconciliation", reconciliation);


### PR DESCRIPTION
- Removed the `getProductsList()` method from `ProductService` and `StoreApiClient` as it is no longer used in the current store flow. This cleanup improves code maintainability by eliminating dead code.
