### PR TITLE
refactor: Enforce non-null profileDetails in video conferencing feature

### DIFF
--- a/course/src/main/java/in/testpress/course/fragments/VideoConferenceFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/VideoConferenceFragment.kt
@@ -99,7 +99,7 @@ class VideoConferenceFragment : BaseContentDetailFragment() {
 
     private fun loadProfileAndInitializeConference(videoConference: DomainVideoConferenceContent?) {
         TestpressUserDetails.getInstance().load(requireContext(),object : TestpressCallback<ProfileDetails>(){
-            override fun onSuccess(result: ProfileDetails) {
+            override fun onSuccess(result: ProfileDetails?) {
                 profileDetails = result
                 profileDetails?.let {
                     initVideoConferenceHandler(videoConference, it)

--- a/course/src/main/java/in/testpress/course/fragments/VideoConferenceFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/VideoConferenceFragment.kt
@@ -92,27 +92,27 @@ class VideoConferenceFragment : BaseContentDetailFragment() {
 
     private fun initializeVideoConferenceHandler(videoConference: DomainVideoConferenceContent?) {
         showLoadingAndDisableStartButton()
-        if (profileDetails == null) {
-            loadProfileAndInitializeConference(videoConference)
-        } else {
-            initVideoConferenceHandler(videoConference)
-        }
+        profileDetails?.let {
+            initVideoConferenceHandler(videoConference, it)
+        } ?: loadProfileAndInitializeConference(videoConference)
     }
 
     private fun loadProfileAndInitializeConference(videoConference: DomainVideoConferenceContent?) {
         TestpressUserDetails.getInstance().load(requireContext(),object : TestpressCallback<ProfileDetails>(){
-            override fun onSuccess(result: ProfileDetails?) {
+            override fun onSuccess(result: ProfileDetails) {
                 profileDetails = result
-                initVideoConferenceHandler(videoConference)
+                profileDetails?.let {
+                    initVideoConferenceHandler(videoConference, it)
+                }
             }
 
-            override fun onException(exception: TestpressException?) {
-                initVideoConferenceHandler(videoConference)
+            override fun onException(exception: TestpressException) {
+                emptyViewFragment.displayError(exception)
             }
         })
     }
 
-    private fun initVideoConferenceHandler(videoConference: DomainVideoConferenceContent?) {
+    private fun initVideoConferenceHandler(videoConference: DomainVideoConferenceContent?, profileDetails: ProfileDetails) {
         try {
             videoConferenceHandler = VideoConferenceHandler(requireContext(), videoConference!!, profileDetails)
             videoConferenceHandler?.init(object : VideoConferenceInitializeListener {

--- a/course/src/main/java/in/testpress/course/util/VideoConferenceHandler.kt
+++ b/course/src/main/java/in/testpress/course/util/VideoConferenceHandler.kt
@@ -7,7 +7,7 @@ import android.content.Context
 class VideoConferenceHandler(
     val context: Context,
     val videoConference: DomainVideoConferenceContent,
-    val profileDetails: ProfileDetails?
+    val profileDetails: ProfileDetails
 ) {
 
     private var zoomMeetHandler = ZoomMeetHandler(

--- a/course/src/main/java/in/testpress/course/util/ZoomMeetHandler.kt
+++ b/course/src/main/java/in/testpress/course/util/ZoomMeetHandler.kt
@@ -20,7 +20,7 @@ import us.zoom.sdk.MeetingViewsOptions.NO_TEXT_PASSWORD
 class ZoomMeetHandler(
     val context: Context,
     val videoConference: DomainVideoConferenceContent,
-    val profileDetails: ProfileDetails?
+    val profileDetails: ProfileDetails
 ) : ZoomSDKInitializeListener, MeetingCommonCallback.CommonEvent {
 
     private lateinit var zoomSDK: ZoomSDK
@@ -189,11 +189,9 @@ class ZoomMeetHandler(
         options.no_meeting_error_message = true
         options.meeting_views_options = NO_TEXT_PASSWORD + NO_TEXT_MEETING_ID
         options.no_bottom_toolbar = false
-        options.no_webinar_register_dialog = profileDetails != null && profileDetails.email.isEmailValid()
+        options.no_webinar_register_dialog = profileDetails.email.isEmailValid()
         options.no_invite = true
-        if (profileDetails != null) {
-            options.customer_key = profileDetails.username
-        }
+        options.customer_key = profileDetails.username
         return options
     }
 
@@ -205,7 +203,7 @@ class ZoomMeetHandler(
     }
 
     override fun onJoinWebinarNeedUserNameAndEmail(inMeetingEventHandler: InMeetingEventHandler) {
-        if (profileDetails != null && profileDetails.email.isEmailValid()) {
+        if (profileDetails.email.isEmailValid()) {
             val name = profileDetails.displayName ?: profileDetails.username
             inMeetingEventHandler.setRegisterWebinarInfo(name, profileDetails.email, false)
         }


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Improved reliability by ensuring user profile information is always available when joining or managing video conferences.
	- Streamlined error handling and removed unnecessary checks for missing profile details during video conferencing.
- **Bug Fixes**
	- Reduced the chance of errors related to missing user profile data in video conference features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->