### PR TITLE
Refactor course content list items from Views to Jetpack Compose

### DIFF
--- a/course/src/main/java/in/testpress/course/adapter/CourseContentListAdapter .kt
+++ b/course/src/main/java/in/testpress/course/adapter/CourseContentListAdapter .kt
@@ -5,8 +5,6 @@ import android.view.ViewGroup
 import androidx.paging.PagingDataAdapter
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
-import `in`.testpress.core.TestpressSdk
-import `in`.testpress.course.R
 import `in`.testpress.course.adapter.viewholder.RunningContentItemViewHolder
 import `in`.testpress.course.adapter.viewholder.UpcomingContentItemViewHolder
 import `in`.testpress.course.databinding.RunningUpcomingListItemBinding
@@ -66,37 +64,8 @@ class CourseContentListAdapter :
 
 }
 
-open class BaseCourseContentItemViewHolder(binding: RunningUpcomingListItemBinding) :
+abstract class BaseCourseContentItemViewHolder(binding: RunningUpcomingListItemBinding) :
     RecyclerView.ViewHolder(binding.root) {
-    private val title = binding.title
-    private val path = binding.path
-    private val date = binding.date
-    private val thumbnail = binding.thumbnail
 
-    init {
-        title.typeface = TestpressSdk.getRubikMediumFont(binding.root.context)
-        path.typeface = TestpressSdk.getRubikMediumFont(binding.root.context)
-        date.typeface = TestpressSdk.getRubikMediumFont(binding.root.context)
-    }
-
-    open fun bind(content: DomainContent) {
-        showContentDetails(content)
-    }
-
-    private fun showContentDetails(content: DomainContent){
-        title.text = content.title
-        path.text = "${content.treePath}"
-        thumbnail.setImageResource(getContentImage(content.contentType))
-    }
-
-    private fun getContentImage(contentType: String?): Int {
-        return when (contentType) {
-            "Attachment" -> R.drawable.testpress_file_icon
-            "Video" -> R.drawable.testpress_video_icon
-            "Notes" -> R.drawable.testpress_notes_icon
-            "VideoConference" -> R.drawable.testpress_live_conference_icon
-            "Exam" -> R.drawable.testpress_exam_icon
-            else -> R.drawable.testpress_exam_icon
-        }
-    }
+    abstract fun bind(content: DomainContent)
 }

