### PR TITLE
feat: Add window monitoring feature to detect and limit app switches during exams

### DIFF
--- a/core/src/main/java/in/testpress/models/greendao/Exam.java
+++ b/core/src/main/java/in/testpress/models/greendao/Exam.java
@@ -903,6 +903,10 @@ public class Exam implements android.os.Parcelable {
         return disableAttemptResume != null && disableAttemptResume;
     }
 
+    public boolean isWindowMonitoringEnabled() {
+        return disableAttemptResume != null && disableAttemptResume;
+    }
+
     public boolean isPreemptiveSectionEndingEnabled() {
         return allowPreemptiveSectionEnding != null && allowPreemptiveSectionEnding;
     }

--- a/core/src/main/java/in/testpress/models/greendao/Exam.java
+++ b/core/src/main/java/in/testpress/models/greendao/Exam.java
@@ -904,7 +904,7 @@ public class Exam implements android.os.Parcelable {
     }
 
     public boolean isWindowMonitoringEnabled() {
-        return disableAttemptResume != null && disableAttemptResume;
+        return enableExamWindowMonitoring != null && enableExamWindowMonitoring;
     }
 
     public boolean isPreemptiveSectionEndingEnabled() {

--- a/course/src/main/java/in/testpress/course/ui/ContentAttemptListAdapter.java
+++ b/course/src/main/java/in/testpress/course/ui/ContentAttemptListAdapter.java
@@ -141,7 +141,7 @@ public class ContentAttemptListAdapter extends RecyclerView.Adapter<RecyclerView
                     public void onClick(View v) {
                         //noinspection ConstantConditions
 
-                        if(mContent.getExam().isAttemptResumeDisabled()) {
+                        if(mContent.getExam().isAttemptResumeDisabled() || mContent.getExam().isWindowMonitoringEnabled()) {
                             endExam();
                             return;
                         }

--- a/exam/src/main/java/in/testpress/exam/ui/TestActivity.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestActivity.java
@@ -558,7 +558,7 @@ public class TestActivity extends BaseToolBarActivity  {
                     new MultiLanguagesUtil.LanguageSelectionListener() {
                         @Override
                         public void onLanguageSelected() {
-                            if (exam.isAttemptResumeDisabled()) {
+                            if (exam.isAttemptResumeDisabled() || exam.isWindowMonitoringEnabled()) {
                                 endExam();
                             } else {
                                 startExam(true);

--- a/exam/src/main/java/in/testpress/exam/ui/TestActivity.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestActivity.java
@@ -595,10 +595,19 @@ public class TestActivity extends BaseToolBarActivity  {
     }
 
     private void showResumeDisabledWarningAlertOrStartExam() {
-        if (exam.isAttemptResumeDisabled()) {
+        boolean isResumeDisabled = exam.isAttemptResumeDisabled();
+        boolean isWindowMonitoringEnabled = exam.isWindowMonitoringEnabled();
+
+        if (isResumeDisabled || isWindowMonitoringEnabled) {
             AlertDialog.Builder builder = new AlertDialog.Builder(this, R.style.TestpressAppCompatAlertDialogStyle);
             builder.setTitle(R.string.exam_resume_disable_warning_title);
-            builder.setMessage(R.string.exam_resume_disable_warning_description);
+            if (isResumeDisabled && isWindowMonitoringEnabled){
+                builder.setMessage(R.string.exam_combined_warning_description);
+            } else if (isResumeDisabled){
+                builder.setMessage(R.string.exam_resume_disable_warning_description);
+            } else {
+                builder.setMessage(R.string.window_monitoring_warning_description);
+            }
             builder.setPositiveButton("OK", new DialogInterface.OnClickListener() {
                 @Override
                 public void onClick(DialogInterface dialog, int which) {
@@ -606,8 +615,8 @@ public class TestActivity extends BaseToolBarActivity  {
                 }
             });
             builder.setNegativeButton("Cancel", null);
-            AlertDialog dialog = builder.create();
-            dialog.show();
+            builder.setCancelable(false);
+            builder.show();
         } else {
             startExam(false);
         }

--- a/exam/src/main/java/in/testpress/exam/ui/TestActivity.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestActivity.java
@@ -615,7 +615,6 @@ public class TestActivity extends BaseToolBarActivity  {
                 }
             });
             builder.setNegativeButton("Cancel", null);
-            builder.setCancelable(false);
             builder.show();
         } else {
             startExam(false);

--- a/exam/src/main/java/in/testpress/exam/ui/TestActivity.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestActivity.java
@@ -550,7 +550,7 @@ public class TestActivity extends BaseToolBarActivity  {
                     new MultiLanguagesUtil.LanguageSelectionListener() {
                         @Override
                         public void onLanguageSelected() {
-                            showResumeDisabledWarningAlertOrStartExam();
+                            showWarningAlertOrStartExam();
                         }});
             examDuration.setText(exam.getDuration());
         } else {
@@ -594,7 +594,7 @@ public class TestActivity extends BaseToolBarActivity  {
         }
     }
 
-    private void showResumeDisabledWarningAlertOrStartExam() {
+    private void showWarningAlertOrStartExam() {
         boolean isResumeDisabled = exam.isAttemptResumeDisabled();
         boolean isWindowMonitoringEnabled = exam.isWindowMonitoringEnabled();
 

--- a/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
@@ -1655,26 +1655,13 @@ public class TestFragment extends BaseFragment implements
         }
 
         if (currentViolationCount > MAX_VIOLATION_COUNT) {
-            showFinalViolationDialog();
+            showViolationAlertDialog(true);
         } else if (currentViolationCount > 0) {
-            showViolationDialog();
+            showViolationAlertDialog(false);
         }
     }
 
-    private void showFinalViolationDialog() {
-        showViolationAlertDialog(getString(R.string.exam_final_violation_message), this::endExam);
-    }
-
-    private void showViolationDialog() {
-        String message = getString(
-                R.string.window_violation_warning,
-                currentViolationCount,
-                MAX_VIOLATION_COUNT
-        );
-        showViolationAlertDialog(message, null);
-    }
-
-    private void showViolationAlertDialog(CharSequence message, Runnable onPositiveClick) {
+    private void showViolationAlertDialog(boolean exceededViolationCount) {
         if (!isAdded()) return;
 
         if (windowViolationDialog != null && windowViolationDialog.isShowing()) {
@@ -1686,14 +1673,19 @@ public class TestFragment extends BaseFragment implements
                 R.style.TestpressAppCompatAlertDialogStyle);
 
         builder.setTitle(R.string.window_switch_detected_title);
-        builder.setMessage(message);
 
-        builder.setPositiveButton("OK", (dialog, which) -> {
-            if (onPositiveClick != null) {
-                onPositiveClick.run();
-            }
-        });
-
+        if (exceededViolationCount){
+            builder.setMessage(R.string.exam_final_violation_message);
+            builder.setPositiveButton("OK", (dialog, which)  -> endExam());
+        } else {
+            String message = getString(
+                    R.string.window_violation_warning,
+                    currentViolationCount,
+                    MAX_VIOLATION_COUNT
+            );
+            builder.setMessage(message);
+            builder.setPositiveButton("OK",null);
+        }
         builder.setCancelable(false);
         windowViolationDialog = builder.create();
         windowViolationDialog.show();
@@ -1730,7 +1722,7 @@ public class TestFragment extends BaseFragment implements
     public Dialog[] getDialogs() {
         return new Dialog[] {
                 progressDialog, resumeExamDialog, heartBeatAlertDialog, saveAnswerAlertDialog,
-                networkErrorAlertDialog
+                networkErrorAlertDialog, windowViolationDialog
         };
     }
 

--- a/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
@@ -1660,42 +1660,29 @@ public class TestFragment extends BaseFragment implements
     }
 
     private void showFinalViolationDialog() {
-        AlertDialog.Builder builder = new AlertDialog.Builder(requireActivity(),
-                R.style.TestpressAppCompatAlertDialogStyle);
-
-        builder.setTitle(R.string.window_switch_detected_title);
-        builder.setMessage(R.string.exam_final_violation_message);
-
-        builder.setPositiveButton("OK", new DialogInterface.OnClickListener() {
-            @Override
-            public void onClick(DialogInterface dialog, int which) {
-                dialog.dismiss();
-                endExam();
-            }
-        });
-
-        builder.setCancelable(false);
-        builder.show();
+        showViolationAlertDialog(getString(R.string.exam_final_violation_message), this::endExam);
     }
 
     private void showViolationDialog() {
-        AlertDialog.Builder builder = new AlertDialog.Builder(requireActivity(),
-                R.style.TestpressAppCompatAlertDialogStyle);
-
-        builder.setTitle(R.string.window_switch_detected_title);
-
         String message = getString(
                 R.string.window_violation_warning,
                 currentViolationCount,
                 MAX_VIOLATION_COUNT
         );
+        showViolationAlertDialog(message, null);
+    }
 
+    private void showViolationAlertDialog(CharSequence message, Runnable onPositiveClick) {
+        AlertDialog.Builder builder = new AlertDialog.Builder(requireActivity(),
+                R.style.TestpressAppCompatAlertDialogStyle);
+
+        builder.setTitle(R.string.window_switch_detected_title);
         builder.setMessage(message);
 
-        builder.setPositiveButton("OK", new DialogInterface.OnClickListener() {
-            @Override
-            public void onClick(DialogInterface dialog, int which) {
-                dialog.dismiss();
+        builder.setPositiveButton("OK", (dialog, which) -> {
+            dialog.dismiss();
+            if (onPositiveClick != null) {
+                onPositiveClick.run();
             }
         });
 

--- a/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
@@ -1663,10 +1663,15 @@ public class TestFragment extends BaseFragment implements
         AlertDialog.Builder builder = new AlertDialog.Builder(requireActivity(),
                 R.style.TestpressAppCompatAlertDialogStyle);
 
-        builder.setTitle("Window Switch Detected");
-        builder.setMessage("You switched windows " + currentViolationCount +
-                " time(s). Switching windows more than " + MAX_VIOLATION_COUNT +
-                " times will end the exam.");
+        builder.setTitle(getString(R.string.window_switch_detected_title));
+
+        String message = getString(
+                R.string.window_violation_warning,
+                currentViolationCount,
+                MAX_VIOLATION_COUNT
+        );
+
+        builder.setMessage(message);
 
         builder.setPositiveButton("OK", new DialogInterface.OnClickListener() {
             @Override

--- a/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
@@ -110,6 +110,8 @@ public class TestFragment extends BaseFragment implements
     private AlertDialog saveAnswerAlertDialog;
     private AlertDialog networkErrorAlertDialog;
     private AlertDialog sectionInfoAlertDialog;
+    private AlertDialog windowViolationDialog;
+
     private View questionsListProgressBar;
 
     Attempt attempt;
@@ -1627,7 +1629,7 @@ public class TestFragment extends BaseFragment implements
         }
         CommonUtils.dismissDialogs(new Dialog[] {
                 heartBeatAlertDialog, saveAnswerAlertDialog, networkErrorAlertDialog,
-                sectionInfoAlertDialog
+                sectionInfoAlertDialog, windowViolationDialog
         });
         if (exam != null && exam.isAttemptResumeDisabled()){
             showExamEndDialog();
@@ -1673,6 +1675,13 @@ public class TestFragment extends BaseFragment implements
     }
 
     private void showViolationAlertDialog(CharSequence message, Runnable onPositiveClick) {
+        if (!isAdded()) return;
+
+        if (windowViolationDialog != null && windowViolationDialog.isShowing()) {
+            windowViolationDialog.dismiss();
+            windowViolationDialog = null;
+        }
+
         AlertDialog.Builder builder = new AlertDialog.Builder(requireActivity(),
                 R.style.TestpressAppCompatAlertDialogStyle);
 
@@ -1680,14 +1689,14 @@ public class TestFragment extends BaseFragment implements
         builder.setMessage(message);
 
         builder.setPositiveButton("OK", (dialog, which) -> {
-            dialog.dismiss();
             if (onPositiveClick != null) {
                 onPositiveClick.run();
             }
         });
 
         builder.setCancelable(false);
-        builder.show();
+        windowViolationDialog = builder.create();
+        windowViolationDialog.show();
     }
 
     void removeAppBackgroundHandler() {

--- a/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
@@ -622,7 +622,7 @@ public class TestFragment extends BaseFragment implements
     }
 
     private void endExamAlert() {
-        if (exam == null || exam.isAttemptResumeDisabled()){
+        if (exam == null || exam.isAttemptResumeDisabled() || exam.isWindowMonitoringEnabled()){
             showEndExamAlert();
         } else {
             AlertDialog.Builder dialogBuilder =
@@ -655,7 +655,7 @@ public class TestFragment extends BaseFragment implements
     }
 
     void showPauseExamAlert() {
-        if (exam.isAttemptResumeDisabled()) {
+        if (exam.isAttemptResumeDisabled() || exam.isWindowMonitoringEnabled()) {
             showEndExamAlert();
             return;
         }
@@ -1671,7 +1671,7 @@ public class TestFragment extends BaseFragment implements
         builder.setPositiveButton("OK", new DialogInterface.OnClickListener() {
             @Override
             public void onClick(DialogInterface dialog, int which) {
-                removeAppBackgroundHandler();
+                dialog.dismiss();
             }
         });
 
@@ -1690,11 +1690,12 @@ public class TestFragment extends BaseFragment implements
     public void onStop() {
         super.onStop();
         saveResult(currentQuestionIndex, Action.UPDATE_ANSWER);
-        appBackgroundStateHandler = new Handler();
-        appBackgroundStateHandler.postDelayed(stopTimerTask, APP_BACKGROUND_DELAY);
         if (exam.isWindowMonitoringEnabled()) {
             currentViolationCount++;
+            return;
         }
+        appBackgroundStateHandler = new Handler();
+        appBackgroundStateHandler.postDelayed(stopTimerTask, APP_BACKGROUND_DELAY);
     }
 
     @Override

--- a/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
@@ -1653,17 +1653,36 @@ public class TestFragment extends BaseFragment implements
         }
 
         if (currentViolationCount > MAX_VIOLATION_COUNT) {
-            endExam();
+            showFinalViolationDialog();
         } else if (currentViolationCount > 0) {
             showViolationDialog();
         }
+    }
+
+    private void showFinalViolationDialog() {
+        AlertDialog.Builder builder = new AlertDialog.Builder(requireActivity(),
+                R.style.TestpressAppCompatAlertDialogStyle);
+
+        builder.setTitle(R.string.window_switch_detected_title);
+        builder.setMessage(R.string.exam_final_violation_message);
+
+        builder.setPositiveButton("OK", new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+                dialog.dismiss();
+                endExam();
+            }
+        });
+
+        builder.setCancelable(false);
+        builder.show();
     }
 
     private void showViolationDialog() {
         AlertDialog.Builder builder = new AlertDialog.Builder(requireActivity(),
                 R.style.TestpressAppCompatAlertDialogStyle);
 
-        builder.setTitle(getString(R.string.window_switch_detected_title));
+        builder.setTitle(R.string.window_switch_detected_title);
 
         String message = getString(
                 R.string.window_violation_warning,

--- a/exam/src/main/res/values/strings.xml
+++ b/exam/src/main/res/values/strings.xml
@@ -249,7 +249,7 @@
 
     <string name="exam_resume_disable_warning_title">"IMPORTANT NOTICE!"</string>
 
-    <string name="window_monitoring_warning_description">Before you proceed, please be aware:\n\n<b>WINDOW MONITORING IS ENABLED:</b> This exam monitors if you leave the app.\n\n<b>DO NOT SWITCH APPS:</b> If you minimize this app or switch to another app more than 2 times, your exam will be automatically ended.\n\nStay focused in the exam app to avoid violations and complete your attempt without interruption. </string>
+    <string name="window_monitoring_warning_description">Before you proceed, please be aware:\n\n<b>WINDOW MONITORING IS ENABLED:</b> This exam monitors if you leave the app.\n\n<b>DO NOT SWITCH APPS:</b> If you minimize this app or switch to another app more than 2 times, your exam will be automatically ended.\n\nStay focused in the exam screen to avoid violations and complete your attempt without interruption. </string>
 
     <string name="exam_combined_warning_description">Before you proceed, please be aware:\n\n<b>RESUME IS DISABLED:</b> The admin has disabled the resume feature for this exam. Once you begin, if you close or navigate away from this app, you will NOT be able to resume your attempt. Your attempt will be permanently ended.\n\n<b>WINDOW MONITORING IS ENABLED:</b> This exam monitors if you leave the app. Minimizing this app or switching to another app more than 2 times will automatically end your exam.\n\nEnsure you are ready to take the exam without any interruptions. Double-check your internet connection, silence notifications, and make sure your device has sufficient power. </string>
 

--- a/exam/src/main/res/values/strings.xml
+++ b/exam/src/main/res/values/strings.xml
@@ -254,7 +254,7 @@
     <string name="exam_combined_warning_description">Before you proceed, please be aware:\n\n<b>RESUME IS DISABLED:</b> The admin has disabled the resume feature for this exam. Once you begin, if you close or navigate away from this app, you will NOT be able to resume your attempt. Your attempt will be permanently ended.\n\n<b>WINDOW MONITORING IS ENABLED:</b> This exam monitors if you leave the app. Minimizing this app or switching to another app more than 2 times will automatically end your exam.\n\nEnsure you are ready to take the exam without any interruptions. Double-check your internet connection, silence notifications, and make sure your device has sufficient power. </string>
     <string name="window_switch_detected_title">Window Switch Detected</string>
     <string name="window_violation_warning">You switched apps %1$d time(s). Switching apps more than %2$d times will end the exam.</string>
-
+    <string name="exam_final_violation_message"><b>Violation Detected:</b> You have exceeded the maximum allowed interruptions during the assessment.\n\nThe system has recorded multiple interruptions, which may be caused by one or more of the following:\n1) Minimizing the app or switching to another app.\n2) Pressing restricted keys or attempting to access system features.\n3) Trying to leave the assessment screen.\n\n<b>Your exam will now be ended permanently.</b>\n\nYou will not be able to resume this attempt. Please contact your administrator if you believe this was a mistake.</string>
     <string name="testpress_retake_with">Retake with?</string>
     <string-array name="testpress_retake_options">
         <item>All Questions</item>

--- a/exam/src/main/res/values/strings.xml
+++ b/exam/src/main/res/values/strings.xml
@@ -249,6 +249,10 @@
 
     <string name="exam_resume_disable_warning_title">"IMPORTANT NOTICE!"</string>
 
+    <string name="window_monitoring_warning_description">Before you proceed, please be aware:\n\n<b>WINDOW MONITORING IS ENABLED:</b> This exam monitors if you leave the app.\n\n<b>DO NOT SWITCH APPS:</b> If you minimize this app or switch to another app more than 2 times, your exam will be automatically ended.\n\nStay focused in the exam app to avoid violations and complete your attempt without interruption. </string>
+
+    <string name="exam_combined_warning_description">Before you proceed, please be aware:\n\n<b>RESUME IS DISABLED:</b> The admin has disabled the resume feature for this exam. Once you begin, if you close or navigate away from this app, you will NOT be able to resume your attempt. Your attempt will be permanently ended.\n\n<b>WINDOW MONITORING IS ENABLED:</b> This exam monitors if you leave the app. Minimizing this app or switching to another app more than 2 times will automatically end your exam.\n\nEnsure you are ready to take the exam without any interruptions. Double-check your internet connection, silence notifications, and make sure your device has sufficient power. </string>
+
     <string name="testpress_retake_with">Retake with?</string>
     <string-array name="testpress_retake_options">
         <item>All Questions</item>

--- a/exam/src/main/res/values/strings.xml
+++ b/exam/src/main/res/values/strings.xml
@@ -252,6 +252,8 @@
     <string name="window_monitoring_warning_description">Before you proceed, please be aware:\n\n<b>WINDOW MONITORING IS ENABLED:</b> This exam monitors if you leave the app.\n\n<b>DO NOT SWITCH APPS:</b> If you minimize this app or switch to another app more than 2 times, your exam will be automatically ended.\n\nStay focused in the exam screen to avoid violations and complete your attempt without interruption. </string>
 
     <string name="exam_combined_warning_description">Before you proceed, please be aware:\n\n<b>RESUME IS DISABLED:</b> The admin has disabled the resume feature for this exam. Once you begin, if you close or navigate away from this app, you will NOT be able to resume your attempt. Your attempt will be permanently ended.\n\n<b>WINDOW MONITORING IS ENABLED:</b> This exam monitors if you leave the app. Minimizing this app or switching to another app more than 2 times will automatically end your exam.\n\nEnsure you are ready to take the exam without any interruptions. Double-check your internet connection, silence notifications, and make sure your device has sufficient power. </string>
+    <string name="window_switch_detected_title">Window Switch Detected</string>
+    <string name="window_violation_warning">You switched apps %1$d time(s). Switching apps more than %2$d times will end the exam.</string>
 
     <string name="testpress_retake_with">Retake with?</string>
     <string-array name="testpress_retake_options">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced window monitoring during exams, limiting users to a maximum of two app switches; exceeding this will automatically end the exam.
  * Added warning dialogs to notify users about window monitoring and resume restrictions before starting an exam.
  * Combined warning message displayed when both resume is disabled and window monitoring is enabled.
  * Exam start and resume logic updated to consider window monitoring status alongside resume restrictions.

* **User Interface**
  * Added new warning messages to inform users about exam conditions and consequences of switching apps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->