### PR TITLE
refactor: centralize third-party dependencies in root build file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -92,6 +92,22 @@ ext {
     androidCoreTesting = "androidx.arch.core:core-testing:2.1.0"
     androidRoomTesting = "android.arch.persistence.room:testing:1.1.1"
     jUnitJupiterAPI = "org.junit.jupiter:junit-jupiter-api:5.3.1"
+    ringProgressBar = "com.github.HotBitmapGG:RingProgressBar:V1.2.3"
+    viewPager2 = "androidx.viewpager2:viewpager2:1.0.0"
+    flexboxLayout = "com.google.android.flexbox:flexbox:3.0.0"
+    androidLifecycleExtensions = "androidx.lifecycle:lifecycle-extensions:2.2.0"
+    androidPDFViewer = "com.github.mhiew:android-pdf-viewer:3.2.0-beta.1"
+    pRDownloader = "com.github.alexto9090:PRDownloader:1.0"
+    doubleTapPlayerView = "com.github.vkay94:DoubleTapPlayerView:1.0.0"
+    fragmentTestingExtensions = "androidx.fragment:fragment-testing:1.4.1"
+    kotlinxCoroutinesTest = "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.3.3"
+    androidXTestLibrary = "androidx.test:rules:1.1.0"
+    exoPlayerCore = "com.google.android.exoplayer:exoplayer-core:2.17.1"
+    exoPlayerUI = "com.google.android.exoplayer:exoplayer-ui:2.17.1"
+    exoPlayerHLS = "com.google.android.exoplayer:exoplayer-hls:2.17.1"
+    exoPlayerDash = "com.google.android.exoplayer:exoplayer-dash:2.17.1"
+    exoplayerExtensionOkHttp = "com.google.android.exoplayer:extension-okhttp:2.17.1"
+
 
     //AndroidX Dependencies
     pagingRuntime = 'androidx.paging:paging-runtime-ktx:'+ paging_version

--- a/course/build.gradle
+++ b/course/build.gradle
@@ -41,55 +41,45 @@ dependencies {
     api project(':exam')
     api project(':store')
     implementation project(':mobilertc')
+
     api rootProject.design
-    api 'com.google.android.exoplayer:exoplayer-core:' + rootProject.exoPlayer
-    api 'com.google.android.exoplayer:exoplayer-ui:' + rootProject.exoPlayer
-    api 'com.google.android.exoplayer:exoplayer-hls:' + rootProject.exoPlayer
-    api 'com.google.android.exoplayer:exoplayer-dash:' + rootProject.exoPlayer
-    api 'com.google.android.exoplayer:extension-okhttp:' + rootProject.exoPlayer
+    api rootProject.exoPlayerCore
+    api rootProject.exoPlayerUI
+    api rootProject.exoPlayerHLS
+    api rootProject.exoPlayerDash
+    api rootProject.exoplayerExtensionOkHttp
     api rootProject.constraintLayout
     api rootProject.mediarouter
     api rootProject.shimmer
-    api 'com.github.HotBitmapGG:RingProgressBar:V1.2.3'
-    api "androidx.viewpager2:viewpager2:1.0.0"
-    api "com.google.android.flexbox:flexbox:3.0.0"
+    api rootProject.ringProgressBar
+    api rootProject.viewPager2
+    api rootProject.flexboxLayout
+    implementation rootProject.kotlinStdlibJdk7
+    implementation rootProject.androidLifecycleExtensions
+    api rootProject.androidPDFViewer
+    api rootProject.pRDownloader
+    implementation rootProject.androidMultiDexLibrary
+    api rootProject.doubleTapPlayerView
+    api rootProject.pagingRuntime
+    api rootProject.pagingCommon
+    debugImplementation rootProject.fragmentTestingExtensions
+
     testImplementation rootProject.junit
     testImplementation rootProject.mockito
     testImplementation rootProject.powermockJunit
     testImplementation rootProject.roboelectric
     testImplementation rootProject.androidxCore
     testImplementation rootProject.mockServer
-    testImplementation "androidx.arch.core:core-testing:2.1.0"
-    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$kotlin_coroutine_version"
+    testImplementation rootProject.androidCoreTesting
+    testImplementation rootProject.jUnitJupiterAPI
+    testImplementation rootProject.kotlinxCoroutinesTest
     testImplementation (rootProject.powermockMockio) {
         exclude group: 'org.mockito'
     }
-
     androidTestImplementation rootProject.junit
     androidTestImplementation rootProject.testRunner
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
-    api 'com.github.mhiew:android-pdf-viewer:3.2.0-beta.1'
-    api 'com.github.alexto9090:PRDownloader:1.0'
-
-    androidTestImplementation "androidx.test:core:1.4.0"
-    androidTestImplementation "androidx.test:rules:1.1.0"
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.3.1'
-
-    // Allow methods more than 64K
-    implementation 'androidx.multidex:multidex:2.0.1'
-    api 'com.github.vkay94:DoubleTapPlayerView:1.0.0'
-
-    // Allow methods more than 64K
-    implementation 'androidx.multidex:multidex:2.0.1'
-
-    //Paging
-    api rootProject.pagingRuntime
-    api rootProject.pagingCommon
-
-    def fragment_version = "1.4.1"
-
-    debugImplementation "androidx.fragment:fragment-testing:$fragment_version"
+    androidTestImplementation rootProject.androidxCore
+    androidTestImplementation rootProject.androidXTestLibrary
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-github-packages.gradle')


### PR DESCRIPTION
- Dependency versions were scattered across module-level build files, leading to duplication and inconsistency.
- This happened because dependencies were hardcoded instead of being defined in a single shared location.
- The fix centralizes all relevant dependencies (e.g., ExoPlayer, UI libraries, testing tools) in the root build.gradle file, allowing consistent and maintainable versioning across modules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Centralized dependency version management across build configuration files.
  - Added new library version declarations for analytics, UI components, networking, permissions, testing, media playback, and more.
  - Streamlined and unified dependency declarations by referencing centralized properties, reducing redundancy and removing duplicates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->