### PR TITLE
fix: Add JWT token expiry check in VideoConferenceFragment

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -92,6 +92,7 @@ ext {
     kotlinxCoroutinesCore = "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.3"
     kotlinxCoroutinesAndroid = "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.3"
     flexboxLayout = "com.google.android.flexbox:flexbox:3.0.0"
+    jwtdecode = "com.auth0.android:jwtdecode:2.0.2"
 
     // Payment Dependencies
     payUCheckoutPro = "in.payu:payu-checkout-pro:1.8.0"

--- a/course/build.gradle
+++ b/course/build.gradle
@@ -66,6 +66,7 @@ dependencies {
     api rootProject.doubleTapPlayerView
     api rootProject.pagingRuntime
     api rootProject.pagingCommon
+    api rootProject.jwtdecode
     debugImplementation rootProject.fragmentTestingExtensions
 
     testImplementation rootProject.junit

--- a/course/src/main/java/in/testpress/course/fragments/VideoConferenceFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/VideoConferenceFragment.kt
@@ -18,6 +18,7 @@ import android.widget.TextView
 import android.widget.Toast
 import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
+import com.auth0.android.jwt.JWT
 import `in`.testpress.core.TestpressCallback
 import `in`.testpress.core.TestpressException
 import io.sentry.Sentry
@@ -32,6 +33,8 @@ class VideoConferenceFragment : BaseContentDetailFragment() {
     private lateinit var endMessageDescription: TextView
     private var videoConferenceHandler: VideoConferenceHandler? = null
     private var profileDetails: ProfileDetails? = null
+    private var reloadContent = 0
+    private val maxReloadContent = 3
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -78,6 +81,14 @@ class VideoConferenceFragment : BaseContentDetailFragment() {
         if (videoConference?.isEnded() == true) {
             view?.findViewById<LinearLayout>(R.id.video_conference_ended_layout)?.isVisible = true
             return
+        }
+
+        videoConference?.accessToken?.let { token ->
+            if (JWT(token).isExpired(10) && reloadContent < maxReloadContent) {
+                reloadContent++
+                forceReloadContent()
+                return
+            }
         }
 
         initializeVideoConferenceHandler(videoConference)

--- a/course/src/main/java/in/testpress/course/fragments/VideoConferenceFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/VideoConferenceFragment.kt
@@ -84,9 +84,14 @@ class VideoConferenceFragment : BaseContentDetailFragment() {
         }
 
         videoConference?.accessToken?.let { token ->
-            if (JWT(token).isExpired(10) && reloadContent < maxReloadContent) {
-                reloadContent++
-                forceReloadContent()
+            try {
+                if (JWT(token).isExpired(10) && reloadContent < maxReloadContent) {
+                    reloadContent++
+                    forceReloadContent()
+                    return
+                }
+            } catch (e: Exception) {
+                Sentry.captureException(e)
                 return
             }
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved reliability of video conference access by automatically refreshing content if the access token is near expiration, reducing interruptions during video sessions.
- **Chores**
	- Added a new library dependency to enhance token handling capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->