--- a/course/src/main/java/in/testpress/course/adapter/viewholder/ContentItemView.kt
+++ b/course/src/main/java/in/testpress/course/adapter/viewholder/ContentItemView.kt
@@ -1,0 +1,123 @@
+package `in`.testpress.course.adapter.viewholder
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import `in`.testpress.course.R
+import `in`.testpress.course.domain.DomainContent
+import `in`.testpress.course.util.TestpressFont
+import `in`.testpress.course.util.extension.getContentImage
+import `in`.testpress.util.DateUtils
+
+@Composable
+fun RunningContentItemView(content: DomainContent) {
+    val startDate = DateUtils.convertDateFormat(content.start)
+    val endDate = content.end?.let { " - ${DateUtils.convertDateFormat(it)}" } ?: ""
+    val dateString = "$startDate$endDate"
+    ContentItemLayout(content = content, dateString = dateString)
+}
+
+@Composable
+fun UpcomingContentItemView(content: DomainContent) {
+    val dateString = "Available ${
+        DateUtils.getRelativeTimeString(content.start, LocalContext.current)
+    }"
+    ContentItemLayout(content = content, dateString = dateString)
+}
+
+@Composable
+private fun ContentItemLayout(
+    content: DomainContent,
+    dateString: String
+) {
+    val context = LocalContext.current
+    val fontFamily = TestpressFont.getRubikMediumFont(context.assets)
+
+    Row(
+        verticalAlignment = Alignment.Top,
+        modifier = Modifier.padding(end = 16.dp)
+    ) {
+        Image(
+            painter = painterResource(id = content.getContentImage()),
+            contentDescription = content.contentType,
+            modifier = Modifier
+                .size(72.dp)
+                .padding(16.dp)
+        )
+        Column {
+            Text(
+                text = "${content.title}",
+                color = Color.Black,
+                fontFamily = fontFamily,
+                style = MaterialTheme.typography.bodyLarge,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.padding(top = 16.dp)
+            )
+            Text(
+                text = dateString,
+                color = colorResource(id = R.color.testpress_text_gray),
+                fontFamily = fontFamily,
+                style = MaterialTheme.typography.labelSmall,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+            Text(
+                text = "${content.treePath}",
+                color = colorResource(id = R.color.testpress_text_gray),
+                fontFamily = fontFamily,
+                style = MaterialTheme.typography.labelSmall,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
+    }
+}
+
+
+@Preview
+@Composable
+fun RunningContentItemViewPreview() {
+    val content = DomainContent(
+        id = 0,
+        title = "Big Buck Bunny",
+        treePath = "Course 1 > Chapter 1 > Sub Chapter",
+        start = "2025-05-08T13:21:58Z",
+        end = "2025-05-15T13:21:58Z",
+        isLocked = null,
+        isScheduled = null, active = null,
+        hasStarted = null,
+        isCourseAvailable = null,
+        hasEnded = null
+    )
+    RunningContentItemView(content)
+}
+
+@Preview
+@Composable
+fun UpcomingContentItemViewPreview() {
+    val content = DomainContent(
+        id = 0,
+        title = "Big Buck Bunny",
+        treePath = "Course 1 > Chapter 1 > Sub Chapter",
+        start = "2025-05-18T13:21:58Z",
+        end = "2025-05-15T13:21:58Z",
+        isLocked = null,
+        isScheduled = null, active = null,
+        hasStarted = null,
+        isCourseAvailable = null,
+        hasEnded = null
+    )
+    UpcomingContentItemView(content)
+}

--- a/course/src/main/java/in/testpress/course/adapter/viewholder/RunningContentItemViewHolder.kt
+++ b/course/src/main/java/in/testpress/course/adapter/viewholder/RunningContentItemViewHolder.kt
@@ -4,21 +4,15 @@ import `in`.testpress.course.adapter.BaseCourseContentItemViewHolder
 import `in`.testpress.course.databinding.RunningUpcomingListItemBinding
 import `in`.testpress.course.domain.DomainContent
 import `in`.testpress.course.ui.ContentActivity
-import `in`.testpress.util.DateUtils.convertDateFormat
 
 class RunningContentItemViewHolder(val binding: RunningUpcomingListItemBinding) :
     BaseCourseContentItemViewHolder(binding) {
 
     override fun bind(content: DomainContent) {
-        super.bind(content)
-        setDateText(content)
         onItemClick(content)
-    }
-
-    private fun setDateText(content: DomainContent) {
-        val startDate = convertDateFormat(content.start)
-        val endDate = content.end?.let { " - ${convertDateFormat(it)}" } ?: ""
-        binding.date.text = "$startDate$endDate"
+        binding.composeView.setContent {
+            RunningContentItemView(content)
+        }
     }
 
     private fun onItemClick(content: DomainContent) {

--- a/course/src/main/java/in/testpress/course/adapter/viewholder/UpcomingContentItemViewHolder.kt
+++ b/course/src/main/java/in/testpress/course/adapter/viewholder/UpcomingContentItemViewHolder.kt
@@ -5,21 +5,15 @@ import `in`.testpress.course.adapter.BaseCourseContentItemViewHolder
 import `in`.testpress.course.databinding.RunningUpcomingListItemBinding
 import `in`.testpress.course.domain.DomainContent
 import `in`.testpress.util.DateUtils
-import `in`.testpress.util.ViewUtils
 
 class UpcomingContentItemViewHolder(val binding: RunningUpcomingListItemBinding) :
     BaseCourseContentItemViewHolder(binding) {
 
     override fun bind(content: DomainContent) {
-        super.bind(content)
-        showOrHideDate(content)
         onItemClick(content)
-    }
-
-    private fun showOrHideDate(content: DomainContent) {
-        binding.date.text = "Avaliable ${DateUtils.getRelativeTimeString(content.start, binding.root.context)}"
-        val visibility = DateUtils.getRelativeTimeString(content.start, binding.root.context).isEmpty()
-        ViewUtils.setGone(binding.date, visibility)
+        binding.composeView.setContent {
+            UpcomingContentItemView(content)
+        }
     }
 
     private fun onItemClick(content: DomainContent) {

--- a/course/src/main/java/in/testpress/course/util/Font.kt
+++ b/course/src/main/java/in/testpress/course/util/Font.kt
@@ -1,0 +1,19 @@
+package `in`.testpress.course.util
+
+import android.content.res.AssetManager
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.Typeface
+
+object TestpressFont {
+
+    fun getRubikMediumFont(assets: AssetManager): FontFamily {
+        return FontFamily(
+            Typeface(
+                android.graphics.Typeface.createFromAsset(
+                    assets,
+                    "Rubik-Medium.ttf"
+                )
+            )
+        )
+    }
+}

--- a/course/src/main/java/in/testpress/course/util/extension/DomainContent.kt
+++ b/course/src/main/java/in/testpress/course/util/extension/DomainContent.kt
@@ -1,0 +1,15 @@
+package `in`.testpress.course.util.extension
+
+import `in`.testpress.course.R
+import `in`.testpress.course.domain.DomainContent
+
+fun DomainContent.getContentImage(): Int {
+    return when (this.contentType) {
+        "Attachment" -> R.drawable.testpress_file_icon
+        "Video" -> R.drawable.testpress_video_icon
+        "Notes" -> R.drawable.testpress_notes_icon
+        "VideoConference" -> R.drawable.testpress_live_conference_icon
+        "Exam" -> R.drawable.testpress_exam_icon
+        else -> R.drawable.testpress_exam_icon
+    }
+}

--- a/course/src/main/res/layout/running_upcoming_list_item.xml
+++ b/course/src/main/res/layout/running_upcoming_list_item.xml
@@ -5,50 +5,9 @@
     android:background="?attr/selectableItemBackground"
     android:minHeight="88dp">
 
-    <ImageView
-        android:id="@+id/thumbnail"
-        android:layout_width="72dp"
-        android:layout_height="72dp"
-        android:layout_alignParentStart="true"
-        android:padding="16dp" />
-
-    <TextView
-        android:id="@+id/title"
+    <androidx.compose.ui.platform.ComposeView
+        android:id="@+id/compose_view"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center_vertical"
-        android:layout_toEndOf="@id/thumbnail"
-        android:ellipsize="end"
-        android:maxLines="1"
-        android:paddingTop="16dp"
-        android:paddingEnd="16dp"
-        android:textAppearance="?attr/textAppearanceSubtitle1"
-        android:textColor="#000000" />
-
-    <TextView
-        android:id="@+id/date"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_below="@id/title"
-        android:layout_gravity="center_vertical"
-        android:layout_toEndOf="@id/thumbnail"
-        android:ellipsize="end"
-        android:maxLines="1"
-        android:paddingEnd="16dp"
-        android:paddingTop="2dp"
-        android:textAppearance="?attr/textAppearanceCaption" />
-
-    <TextView
-        android:id="@+id/path"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_below="@id/date"
-        android:layout_gravity="center_vertical"
-        android:layout_toEndOf="@id/thumbnail"
-        android:ellipsize="end"
-        android:maxLines="1"
-        android:paddingEnd="16dp"
-        android:paddingTop="2dp"
-        android:textAppearance="?attr/textAppearanceCaption" />
+        android:layout_height="wrap_content"/>
 
 </RelativeLayout>


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced new Compose UI components for displaying course content items in running and upcoming states, with improved layout and font styling.
  - Added utility functions to support dynamic content images and custom fonts in Compose views.

- **Refactor**
  - Migrated course content list items from traditional Android views to Jetpack Compose, simplifying layout and improving UI consistency.
  - Updated view holder logic to use Compose components for rendering content items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->