### PR TITLE
fix: Loading dialog shown after fragment destroyed on low memory

### DIFF
--- a/exam/src/main/java/in/testpress/exam/ui/TestActivity.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestActivity.java
@@ -5,6 +5,8 @@ import android.app.Activity;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
+
+import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
 import androidx.appcompat.app.AlertDialog;
 import androidx.lifecycle.Observer;
@@ -137,15 +139,6 @@ public class TestActivity extends BaseToolBarActivity  {
             if (testFragment != null) {
                 attempt = testFragment.attempt;
                 courseAttempt = testFragment.courseAttempt;
-
-                if (attempt == null){
-                    attempt = savedInstanceState.getParcelable(PARAM_ATTEMPT);
-                }
-
-                if (courseAttempt == null){
-                    courseAttempt = savedInstanceState.getParcelable(PARAM_COURSE_ATTEMPT);
-                }
-
                 getSupportFragmentManager().beginTransaction().remove(testFragment)
                         .commitAllowingStateLoss();
             } else {
@@ -163,11 +156,24 @@ public class TestActivity extends BaseToolBarActivity  {
         if (courseAttempt == null){
             courseAttempt = data.getParcelable(PARAM_COURSE_ATTEMPT);
         }
+        retrieveDataFromSavedInstanceState(savedInstanceState);
         onDataInitialized();
         observePermissionResources();
         observeLanguageResources();
         observeContentAttemptResources();
         observeAttemptResources();
+    }
+
+    private void retrieveDataFromSavedInstanceState(@Nullable Bundle savedInstanceState) {
+        if (savedInstanceState == null) return;
+
+        if (attempt == null) {
+            attempt = savedInstanceState.getParcelable(PARAM_ATTEMPT);
+        }
+
+        if (courseAttempt == null) {
+            courseAttempt = savedInstanceState.getParcelable(PARAM_COURSE_ATTEMPT);
+        }
     }
 
     void observePermissionResources(){

--- a/exam/src/main/java/in/testpress/exam/ui/TestActivity.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestActivity.java
@@ -136,10 +136,21 @@ public class TestActivity extends BaseToolBarActivity  {
             TestFragment testFragment = getCurrentFragment();
             if (testFragment != null) {
                 attempt = testFragment.attempt;
+                courseAttempt = testFragment.courseAttempt;
+
+                if (attempt == null){
+                    attempt = savedInstanceState.getParcelable(PARAM_ATTEMPT);
+                }
+
+                if (courseAttempt == null){
+                    courseAttempt = savedInstanceState.getParcelable(PARAM_COURSE_ATTEMPT);
+                }
+
                 getSupportFragmentManager().beginTransaction().remove(testFragment)
                         .commitAllowingStateLoss();
             } else {
                 attempt = savedInstanceState.getParcelable(PARAM_ATTEMPT);
+                courseAttempt = savedInstanceState.getParcelable(PARAM_COURSE_ATTEMPT);
             }
             permission = savedInstanceState.getParcelable(PARAM_PERMISSION);
             languages = savedInstanceState.getParcelableArrayList(PARAM_LANGUAGES);
@@ -149,7 +160,9 @@ public class TestActivity extends BaseToolBarActivity  {
             attempt = data.getParcelable(PARAM_ATTEMPT);
         }
         courseContent = data.getParcelable(PARAM_COURSE_CONTENT);
-        courseAttempt = data.getParcelable(PARAM_COURSE_ATTEMPT);
+        if (courseAttempt == null){
+            courseAttempt = data.getParcelable(PARAM_COURSE_ATTEMPT);
+        }
         onDataInitialized();
         observePermissionResources();
         observeLanguageResources();
@@ -542,7 +555,11 @@ public class TestActivity extends BaseToolBarActivity  {
                     new MultiLanguagesUtil.LanguageSelectionListener() {
                         @Override
                         public void onLanguageSelected() {
-                            startExam(true);
+                            if (exam.isAttemptResumeDisabled()) {
+                                endExam();
+                            } else {
+                                startExam(true);
+                            }
                         }});
             durationLabel.setText(getString(R.string.testpress_time_remaining));
             examDuration.setText(attempt.getRemainingTime());
@@ -749,6 +766,7 @@ public class TestActivity extends BaseToolBarActivity  {
     protected void onSaveInstanceState(Bundle outState) {
         outState.putParcelable(PARAM_EXAM, exam);
         outState.putParcelable(PARAM_ATTEMPT, attempt);
+        outState.putParcelable(PARAM_COURSE_ATTEMPT, courseAttempt);
         outState.putParcelable(PARAM_PERMISSION, permission);
         if (languages != null) {
             outState.putParcelableArrayList(PARAM_LANGUAGES, new ArrayList<>(languages));

--- a/exam/src/main/java/in/testpress/exam/ui/TestActivity.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestActivity.java
@@ -5,7 +5,6 @@ import android.app.Activity;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
-
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
 import androidx.appcompat.app.AlertDialog;
@@ -153,9 +152,7 @@ public class TestActivity extends BaseToolBarActivity  {
             attempt = data.getParcelable(PARAM_ATTEMPT);
         }
         courseContent = data.getParcelable(PARAM_COURSE_CONTENT);
-        if (courseAttempt == null){
-            courseAttempt = data.getParcelable(PARAM_COURSE_ATTEMPT);
-        }
+        courseAttempt = data.getParcelable(PARAM_COURSE_ATTEMPT);
         retrieveDataFromSavedInstanceState(savedInstanceState);
         onDataInitialized();
         observePermissionResources();

--- a/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
@@ -148,8 +148,6 @@ public class TestFragment extends BaseFragment implements
     private EventsTrackerFacade eventsTrackerFacade;
     private AttemptViewModel attemptViewModel;
 
-    private String TAG = "TAG";
-
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);

--- a/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
@@ -4,8 +4,10 @@ import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.Dialog;
 import android.app.ProgressDialog;
+import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
+import android.content.res.Configuration;
 import android.graphics.Color;
 import android.os.Build;
 import android.os.Bundle;
@@ -22,6 +24,7 @@ import androidx.slidingpanelayout.widget.SlidingPaneLayout;
 import androidx.appcompat.app.AlertDialog;
 
 import android.text.Html;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -115,7 +118,7 @@ public class TestFragment extends BaseFragment implements
     Attempt attempt;
     private Exam exam;
     private Content courseContent;
-    private CourseAttempt courseAttempt;
+    CourseAttempt courseAttempt;
     private int currentQuestionIndex;
     List<AttemptSection> sections = new ArrayList<>();
     List<AttemptItem> attemptItemList = new ArrayList<>();
@@ -148,9 +151,12 @@ public class TestFragment extends BaseFragment implements
     private EventsTrackerFacade eventsTrackerFacade;
     private AttemptViewModel attemptViewModel;
 
+    private String TAG = "TAG";
+
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        Log.d(TAG, "onCreate: ");
         attemptViewModel = AttemptViewModel.Companion.initializeViewModel(requireActivity());
         initializeAttemptAndExamVariables(savedInstanceState);
         instituteSettings = TestpressSdk.getTestpressSession(getContext()).getInstituteSettings();
@@ -188,6 +194,7 @@ public class TestFragment extends BaseFragment implements
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
+        Log.d(TAG, "onCreateView: ");
 
         return inflater.inflate(R.layout.testpress_fragment_test_engine, container, false);
     }
@@ -195,6 +202,7 @@ public class TestFragment extends BaseFragment implements
     @Override
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
+        Log.d(TAG, "onViewCreated: ");
         bindViews();
         initializeProgressDialog();
         initializeListeners();
@@ -692,6 +700,7 @@ public class TestFragment extends BaseFragment implements
     }
 
     private void observeAttemptItemResources(){
+        Log.d(TAG, "observeAttemptItemResources: ");
         attemptViewModel.getAttemptItemsResource().observe(requireActivity(), new Observer<Resource<List<AttemptItem>>>() {
             @Override
             public void onChanged(Resource<List<AttemptItem>> listResource) {
@@ -763,7 +772,9 @@ public class TestFragment extends BaseFragment implements
                         break;
                     }
                     case LOADING:{
-                        progressDialog.show();
+                        if (isAdded()) {
+                            progressDialog.show();
+                        }
                         break;
                     }
                     case ERROR:{
@@ -1637,12 +1648,14 @@ public class TestFragment extends BaseFragment implements
     @Override
     public void onSaveInstanceState(@NonNull Bundle outState) {
         attempt.setSections(sections);
+        Log.d(TAG, "onSaveInstanceState: ");
         outState.putParcelable(PARAM_ATTEMPT, attempt);
         super.onSaveInstanceState(outState);
     }
 
     @Override
     public void onResume() {
+        Log.d(TAG, "onResume: ");
         super.onResume();
         removeAppBackgroundHandler();
     }
@@ -1657,6 +1670,7 @@ public class TestFragment extends BaseFragment implements
     @Override
     public void onStop() {
         super.onStop();
+        Log.d(TAG, "onStop: ");
         saveResult(currentQuestionIndex, Action.UPDATE_ANSWER);
         appBackgroundStateHandler = new Handler();
         appBackgroundStateHandler.postDelayed(stopTimerTask, APP_BACKGROUND_DELAY);
@@ -1672,6 +1686,7 @@ public class TestFragment extends BaseFragment implements
 
     @Override
     public Dialog[] getDialogs() {
+        Log.d(TAG, "getDialogs: ");
         return new Dialog[] {
                 progressDialog, resumeExamDialog, heartBeatAlertDialog, saveAnswerAlertDialog,
                 networkErrorAlertDialog
@@ -1680,6 +1695,7 @@ public class TestFragment extends BaseFragment implements
 
     @Override
     public void onDestroy() {
+        Log.d(TAG, "onDestroy: ");
         stopTimer();
         removeAppBackgroundHandler();
         super.onDestroy();
@@ -1698,5 +1714,53 @@ public class TestFragment extends BaseFragment implements
 
     private boolean isOfflineExam() {
         return exam != null && Boolean.TRUE.equals(exam.getIsOfflineExam());
+    }
+
+    @Override
+    public void onLowMemory() {
+        super.onLowMemory();
+        Log.d(TAG, "onLowMemory: ");
+    }
+
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        Log.d(TAG, "onDestroyView: ");
+    }
+
+    @Override
+    public void onAttach(@NonNull Context context) {
+        super.onAttach(context);
+        Log.d(TAG, "onAttach: ");
+    }
+
+    @Override
+    public void onDetach() {
+        super.onDetach();
+        Log.d(TAG, "onDetach: ");
+    }
+
+    @Override
+    public void onConfigurationChanged(@NonNull Configuration newConfig) {
+        super.onConfigurationChanged(newConfig);
+        Log.d(TAG, "onConfigurationChanged: ");
+    }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+        Log.d(TAG, "onPause: ");
+    }
+
+    @Override
+    public void onStart() {
+        super.onStart();
+        Log.d(TAG, "onStart: ");
+    }
+
+    @Override
+    public void onPrimaryNavigationFragmentChanged(boolean isPrimaryNavigationFragment) {
+        super.onPrimaryNavigationFragmentChanged(isPrimaryNavigationFragment);
+        Log.d(TAG, "onPrimaryNavigationFragmentChanged: ");
     }
 }

--- a/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
@@ -4,10 +4,8 @@ import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.Dialog;
 import android.app.ProgressDialog;
-import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
-import android.content.res.Configuration;
 import android.graphics.Color;
 import android.os.Build;
 import android.os.Bundle;
@@ -24,7 +22,6 @@ import androidx.slidingpanelayout.widget.SlidingPaneLayout;
 import androidx.appcompat.app.AlertDialog;
 
 import android.text.Html;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -156,7 +153,6 @@ public class TestFragment extends BaseFragment implements
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        Log.d(TAG, "onCreate: ");
         attemptViewModel = AttemptViewModel.Companion.initializeViewModel(requireActivity());
         initializeAttemptAndExamVariables(savedInstanceState);
         instituteSettings = TestpressSdk.getTestpressSession(getContext()).getInstituteSettings();
@@ -194,7 +190,6 @@ public class TestFragment extends BaseFragment implements
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
-        Log.d(TAG, "onCreateView: ");
 
         return inflater.inflate(R.layout.testpress_fragment_test_engine, container, false);
     }
@@ -202,7 +197,6 @@ public class TestFragment extends BaseFragment implements
     @Override
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
-        Log.d(TAG, "onViewCreated: ");
         bindViews();
         initializeProgressDialog();
         initializeListeners();
@@ -700,8 +694,7 @@ public class TestFragment extends BaseFragment implements
     }
 
     private void observeAttemptItemResources(){
-        Log.d(TAG, "observeAttemptItemResources: ");
-        attemptViewModel.getAttemptItemsResource().observe(requireActivity(), new Observer<Resource<List<AttemptItem>>>() {
+        attemptViewModel.getAttemptItemsResource().observe(getViewLifecycleOwner(), new Observer<Resource<List<AttemptItem>>>() {
             @Override
             public void onChanged(Resource<List<AttemptItem>> listResource) {
                 switch (listResource.getStatus()){
@@ -772,9 +765,7 @@ public class TestFragment extends BaseFragment implements
                         break;
                     }
                     case LOADING:{
-                        if (isAdded()) {
-                            progressDialog.show();
-                        }
+                        progressDialog.show();
                         break;
                     }
                     case ERROR:{
@@ -938,7 +929,7 @@ public class TestFragment extends BaseFragment implements
     }
 
     private void observeSaveAnswerResource() {
-        attemptViewModel.getSaveResultResource().observe(requireActivity(), new Observer<Resource<Triple<Integer, AttemptItem, Action>>>() {
+        attemptViewModel.getSaveResultResource().observe(getViewLifecycleOwner(), new Observer<Resource<Triple<Integer, AttemptItem, Action>>>() {
             @Override
             public void onChanged(Resource<Triple<Integer, AttemptItem, Action>> hashMapResource) {
                 if (hashMapResource == null || getActivity() == null) {
@@ -1062,7 +1053,7 @@ public class TestFragment extends BaseFragment implements
     }
 
     void observeUpdateSectionResource() {
-        attemptViewModel.getUpdateSectionResource().observe(requireActivity(), new Observer<Resource<Pair<NetworkAttemptSection, Action>>>() {
+        attemptViewModel.getUpdateSectionResource().observe(getViewLifecycleOwner(), new Observer<Resource<Pair<NetworkAttemptSection, Action>>>() {
             @Override
             public void onChanged(Resource<Pair<NetworkAttemptSection, Action>> pairResource) {
                 if (pairResource == null || getActivity() == null) {
@@ -1165,7 +1156,7 @@ public class TestFragment extends BaseFragment implements
     }
 
     private void observeEndContentAttemptResources(){
-        attemptViewModel.getEndContentAttemptResource().observe(requireActivity(), new Observer<Resource<CourseAttempt>>() {
+        attemptViewModel.getEndContentAttemptResource().observe(getViewLifecycleOwner(), new Observer<Resource<CourseAttempt>>() {
             @Override
             public void onChanged(Resource<CourseAttempt> courseAttemptResource) {
                 switch (courseAttemptResource.getStatus()){
@@ -1209,7 +1200,7 @@ public class TestFragment extends BaseFragment implements
     }
 
     private void observeEndAttemptResources() {
-        attemptViewModel.getEndAttemptResource().observe(requireActivity(), new Observer<Resource<Attempt>>() {
+        attemptViewModel.getEndAttemptResource().observe(getViewLifecycleOwner(), new Observer<Resource<Attempt>>() {
             @Override
             public void onChanged(Resource<Attempt> attemptResource) {
                 switch (attemptResource.getStatus()){
@@ -1648,14 +1639,12 @@ public class TestFragment extends BaseFragment implements
     @Override
     public void onSaveInstanceState(@NonNull Bundle outState) {
         attempt.setSections(sections);
-        Log.d(TAG, "onSaveInstanceState: ");
         outState.putParcelable(PARAM_ATTEMPT, attempt);
         super.onSaveInstanceState(outState);
     }
 
     @Override
     public void onResume() {
-        Log.d(TAG, "onResume: ");
         super.onResume();
         removeAppBackgroundHandler();
     }
@@ -1670,7 +1659,6 @@ public class TestFragment extends BaseFragment implements
     @Override
     public void onStop() {
         super.onStop();
-        Log.d(TAG, "onStop: ");
         saveResult(currentQuestionIndex, Action.UPDATE_ANSWER);
         appBackgroundStateHandler = new Handler();
         appBackgroundStateHandler.postDelayed(stopTimerTask, APP_BACKGROUND_DELAY);
@@ -1686,7 +1674,6 @@ public class TestFragment extends BaseFragment implements
 
     @Override
     public Dialog[] getDialogs() {
-        Log.d(TAG, "getDialogs: ");
         return new Dialog[] {
                 progressDialog, resumeExamDialog, heartBeatAlertDialog, saveAnswerAlertDialog,
                 networkErrorAlertDialog
@@ -1695,7 +1682,6 @@ public class TestFragment extends BaseFragment implements
 
     @Override
     public void onDestroy() {
-        Log.d(TAG, "onDestroy: ");
         stopTimer();
         removeAppBackgroundHandler();
         super.onDestroy();
@@ -1714,53 +1700,5 @@ public class TestFragment extends BaseFragment implements
 
     private boolean isOfflineExam() {
         return exam != null && Boolean.TRUE.equals(exam.getIsOfflineExam());
-    }
-
-    @Override
-    public void onLowMemory() {
-        super.onLowMemory();
-        Log.d(TAG, "onLowMemory: ");
-    }
-
-    @Override
-    public void onDestroyView() {
-        super.onDestroyView();
-        Log.d(TAG, "onDestroyView: ");
-    }
-
-    @Override
-    public void onAttach(@NonNull Context context) {
-        super.onAttach(context);
-        Log.d(TAG, "onAttach: ");
-    }
-
-    @Override
-    public void onDetach() {
-        super.onDetach();
-        Log.d(TAG, "onDetach: ");
-    }
-
-    @Override
-    public void onConfigurationChanged(@NonNull Configuration newConfig) {
-        super.onConfigurationChanged(newConfig);
-        Log.d(TAG, "onConfigurationChanged: ");
-    }
-
-    @Override
-    public void onPause() {
-        super.onPause();
-        Log.d(TAG, "onPause: ");
-    }
-
-    @Override
-    public void onStart() {
-        super.onStart();
-        Log.d(TAG, "onStart: ");
-    }
-
-    @Override
-    public void onPrimaryNavigationFragmentChanged(boolean isPrimaryNavigationFragment) {
-        super.onPrimaryNavigationFragmentChanged(isPrimaryNavigationFragment);
-        Log.d(TAG, "onPrimaryNavigationFragmentChanged: ");
     }
 }


### PR DESCRIPTION
- When the app goes to the background and the system kills the activity due to memory pressure, the TestActivity is recreated on resume. In this fast init phase, the TestFragment may also be recreated. Previously, observers used `getActivity()` as the lifecycle owner. If the fragment gets destroyed while activity execution continues, those observers remain active, causing issues like loading dialogs staying open even after the fragment is destroyed.

- This change updates all observers in TestFragment to use `getViewLifecycleOwner()` to ensure they are properly tied to the fragment's view lifecycle and get automatically cleared when the view is destroyed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved state restoration and preservation for exam attempts, ensuring smoother resume and recovery during exams.
	- Updated language selection behavior to better handle exams where resuming attempts is disabled.
	- Enhanced reliability of exam progress and result updates by improving how exam data is observed and managed within the app.
- **Refactor**
	- Improved internal handling of exam attempt data for better maintainability and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->