### PR TITLE
fix: Remove unavailable test dependency causing build failure

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -119,7 +119,6 @@ dependencies {
     kapt "androidx.room:room-compiler:$room_version"
     api "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlin_coroutine_version"
     api "org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlin_coroutine_version"
-    testImplementation "com.github.nimbl3:robolectric.shadows-supportv4:4.1-SNAPSHOT"
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-github-packages.gradle')

--- a/course/build.gradle
+++ b/course/build.gradle
@@ -61,7 +61,6 @@ dependencies {
     testImplementation rootProject.mockServer
     testImplementation "androidx.arch.core:core-testing:2.1.0"
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$kotlin_coroutine_version"
-    testImplementation "com.github.nimbl3:robolectric.shadows-supportv4:4.1-SNAPSHOT"
     testImplementation (rootProject.powermockMockio) {
         exclude group: 'org.mockito'
     }


### PR DESCRIPTION
- The build was failing during lint analysis due to a missing test dependency: com.github.nimbl3:robolectric.shadows-supportv4:4.1-SNAPSHOT.
- This happened because the dependency is hosted in a custom Maven repository that is no longer accessible or defined in the project.
- The issue is fixed by removing the unused test dependency from the core and course modules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Removed an unused test dependency to streamline the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->