### PR TITLE
refactor: centralize payment and testing dependencies in root project

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -107,7 +107,9 @@ ext {
     exoPlayerHLS = "com.google.android.exoplayer:exoplayer-hls:2.17.1"
     exoPlayerDash = "com.google.android.exoplayer:exoplayer-dash:2.17.1"
     exoplayerExtensionOkHttp = "com.google.android.exoplayer:extension-okhttp:2.17.1"
-
+    payUCheckoutPro = "in.payu:payu-checkout-pro:1.8.0"
+    payUGpay = "in.payu:payu-gpay:1.4.0"
+    razorpayAndroidCheckoutSDK = "com.razorpay:checkout:1.6.33"
 
     //AndroidX Dependencies
     pagingRuntime = 'androidx.paging:paging-runtime-ktx:'+ paging_version

--- a/store/build.gradle
+++ b/store/build.gradle
@@ -30,9 +30,9 @@ dependencies {
     api project(':core')
     api project(':exam')
 
-    api 'in.payu:payu-checkout-pro:1.8.0'
-    api 'in.payu:payu-gpay:1.4.0'
-    api 'com.razorpay:checkout:1.6.33'
+    api rootProject.payUCheckoutPro
+    api rootProject.payUGpay
+    api rootProject.razorpayAndroidCheckoutSDK
 
     testImplementation rootProject.junit
     testImplementation rootProject.mockito
@@ -40,7 +40,7 @@ dependencies {
     testImplementation rootProject.roboelectric
     testImplementation rootProject.androidxCore
     testImplementation rootProject.mockServer
-    testImplementation "androidx.arch.core:core-testing:2.1.0"
+    testImplementation rootProject.androidCoreTesting
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-github-packages.gradle')


### PR DESCRIPTION
- Hardcoded payment and testing dependencies were used directly in the store module, making version updates error-prone and inconsistent across modules.
- This happened because versions for Razorpay and PayU SDKs were defined inline rather than using shared root project properties.
- The fix moves these dependencies to the root build.gradle and updates the store module to reference them via rootProject, ensuring consistent and maintainable dependency management.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated dependency management to use centralized version variables for payment SDKs and Android core testing libraries. This change streamlines future updates and ensures consistency across the project. No functional changes to the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->