### PR TITLE
refactor: Rename DOWNLOADED to COMPLETED in OfflineAttachmentDownloadStatus

### DIFF
--- a/core/src/main/java/in/testpress/database/entities/OfflineAttachment.kt
+++ b/core/src/main/java/in/testpress/database/entities/OfflineAttachment.kt
@@ -14,5 +14,5 @@ data class OfflineAttachment(
 )
 
 enum class OfflineAttachmentDownloadStatus {
-    QUEUED, DOWNLOADING, FAILED, DOWNLOADED, DELETE
+    QUEUED, DOWNLOADING, FAILED, COMPLETED, DELETE
 }

--- a/course/src/main/java/in/testpress/course/fragments/OfflineAttachmentListFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/OfflineAttachmentListFragment.kt
@@ -92,7 +92,7 @@ fun OfflineAttachmentScreen(viewModel: OfflineAttachmentViewModel) {
             OfflineAttachmentList(
                 attachments = attachments!!,
                 onOpenFile = { file ->
-                    if (file.status == OfflineAttachmentDownloadStatus.DOWNLOADED) {
+                    if (file.status == OfflineAttachmentDownloadStatus.COMPLETED) {
                         viewModel.openFile(context, file)
                     }
                 },
@@ -335,7 +335,7 @@ fun getAttachmentStatusText(
     attachmentProgress: Int
 ): String {
     return when (attachmentStatus) {
-        OfflineAttachmentDownloadStatus.DOWNLOADED -> "Tap to open"
+        OfflineAttachmentDownloadStatus.COMPLETED -> "Tap to open"
         OfflineAttachmentDownloadStatus.FAILED -> "Download Failed"
         OfflineAttachmentDownloadStatus.QUEUED -> "Waiting to download..."
         OfflineAttachmentDownloadStatus.DOWNLOADING -> "Downloading...${attachmentProgress}%"
@@ -372,7 +372,7 @@ private fun AttachmentBottomSheet(
                 }
             }
 
-            OfflineAttachmentDownloadStatus.DOWNLOADED,
+            OfflineAttachmentDownloadStatus.COMPLETED,
             OfflineAttachmentDownloadStatus.DELETE,
             OfflineAttachmentDownloadStatus.FAILED -> {
                 TextButton(
@@ -413,7 +413,7 @@ fun OfflineAttachmentListPreview() {
             title = "Chapter 1 Notes",
             url = "",
             path = "/path/to/file1.pdf",
-            status = OfflineAttachmentDownloadStatus.DOWNLOADED,
+            status = OfflineAttachmentDownloadStatus.COMPLETED,
             progress = 100
         ),
         OfflineAttachment(

--- a/course/src/main/java/in/testpress/course/repository/OfflineAttachmentsRepository.kt
+++ b/course/src/main/java/in/testpress/course/repository/OfflineAttachmentsRepository.kt
@@ -54,7 +54,7 @@ class OfflineAttachmentsRepository(
 
     override fun onDownloadCompleted(item: DownloadItem) {
         scope.launch {
-            updateStatus(item.id, OfflineAttachmentDownloadStatus.DOWNLOADED)
+            updateStatus(item.id, OfflineAttachmentDownloadStatus.COMPLETED)
         }
     }
 

--- a/samples/src/main/java/in/testpress/samples/course/OfflineAttachmentSampleActivity.kt
+++ b/samples/src/main/java/in/testpress/samples/course/OfflineAttachmentSampleActivity.kt
@@ -99,7 +99,7 @@ class DownloadsAdapter(
             binding.textSubtitle.text = getAttachmentStatusText(item.status, item.progress)
 
             when (item.status) {
-                OfflineAttachmentDownloadStatus.DOWNLOADED,
+                OfflineAttachmentDownloadStatus.COMPLETED,
                 OfflineAttachmentDownloadStatus.DELETE,
                 OfflineAttachmentDownloadStatus.FAILED -> {
                     binding.progressBar.visibility = android.view.View.GONE
@@ -126,7 +126,7 @@ class DownloadsAdapter(
         attachmentProgress: Int
     ): String {
         return when (attachmentStatus) {
-            OfflineAttachmentDownloadStatus.DOWNLOADED -> "Tap to open"
+            OfflineAttachmentDownloadStatus.COMPLETED -> "Tap to open"
             OfflineAttachmentDownloadStatus.FAILED -> "Download Failed"
             OfflineAttachmentDownloadStatus.QUEUED -> "Waiting to download..."
             OfflineAttachmentDownloadStatus.DOWNLOADING -> "Downloading...${attachmentProgress}%"


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the terminology for offline attachment download status from "Downloaded" to "Completed" throughout the app. Status indicators, action options, and related UI text now reflect this change for a more consistent user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->