### PR TITLE
feat: Support fullscreen playback in WebView content

### DIFF
--- a/core/src/main/java/in/testpress/fragments/WebViewFragment.kt
+++ b/core/src/main/java/in/testpress/fragments/WebViewFragment.kt
@@ -111,6 +111,8 @@ class WebViewFragment : Fragment(), EmptyViewListener {
         webView.settings.builtInZoomControls = false
         webView.settings.cacheMode = WebSettings.LOAD_CACHE_ELSE_NETWORK
         webView.settings.setSupportZoom(allowZoomControl)
+        webView.settings.mediaPlaybackRequiresUserGesture = false
+        webView.settings.setSupportMultipleWindows(true)
         webView.webViewClient = CustomWebViewClient(this)
         webView.webChromeClient = CustomWebChromeClient(this)
         webView.settings.userAgentString += CUSTOM_USER_AGENT

--- a/core/src/main/java/in/testpress/fragments/WebViewFragment.kt
+++ b/core/src/main/java/in/testpress/fragments/WebViewFragment.kt
@@ -111,8 +111,6 @@ class WebViewFragment : Fragment(), EmptyViewListener {
         webView.settings.builtInZoomControls = false
         webView.settings.cacheMode = WebSettings.LOAD_CACHE_ELSE_NETWORK
         webView.settings.setSupportZoom(allowZoomControl)
-        webView.settings.mediaPlaybackRequiresUserGesture = false
-        webView.settings.setSupportMultipleWindows(true)
         webView.webViewClient = CustomWebViewClient(this)
         webView.webChromeClient = CustomWebChromeClient(this)
         webView.settings.userAgentString += CUSTOM_USER_AGENT

--- a/core/src/main/java/in/testpress/util/webview/CustomWebChromeClient.kt
+++ b/core/src/main/java/in/testpress/util/webview/CustomWebChromeClient.kt
@@ -50,6 +50,8 @@ class CustomWebChromeClient(val fragment: WebViewFragment) : WebChromeClient() {
     private var customView: View? = null
     private var customViewCallback: CustomViewCallback? = null
     private var backCallback: OnBackPressedCallback? = null
+    private var previousOrientation: Int? = null
+    private var previousSystemUiVisibility: Int? = null
 
     private fun capturedImageNotAvailable(): Array<Uri>? {
         return if (fragment.imagePath != null) {
@@ -161,9 +163,12 @@ class CustomWebChromeClient(val fragment: WebViewFragment) : WebChromeClient() {
             )
         )
 
-        // Change to landscape orientation
-        fragment.requireActivity().requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE
+        // Remember current state and switch to landscape
+        previousOrientation = fragment.requireActivity().requestedOrientation
+        fragment.requireActivity().requestedOrientation =
+            ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE
 
+        previousSystemUiVisibility = fragment.requireActivity().window.decorView.systemUiVisibility
         hideSystemUI()
 
         fragment.webView.visibility = View.GONE
@@ -190,10 +195,13 @@ class CustomWebChromeClient(val fragment: WebViewFragment) : WebChromeClient() {
         customView = null
         customViewCallback?.onCustomViewHidden()
 
-        // Restore to user's default orientation
-        fragment.requireActivity().requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
+        previousOrientation?.let {
+            fragment.requireActivity().requestedOrientation = it
+        }
 
-        showSystemUI()
+        previousSystemUiVisibility?.let {
+            fragment.requireActivity().window.decorView.systemUiVisibility = it
+        } ?: showSystemUI()
 
         fragment.webView.visibility = View.VISIBLE
 

--- a/core/src/main/java/in/testpress/util/webview/CustomWebChromeClient.kt
+++ b/core/src/main/java/in/testpress/util/webview/CustomWebChromeClient.kt
@@ -4,15 +4,20 @@ import `in`.testpress.fragments.WebViewFragment
 import android.annotation.SuppressLint
 import android.app.Activity.RESULT_OK
 import android.content.Intent
+import android.content.pm.ActivityInfo
 import android.net.Uri
 import android.os.Environment
 import android.provider.MediaStore
 import android.webkit.*
 import android.util.Log
+import android.view.View
+import android.view.ViewGroup
 import android.webkit.PermissionRequest
 import android.webkit.ValueCallback
 import android.webkit.WebChromeClient
 import android.webkit.WebView
+import android.widget.FrameLayout
+import androidx.activity.OnBackPressedCallback
 import androidx.activity.result.contract.ActivityResultContracts
 import java.io.File
 import java.io.IOException
@@ -41,6 +46,10 @@ class CustomWebChromeClient(val fragment: WebViewFragment) : WebChromeClient() {
         fragment.filePathCallback?.onReceiveValue(results)
         fragment.filePathCallback = null
     }
+
+    private var customView: View? = null
+    private var customViewCallback: CustomViewCallback? = null
+    private var backCallback: OnBackPressedCallback? = null
 
     private fun capturedImageNotAvailable(): Array<Uri>? {
         return if (fragment.imagePath != null) {
@@ -132,5 +141,78 @@ class CustomWebChromeClient(val fragment: WebViewFragment) : WebChromeClient() {
         val storageDir =
             Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES)
         return File.createTempFile(imageFileName, ".jpg", storageDir)
+    }
+
+    override fun onShowCustomView(view: View, callback: CustomViewCallback) {
+        if (customView != null) {
+            callback.onCustomViewHidden()
+            return
+        }
+
+        customView = view
+        customViewCallback = callback
+
+        // Add the fullscreen view
+        (fragment.requireActivity().window.decorView as FrameLayout).addView(
+            view,
+            FrameLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT
+            )
+        )
+
+        // Change to landscape orientation
+        fragment.requireActivity().requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE
+
+        hideSystemUI()
+
+        fragment.webView.visibility = View.GONE
+
+        backCallback = object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                if (customView != null) {
+                    customViewCallback?.onCustomViewHidden()
+                } else {
+                    isEnabled = false
+                    fragment.requireActivity().onBackPressedDispatcher.onBackPressed()
+                }
+            }
+        }
+        fragment.requireActivity().onBackPressedDispatcher.addCallback(fragment.viewLifecycleOwner, backCallback!!)
+    }
+
+
+    override fun onHideCustomView() {
+        if (customView == null) return
+
+        // Remove the fullscreen view
+        (fragment.requireActivity().window.decorView as FrameLayout).removeView(customView)
+        customView = null
+        customViewCallback?.onCustomViewHidden()
+
+        // Restore to user's default orientation
+        fragment.requireActivity().requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
+
+        showSystemUI()
+
+        fragment.webView.visibility = View.VISIBLE
+
+        backCallback?.remove()
+        backCallback = null
+    }
+
+    private fun hideSystemUI() {
+        fragment.requireActivity().window.decorView.systemUiVisibility =
+            View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY or
+                    View.SYSTEM_UI_FLAG_LAYOUT_STABLE or
+                    View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION or
+                    View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN or
+                    View.SYSTEM_UI_FLAG_HIDE_NAVIGATION or
+                    View.SYSTEM_UI_FLAG_FULLSCREEN
+    }
+
+    private fun showSystemUI() {
+        fragment.requireActivity().window.decorView.systemUiVisibility =
+            View.SYSTEM_UI_FLAG_LAYOUT_STABLE
     }
 }


### PR DESCRIPTION
- Users couldn't view web videos in full-screen mode inside the WebView.
- This was because full-screen video callbacks from the WebChromeClient were not handled.
- This is fixed by implementing onShowCustomView and onHideCustomView to enable fullscreen video playback, hide system UI, and handle back press to exit fullscreen.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support for fullscreen video and custom content in WebView, including immersive fullscreen mode and automatic orientation changes.
	- Improved back button behavior to properly exit fullscreen mode.
- **Enhancements**
	- System UI and screen orientation are now managed automatically when entering and exiting fullscreen content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->