### PR TITLE
fix: Add model mapper for product entity

### DIFF
--- a/store/src/main/java/in/testpress/store/data/model/mapping/ProdictMapping.kt
+++ b/store/src/main/java/in/testpress/store/data/model/mapping/ProdictMapping.kt
@@ -1,0 +1,55 @@
+package `in`.testpress.store.data.model.mapping
+
+import `in`.testpress.database.entities.Image
+import `in`.testpress.database.entities.PriceEntity
+import `in`.testpress.database.entities.ProductWithPrices
+import `in`.testpress.store.models.Images
+import `in`.testpress.store.models.PricesItem
+import `in`.testpress.store.models.Product
+
+fun ProductWithPrices.asProduct(): Product {
+    val product = Product()
+    product.id = this.product.id
+    product.url = this.product.url
+    product.title = this.product.title
+    product.slug = this.product.slug
+    product.image = null
+    product.startDate = this.product.startDate
+    product.endDate = this.product.endDate
+    product.categories = arrayListOf()
+    product.types = arrayListOf()
+    product.examsCount = this.product.examsCount
+    product.notesCount = this.product.htmlCount
+    product.price = this.product.price
+    product.images = this.product.images?.map { it.asDomainImage() }
+    product.buyNowText = this.product.buyNowText
+    product.description = this.product.description
+    product.additionalInfo = null
+    product.paymentLink = this.product.paymentLink
+    product.institute = this.product.institute
+    product.requiresShipping = this.product.requiresShipping
+    product.exams = arrayListOf()
+    product.notes = arrayListOf()
+    product.prices = this.prices.map { it.asDomainPricesItem() }
+
+    return product
+}
+
+fun Image.asDomainImage(): Images {
+    val images = Images()
+    images.small = this.small
+    images.medium = this.medium
+    images.original = this.original
+    return images
+}
+
+fun PriceEntity.asDomainPricesItem(): PricesItem {
+    return PricesItem(
+        id = id,
+        name = name,
+        price = price,
+        validity = validity?.toInt(),
+        endDate = endDate,
+        startDate = startDate
+    )
+}

--- a/store/src/main/java/in/testpress/store/models/Images.java
+++ b/store/src/main/java/in/testpress/store/models/Images.java
@@ -8,6 +8,8 @@ public class Images implements Parcelable {
     private String medium;
     private String small;
 
+    public Images(){}
+
     // Parcelling part
     public Images(Parcel parcel){
         original = parcel.readString();

--- a/store/src/main/java/in/testpress/store/models/Product.java
+++ b/store/src/main/java/in/testpress/store/models/Product.java
@@ -33,6 +33,8 @@ public class Product implements Parcelable {
     private List<Notes> notes = new ArrayList<Notes>();
     private List<PricesItem> prices = new ArrayList<PricesItem>();
 
+    public Product(){}
+
     // Parcelling part
     public Product(Parcel parcel){
         url        = parcel.readString();


### PR DESCRIPTION
- Introduced a new mapping layer (ProdictMapping.kt) to convert Room’s ProductWithPrices model into the UI-compatible Product model. This includes:
- Mapping images from Image to Images
- Mapping prices from PriceEntity to PricesItem
- Initializing missing fields in the UI model
- Also added empty constructors to Images and Product classes to support clean instantiation during model mapping.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for converting database entities to domain models for products, images, and prices within the store module.
- **Chores**
  - Introduced no-argument constructors to the Images and Product classes to improve compatibility and instantiation flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->