### PR TITLE
fix: Crash on payment success by replacing putExtras with specific putExtra calls

### DIFF
--- a/store/src/main/java/in/testpress/store/ui/OrderConfirmActivity.java
+++ b/store/src/main/java/in/testpress/store/ui/OrderConfirmActivity.java
@@ -278,9 +278,9 @@ public class OrderConfirmActivity extends BaseToolBarActivity implements Payment
 
     public void showPaymentSuccessScreen() {
         Intent intent = new Intent(this, PaymentSuccessActivity.class);
+        intent.putExtras(getIntent().getExtras());
         intent.putExtra(ORDER, order);
         //noinspection ConstantConditions
-        intent.putExtras(getIntent().getExtras());
         startActivityForResult(intent, STORE_REQUEST_CODE);
     }
 

--- a/store/src/main/java/in/testpress/store/ui/OrderConfirmActivity.java
+++ b/store/src/main/java/in/testpress/store/ui/OrderConfirmActivity.java
@@ -278,9 +278,9 @@ public class OrderConfirmActivity extends BaseToolBarActivity implements Payment
 
     public void showPaymentSuccessScreen() {
         Intent intent = new Intent(this, PaymentSuccessActivity.class);
-        intent.putExtras(getIntent().getExtras());
         intent.putExtra(ORDER, order);
         //noinspection ConstantConditions
+        intent.putExtra(PRODUCT, product);
         startActivityForResult(intent, STORE_REQUEST_CODE);
     }
 


### PR DESCRIPTION
#### Description
- Navigating to the payment success screen sometimes caused the app to crash.
- This occurred because when (`putExtras`) was called with its `getIntent().getExtras()` to put PRODUCT and ORDER from the current intent and it overwrote the order to `None` being set in the previous line.
- The fix replaces `putExtras` with `putExtra` to put data what's needed rather than getting all from intent , so it is correctly passed to the next screen.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of payment success screen by ensuring only the relevant product information is passed after order confirmation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->