### PR TITLE
chore: standardize exam module dependencies using centralized definitions

### DIFF
--- a/exam/build.gradle
+++ b/exam/build.gradle
@@ -36,6 +36,7 @@ android {
 
 dependencies {
     api project(':core')
+
     api rootProject.design
     api rootProject.cardview
     api rootProject.chart
@@ -43,25 +44,25 @@ dependencies {
     api rootProject.lottie
     api rootProject.pickiT
     api rootProject.constraintLayout
+    implementation rootProject.coreKotlinExtensions
+    implementation rootProject.kotlinStdlibJdk7
+
     testImplementation rootProject.junit
     testImplementation rootProject.mockito
     testImplementation rootProject.roboelectric
     testImplementation rootProject.androidxCore
     testImplementation rootProject.powermockJunit
     testImplementation rootProject.mockServer
-    testImplementation "androidx.arch.core:core-testing:2.1.0"
-    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.3.3"
+    testImplementation rootProject.androidCoreTesting
+    testImplementation rootProject.kotlinxCoroutinesTest
     testImplementation (rootProject.powermockMockio) {
         exclude group: 'org.mockito'
     }
-
     androidTestImplementation rootProject.junit
     androidTestImplementation rootProject.testRunner
     androidTestImplementation rootProject.espressoCore
     androidTestImplementation rootProject.uiautomator
-    androidTestImplementation 'androidx.test:rules:1.2.0'
-    implementation "androidx.core:core-ktx:1.7.0"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    androidTestImplementation rootProject.androidXTestLibrary
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-github-packages.gradle')


### PR DESCRIPTION
- The exam module contained hardcoded dependency versions, leading to potential inconsistencies with other modules.
- This occurred because dependencies like Kotlin stdlib, core-ktx, coroutine test, and test rules were declared locally rather than using shared root project properties.
- The change removes hardcoded versions and switches to using centralized dependency declarations from the root build.gradle, improving maintainability and consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated dependency declarations to use centralized project properties for library versions, improving consistency and maintainability. No changes to app functionality or build behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->