### PR TITLE
build: centralize PickiT dependency declaration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,7 @@ ext {
     androidxCore = 'androidx.test:core:1.4.0'
     mockServer = 'com.squareup.okhttp3:mockwebserver:3.10.0'
     shimmer = 'com.facebook.shimmer:shimmer:0.5.0'
+    pickiT = 'com.github.HBiSoft:PickiT:0.1.14'
 
     //AndroidX Dependencies
     pagingRuntime = 'androidx.paging:paging-runtime-ktx:'+ paging_version

--- a/exam/build.gradle
+++ b/exam/build.gradle
@@ -41,7 +41,7 @@ dependencies {
     api rootProject.chart
     api rootProject.imageCropper
     api rootProject.lottie
-    api 'com.github.HBiSoft:PickiT:0.1.14'
+    api rootProject.pickiT
     api rootProject.constraintLayout
     testImplementation rootProject.junit
     testImplementation rootProject.mockito


### PR DESCRIPTION
- This PR moves the PickiT library dependency to the root build.gradle's ext block for centralized version management:
- Added pickiT to root project dependencies.
- Replaced hardcoded PickiT version in the exam module with rootProject.pickiT.
- This improves maintainability and makes it easier to update the library version across modules in the future.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated dependency management for the PickiT library to use a centralized project reference, improving consistency across the project. No changes to user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->