### PR TITLE
fix: Filter unsupported bookmark types in notifyDataSetChanged

### DIFF
--- a/course/src/main/java/in/testpress/course/ui/BookmarksListAdapter.java
+++ b/course/src/main/java/in/testpress/course/ui/BookmarksListAdapter.java
@@ -59,14 +59,16 @@ class BookmarksListAdapter extends SingleTypeAdapter<Bookmark> {
 
     public void notifyDataSetChanged() {
         bookmarks = Bookmark.getQueryBuilderToDisplay(activity, currentFolder).list();
-        List<Bookmark> filteredBookmarks = new ArrayList<>();
+
+        List<Bookmark> filteredBookmarks = new ArrayList<>(bookmarks.size());
         for (Bookmark bookmark : bookmarks) {
             Object object = bookmark.getBookmarkedObject();
-            if (object instanceof ReviewItem || object instanceof Content) {
+            if ((object instanceof ReviewItem || object instanceof Content)) {
                 filteredBookmarks.add(bookmark);
             }
         }
-        bookmarks = new ArrayList<>(filteredBookmarks);
+        bookmarks = filteredBookmarks;
+
         super.notifyDataSetChanged();
     }
 

--- a/course/src/main/java/in/testpress/course/ui/BookmarksListAdapter.java
+++ b/course/src/main/java/in/testpress/course/ui/BookmarksListAdapter.java
@@ -8,7 +8,9 @@ import androidx.core.content.ContextCompat;
 import android.text.Html;
 import android.view.View;
 
-import org.greenrobot.greendao.query.LazyList;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import in.testpress.core.TestpressSdk;
 import in.testpress.course.R;
@@ -23,7 +25,7 @@ import in.testpress.util.SingleTypeAdapter;
 class BookmarksListAdapter extends SingleTypeAdapter<Bookmark> {
 
     private Activity activity;
-    private LazyList<Bookmark> bookmarks;
+    private List<Bookmark> bookmarks;
     private String currentFolder;
     private int backgroundShadePosition;
     private ObjectAnimator animator;
@@ -32,7 +34,7 @@ class BookmarksListAdapter extends SingleTypeAdapter<Bookmark> {
         super(activity.getLayoutInflater(), R.layout.testpress_bookmark_panel_list_item);
         this.currentFolder = currentFolder;
         this.activity = activity;
-        bookmarks = Bookmark.getQueryBuilderToDisplay(activity, currentFolder).listLazy();
+        bookmarks = Bookmark.getQueryBuilderToDisplay(activity, currentFolder).list();
     }
 
     @Override
@@ -55,9 +57,16 @@ class BookmarksListAdapter extends SingleTypeAdapter<Bookmark> {
         return bookmarks.size();
     }
 
-    @Override
     public void notifyDataSetChanged() {
-        bookmarks = Bookmark.getQueryBuilderToDisplay(activity, currentFolder).listLazy();
+        bookmarks = Bookmark.getQueryBuilderToDisplay(activity, currentFolder).list();
+        List<Bookmark> filteredBookmarks = new ArrayList<>();
+        for (Bookmark bookmark : bookmarks) {
+            Object object = bookmark.getBookmarkedObject();
+            if (object instanceof ReviewItem || object instanceof Content) {
+                filteredBookmarks.add(bookmark);
+            }
+        }
+        bookmarks = new ArrayList<>(filteredBookmarks);
         super.notifyDataSetChanged();
     }
 


### PR DESCRIPTION
Updated notifyDataSetChanged() in BookmarksListAdapter to filter out unsupported bookmark types, which were causing issues during rendering.

#### What’s Changed:
- Replaced LazyList<Bookmark> with List<Bookmark> to simplify filtering.
- In notifyDataSetChanged(), filtered out bookmarks with null objects or objects that are not instances of ReviewItem or Content.

#### Why:
- Some bookmarks had unsupported or null objects, which caused crashes or incorrect rendering. This fix ensures only valid bookmark types are shown, improving UI stability and reliability.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Refactor**
  - Enhanced the bookmarks view by updating the loading mechanism and refining the filtering logic. Bookmarks are now fully loaded and only display the most relevant items. This update ensures a cleaner, more consistent experience when managing and viewing bookmarks, improving overall navigational clarity for users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->