### PR TITLE
fix: Update customer_key to use user ID in zoom live classes

### DIFF
--- a/course/src/main/java/in/testpress/course/util/ZoomMeetHandler.kt
+++ b/course/src/main/java/in/testpress/course/util/ZoomMeetHandler.kt
@@ -191,7 +191,7 @@ class ZoomMeetHandler(
         options.no_bottom_toolbar = false
         options.no_webinar_register_dialog = profileDetails.email.isEmailValid()
         options.no_invite = true
-        options.customer_key = profileDetails.username
+        options.customer_key = "id:${profileDetails.id}"
         return options
     }
 


### PR DESCRIPTION
- We use the `customer_key` field to record user attendance for Zoom live classes by matching it back to a user in our system. Previously, this key was often set to the user's email or username. Ref - https://github.com/testpress/testpress_python/commit/a79345ebd776d5d2887ec8cc7aa4f0412fe04d91
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the customer key format used when joining Zoom meetings to improve identification reliability. The key now uses the user's ID instead of the username.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->