### PR TITLE
fix: Show success screen for completed orders with 100% discount in mobile app

### DIFF
--- a/store/src/main/java/in/testpress/store/ui/OrderConfirmActivity.java
+++ b/store/src/main/java/in/testpress/store/ui/OrderConfirmActivity.java
@@ -232,12 +232,11 @@ public class OrderConfirmActivity extends BaseToolBarActivity implements Payment
                 .enqueue(new TestpressCallback<Order>() {
                     @Override
                     public void onSuccess(final Order confirmedOrder) {
+                        progressBar.setVisibility(View.GONE);
                         if (confirmedOrder.getStatus().equals("Completed")) {
-                            progressBar.setVisibility(View.GONE);
                             logEvent(EventsTrackerFacade.PAYMENT_SUCCESS);
                             showPaymentSuccessScreen();
                         } else {
-                            progressBar.setVisibility(View.GONE);
                             order.setOrderId(confirmedOrder.getOrderId()); // orderId for Razorpay order gets assigned by Razorpay on confirming
                             PaymentGateway paymentGateway = new PaymentGatewayFactory().create(confirmedOrder, OrderConfirmActivity.this);
                             paymentGateway.setPaymentGatewayListener(OrderConfirmActivity.this);

--- a/store/src/main/java/in/testpress/store/ui/OrderConfirmActivity.java
+++ b/store/src/main/java/in/testpress/store/ui/OrderConfirmActivity.java
@@ -232,11 +232,15 @@ public class OrderConfirmActivity extends BaseToolBarActivity implements Payment
                 .enqueue(new TestpressCallback<Order>() {
                     @Override
                     public void onSuccess(final Order confirmedOrder) {
-                        progressBar.setVisibility(View.GONE);
-                        order.setOrderId(confirmedOrder.getOrderId()); // orderId for Razorpay order gets assigned by Razorpay on confirming
-                        PaymentGateway paymentGateway = new PaymentGatewayFactory().create(confirmedOrder, OrderConfirmActivity.this);
-                        paymentGateway.setPaymentGatewayListener(OrderConfirmActivity.this);
-                        paymentGateway.showPaymentPage();
+                        if (confirmedOrder.getStatus().equals("Completed")) {
+                            showPaymentSuccessScreen();
+                        } else {
+                            progressBar.setVisibility(View.GONE);
+                            order.setOrderId(confirmedOrder.getOrderId()); // orderId for Razorpay order gets assigned by Razorpay on confirming
+                            PaymentGateway paymentGateway = new PaymentGatewayFactory().create(confirmedOrder, OrderConfirmActivity.this);
+                            paymentGateway.setPaymentGatewayListener(OrderConfirmActivity.this);
+                            paymentGateway.showPaymentPage();
+                        }
                     }
 
                     @Override

--- a/store/src/main/java/in/testpress/store/ui/OrderConfirmActivity.java
+++ b/store/src/main/java/in/testpress/store/ui/OrderConfirmActivity.java
@@ -233,6 +233,7 @@ public class OrderConfirmActivity extends BaseToolBarActivity implements Payment
                     @Override
                     public void onSuccess(final Order confirmedOrder) {
                         if (confirmedOrder.getStatus().equals("Completed")) {
+                            progressBar.setVisibility(View.GONE);
                             logEvent(EventsTrackerFacade.PAYMENT_SUCCESS);
                             showPaymentSuccessScreen();
                         } else {

--- a/store/src/main/java/in/testpress/store/ui/OrderConfirmActivity.java
+++ b/store/src/main/java/in/testpress/store/ui/OrderConfirmActivity.java
@@ -233,6 +233,7 @@ public class OrderConfirmActivity extends BaseToolBarActivity implements Payment
                     @Override
                     public void onSuccess(final Order confirmedOrder) {
                         if (confirmedOrder.getStatus().equals("Completed")) {
+                            logEvent(EventsTrackerFacade.PAYMENT_SUCCESS);
                             showPaymentSuccessScreen();
                         } else {
                             progressBar.setVisibility(View.GONE);


### PR DESCRIPTION
#### Purpose of the PR ?
- Users with 100% discount codes were stuck on payment error screens even though their orders were already completed, this happened because the mobile app always redirected to payment gateway regardless of order status. (After this PR [#9650](https://github.com/testpress/testpress_python/pull/9650))
- This is fixed by checking order status in `OrderConfirmActivity` and showing the success screen directly for completed orders instead of attempting payment processing through different gateways.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved order confirmation handling to directly show the payment success screen if the order status is already "Completed," avoiding unnecessary payment steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->