### PR TITLE
Enable Jetpack Compose and view binding in Android library build config

### DIFF
--- a/course/build.gradle
+++ b/course/build.gradle
@@ -34,6 +34,13 @@ android {
     kotlinOptions {
         jvmTarget = JavaVersion.VERSION_1_8.toString()
     }
+    buildFeatures {
+        viewBinding true
+        compose true
+    }
+    composeOptions {
+        kotlinCompilerExtensionVersion '1.4.1'
+    }
 }
 
 dependencies {
@@ -79,6 +86,18 @@ dependencies {
     androidTestImplementation rootProject.testRunner
     androidTestImplementation rootProject.androidxCore
     androidTestImplementation rootProject.androidXTestLibrary
+
+    def composeBom = platform('androidx.compose:compose-bom:2024.08.00')
+    implementation(composeBom)
+    androidTestImplementation(composeBom)
+
+    implementation "androidx.compose.runtime:runtime"
+    implementation "androidx.compose.ui:ui"
+    implementation "androidx.compose.foundation:foundation"
+    implementation "androidx.compose.foundation:foundation-layout"
+    implementation "androidx.compose.material3:material3"
+    implementation "androidx.compose.runtime:runtime-livedata"
+    implementation "androidx.compose.ui:ui-tooling"
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-github-packages.gradle')

--- a/course/build.gradle
+++ b/course/build.gradle
@@ -5,8 +5,6 @@ android {
     compileSdkVersion rootProject.compileSdkVersion
     buildToolsVersion rootProject.buildToolsVersion
 
-    viewBinding.enabled = true
-
     defaultConfig {
         minSdkVersion rootProject.minSdkVersion
         targetSdkVersion rootProject.targetSdkVersion


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated build configuration to enable Jetpack Compose support.
  - Added necessary Compose libraries and dependencies for development and testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->