### PR TITLE
fix: Downgrade compose BOM to resolve compatibility issue with Stripe SDK v32.0.0

### DIFF
--- a/course/build.gradle
+++ b/course/build.gradle
@@ -85,7 +85,7 @@ dependencies {
     androidTestImplementation rootProject.androidxCore
     androidTestImplementation rootProject.androidXTestLibrary
 
-    def composeBom = platform('androidx.compose:compose-bom:2024.08.00')
+    def composeBom = platform('androidx.compose:compose-bom:2023.09.01')
     implementation(composeBom)
     androidTestImplementation(composeBom)
 


### PR DESCRIPTION
#### What is the purpose of this PR?

This PR addresses a compatibility issue between androidx.compose:compose-bom:2024.08.00 and com.stripe:stripe-android:32.0.0. The newer Compose BOM version introduced changes that are not compatible with the current Stripe SDK version in use.

### Changes done
- Compose BOM version downgraded
- **From** `androidx.compose:compose-bom:2024.08.00` **to** `androidx.compose:compose-bom:2023.09.01`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the version of AndroidX Compose libraries used in the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->