### PR TITLE
fix: Show course list instead of chapter list for single-course products

### DIFF
--- a/course/src/main/java/in/testpress/course/AvailableCourseListAdapter.java
+++ b/course/src/main/java/in/testpress/course/AvailableCourseListAdapter.java
@@ -92,10 +92,8 @@ public class AvailableCourseListAdapter extends SingleTypeAdapter<Product> {
     }
 
     private void showProductDetail(Product product) {
-        if (product.getCourseIds().size() > 1) {
+        if (product.getCourseIds().size() >= 1) {
             activity.startActivity(CoursePreviewActivity.createIntent(product.getCourseIds(), activity, product.getSlug()));
-        } else if (product.getCourseIds().size() == 1 ) {
-            openChapters(product, activity);
         } else {
             Intent intent = new Intent(activity, ProductDetailsActivity.class);
             intent.putExtra(ProductDetailsActivity.PRODUCT_SLUG, product.getSlug());

--- a/course/src/main/java/in/testpress/course/AvailableCourseListAdapter.java
+++ b/course/src/main/java/in/testpress/course/AvailableCourseListAdapter.java
@@ -100,12 +100,4 @@ public class AvailableCourseListAdapter extends SingleTypeAdapter<Product> {
             activity.startActivityForResult(intent, TestpressStore.STORE_REQUEST_CODE);
         }
     }
-
-    private void openChapters(Product product, Activity activity) {
-        activity.startActivity(ChapterDetailActivity.createIntent(
-                product.getTitle(),
-                product.getCourseIds().get(0).toString(),
-                activity, product.getSlug()));
-    }
-
 }


### PR DESCRIPTION
### What
- Changed the logic to always open the course list (CoursePreviewActivity) when a product has one or more course IDs.
- Removed the previous logic that opened the chapter list screen directly for single-course products.

### Why
- Opening the chapter list screen requires user registration, and the API call fails if registration isn't completed. By showing the course list instead, we allow the user to first register if needed before accessing chapters, ensuring a smoother and more reliable user experience.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved navigation for products with one or more course IDs, ensuring consistent redirection to the course preview screen. Products with no course IDs now correctly open the product details screen.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->