### PR TITLE
fix: Support file uploads from Adobe and Drive-based file pickers

### DIFF
--- a/core/src/main/java/in/testpress/util/FileUtils.kt
+++ b/core/src/main/java/in/testpress/util/FileUtils.kt
@@ -8,15 +8,16 @@ import java.io.InputStream
 
 fun copyFileFromUriAndUpload(
     context: Context,
-    uri: Uri,
+    uri: Uri?,
     onSuccess: (filePath: String) -> Unit,
     onError: (error: String) -> Unit
 ) {
+    if (uri == null) onError("No file selected for upload")
     var inputStream: InputStream? = null
     var outputStream: FileOutputStream? = null
 
     try {
-        inputStream = context.contentResolver.openInputStream(uri)
+        inputStream = context.contentResolver.openInputStream(uri!!)
         if (inputStream == null) {
             onError("Unable to read selected file")
             return

--- a/core/src/main/java/in/testpress/util/FileUtils.kt
+++ b/core/src/main/java/in/testpress/util/FileUtils.kt
@@ -44,6 +44,7 @@ fun copyFileFromUriAndUpload(
 
     } catch (e: Exception) {
         e.printStackTrace()
+        tempFile?.delete()
         onError("Failed to copy and upload file: ${e.message}")
         return
     } finally {

--- a/core/src/main/java/in/testpress/util/FileUtils.kt
+++ b/core/src/main/java/in/testpress/util/FileUtils.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.net.Uri
 import java.io.File
 import java.io.FileOutputStream
+import java.io.InputStream
 
 fun copyFileFromUriAndUpload(
     context: Context,
@@ -11,15 +12,18 @@ fun copyFileFromUriAndUpload(
     onSuccess: (filePath: String) -> Unit,
     onError: (error: String) -> Unit
 ) {
+    var inputStream: InputStream? = null
+    var outputStream: FileOutputStream? = null
+
     try {
-        val inputStream = context.contentResolver.openInputStream(uri)
+        inputStream = context.contentResolver.openInputStream(uri)
         if (inputStream == null) {
             onError("Unable to read selected file")
             return
         }
 
         val tempFile = File(context.cacheDir, "upload_temp.pdf")
-        val outputStream = FileOutputStream(tempFile)
+        outputStream = FileOutputStream(tempFile)
 
         val buffer = ByteArray(4096)
         var bytesRead: Int
@@ -27,13 +31,13 @@ fun copyFileFromUriAndUpload(
             outputStream.write(buffer, 0, bytesRead)
         }
 
-        inputStream.close()
-        outputStream.close()
-
         onSuccess(tempFile.absolutePath)
 
     } catch (e: Exception) {
         e.printStackTrace()
         onError("Failed to copy and upload file: ${e.message}")
+    } finally {
+        inputStream?.close()
+        outputStream?.close()
     }
 }

--- a/core/src/main/java/in/testpress/util/FileUtils.kt
+++ b/core/src/main/java/in/testpress/util/FileUtils.kt
@@ -1,0 +1,39 @@
+package `in`.testpress.util
+
+import android.content.Context
+import android.net.Uri
+import java.io.File
+import java.io.FileOutputStream
+
+fun copyFileFromUriAndUpload(
+    context: Context,
+    uri: Uri,
+    onSuccess: (filePath: String) -> Unit,
+    onError: (error: String) -> Unit
+) {
+    try {
+        val inputStream = context.contentResolver.openInputStream(uri)
+        if (inputStream == null) {
+            onError("Unable to read selected file")
+            return
+        }
+
+        val tempFile = File(context.cacheDir, "upload_temp.pdf")
+        val outputStream = FileOutputStream(tempFile)
+
+        val buffer = ByteArray(4096)
+        var bytesRead: Int
+        while (inputStream.read(buffer).also { bytesRead = it } != -1) {
+            outputStream.write(buffer, 0, bytesRead)
+        }
+
+        inputStream.close()
+        outputStream.close()
+
+        onSuccess(tempFile.absolutePath)
+
+    } catch (e: Exception) {
+        e.printStackTrace()
+        onError("Failed to copy and upload file: ${e.message}")
+    }
+}

--- a/core/src/main/java/in/testpress/util/FileUtils.kt
+++ b/core/src/main/java/in/testpress/util/FileUtils.kt
@@ -5,6 +5,7 @@ import android.net.Uri
 import java.io.File
 import java.io.FileOutputStream
 import java.io.InputStream
+import android.provider.OpenableColumns
 
 fun copyFileFromUriAndUpload(
     context: Context,
@@ -12,18 +13,24 @@ fun copyFileFromUriAndUpload(
     onSuccess: (filePath: String) -> Unit,
     onError: (error: String) -> Unit
 ) {
-    if (uri == null) onError("No file selected for upload")
+    if (uri == null) {
+        onError("No file selected for upload")
+        return
+    }
+
     var inputStream: InputStream? = null
     var outputStream: FileOutputStream? = null
 
     try {
-        inputStream = context.contentResolver.openInputStream(uri!!)
+        inputStream = context.contentResolver.openInputStream(uri)
         if (inputStream == null) {
             onError("Unable to read selected file")
             return
         }
 
-        val tempFile = File(context.cacheDir, "upload_temp.pdf")
+        val fileName = getFileNameFromUri(context, uri) ?: "upload_temp"
+        val tempFile = File(context.cacheDir, fileName)
+
         outputStream = FileOutputStream(tempFile)
 
         val buffer = ByteArray(4096)
@@ -41,4 +48,18 @@ fun copyFileFromUriAndUpload(
         inputStream?.close()
         outputStream?.close()
     }
+}
+
+private fun getFileNameFromUri(context: Context, uri: Uri): String? {
+    var name: String? = null
+    val cursor = context.contentResolver.query(uri, null, null, null, null)
+    cursor?.use {
+        if (it.moveToFirst()) {
+            val index = it.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+            if (index != -1) {
+                name = it.getString(index)
+            }
+        }
+    }
+    return name
 }

--- a/exam/src/main/java/in/testpress/exam/ui/TestQuestionFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestQuestionFragment.java
@@ -100,6 +100,9 @@ public class TestQuestionFragment extends Fragment implements PickiTCallbacks, E
         instituteSettings = TestpressSdk.getTestpressSession(getContext()).getInstituteSettings();
         apiClient = new TestpressExamApiClient(getContext());
         pickiT = new PickiT(requireContext(), this, requireActivity());
+        if (savedInstanceState != null) {
+            selectedUriFromIntent = savedInstanceState.getParcelable("KEY_SELECTED_URI");
+        }
     }
 
     @SuppressLint({"SetTextI18n", "AddJavascriptInterface"})
@@ -399,8 +402,13 @@ public class TestQuestionFragment extends Fragment implements PickiTCallbacks, E
     public void onActivityResult(int requestCode, int resultCode, @Nullable Intent data) {
         if (requestCode == 42 && resultCode == Activity.RESULT_OK) {
             if (data != null) {
-                selectedUriFromIntent = data.getData();
-                pickiT.getPath(data.getData(), Build.VERSION.SDK_INT);
+                Uri uri = data.getData();
+                if (uri != null){
+                    requireContext().getContentResolver()
+                            .takePersistableUriPermission(uri, Intent.FLAG_GRANT_READ_URI_PERMISSION);
+                    selectedUriFromIntent = uri;
+                }
+                pickiT.getPath(uri, Build.VERSION.SDK_INT);
             }
         } else {
             super.onActivityResult(requestCode, resultCode, data);
@@ -431,6 +439,11 @@ public class TestQuestionFragment extends Fragment implements PickiTCallbacks, E
         attemptItem.setUnSyncedFiles(fileURLs);
     }
 
+    @Override
+    public void onSaveInstanceState(@NonNull Bundle outState) {
+        super.onSaveInstanceState(outState);
+        outState.putParcelable("KEY_SELECTED_URI", selectedUriFromIntent);
+    }
 
     @Override
     public void onDestroyView() {

--- a/exam/src/main/java/in/testpress/exam/ui/TestQuestionFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestQuestionFragment.java
@@ -428,12 +428,14 @@ public class TestQuestionFragment extends Fragment implements PickiTCallbacks, E
                         saveUploadedFileURL(fileDetails);
                         progressDialog.hide();
                         update();
+                        FileUtilsKt.deleteFileByPath(filePath);
                     }
 
                     @Override
                     public void onException(TestpressException exception) {
                         Toast.makeText(getContext(), exception.getMessage(), Toast.LENGTH_LONG).show();
                         progressDialog.hide();
+                        FileUtilsKt.deleteFileByPath(filePath);
                     }
                 });
     }

--- a/exam/src/main/java/in/testpress/exam/ui/TestQuestionFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestQuestionFragment.java
@@ -389,7 +389,12 @@ public class TestQuestionFragment extends Fragment implements PickiTCallbacks, E
     void pickFile() {
         Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
         intent.addCategory(Intent.CATEGORY_OPENABLE);
+
         intent.setType("*/*");
+
+        String[] mimeTypes = {"image/jpeg", "application/pdf"};
+        intent.putExtra(Intent.EXTRA_MIME_TYPES, mimeTypes);
+
         intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION);
        if(getParentFragment() != null) {
            getParentFragment().startActivityForResult(intent, 42);


### PR DESCRIPTION
- App crashes when picking files from cloud storage providers like Adobe or Drive


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a fallback mechanism for file uploads that copies files from their URI when a direct file path is unavailable.
  - Improved error handling with user-friendly alerts during file upload failures.
  - Maintained file URI permissions and state across configuration changes for reliable uploads.
  - Restricted file picker to accept only JPEG images and PDF documents.
  - Temporary files created during upload are now cleaned up automatically.

- **Bug Fixes**
  - Fixed upload failures caused by missing file paths, ensuring smoother and more reliable file uploads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->