### PR TITLE
fix: Add optional exam window violation flag to end content attempt methods

### DIFF
--- a/exam/src/main/java/in/testpress/exam/api/ExamService.java
+++ b/exam/src/main/java/in/testpress/exam/api/ExamService.java
@@ -107,6 +107,11 @@ public interface ExamService {
     RetrofitCall<CourseAttempt> endContentAttempt(
             @Path(value = "end_exam_url", encoded = true) String endExamUrlFrag);
 
+    @PATCH("{end_exam_url}")
+    RetrofitCall<CourseAttempt> endContentAttempt(
+            @Path(value = "end_exam_url", encoded = true) String endExamUrlFrag,
+            @Body Map<String, Object> body);
+
     @GET("{attempts_url}")
     RetrofitCall<TestpressApiResponse<Attempt>> getAttempts(
             @Path(value = "attempts_url", encoded = true) String attemptsUrlFrag,

--- a/exam/src/main/java/in/testpress/exam/api/ExamService.java
+++ b/exam/src/main/java/in/testpress/exam/api/ExamService.java
@@ -110,7 +110,7 @@ public interface ExamService {
     @PATCH("{end_exam_url}")
     RetrofitCall<CourseAttempt> endContentAttempt(
             @Path(value = "end_exam_url", encoded = true) String endExamUrlFrag,
-            @Body Map<String, Object> body);
+            @Body Map<String, Object> requestBody);
 
     @GET("{attempts_url}")
     RetrofitCall<TestpressApiResponse<Attempt>> getAttempts(

--- a/exam/src/main/java/in/testpress/exam/api/TestpressExamApiClient.java
+++ b/exam/src/main/java/in/testpress/exam/api/TestpressExamApiClient.java
@@ -33,7 +33,6 @@ import in.testpress.v2_4.models.BookmarksListResponse;
 import in.testpress.v2_4.models.FolderListResponse;
 import in.testpress.network.RetrofitCall;
 import in.testpress.network.TestpressApiClient;
-import okhttp3.ResponseBody;
 
 public class TestpressExamApiClient extends TestpressApiClient {
 

--- a/exam/src/main/java/in/testpress/exam/api/TestpressExamApiClient.java
+++ b/exam/src/main/java/in/testpress/exam/api/TestpressExamApiClient.java
@@ -150,8 +150,16 @@ public class TestpressExamApiClient extends TestpressApiClient {
         return getExamService().endExam(endAttemptUrlFrag);
     }
 
-    public RetrofitCall<CourseAttempt> endContentAttempt(String endAttemptUrlFrag) {
-        return getExamService().endContentAttempt(endAttemptUrlFrag);
+    public RetrofitCall<CourseAttempt> endContentAttempt(String endAttemptUrlFrag, boolean isExamWindowViolated) {
+        if (isExamWindowViolated){
+            Map<String, Object> body = new HashMap<>();
+            Map<String, Object> assessment = new HashMap<>();
+            assessment.put("is_exam_window_violated", true);
+            body.put("assessment", assessment);
+            return getExamService().endContentAttempt(endAttemptUrlFrag, body);
+        } else {
+            return getExamService().endContentAttempt(endAttemptUrlFrag);
+        }
     }
 
     public RetrofitCall<TestpressApiResponse<AttemptItem>> getQuestions(

--- a/exam/src/main/java/in/testpress/exam/api/TestpressExamApiClient.java
+++ b/exam/src/main/java/in/testpress/exam/api/TestpressExamApiClient.java
@@ -33,6 +33,7 @@ import in.testpress.v2_4.models.BookmarksListResponse;
 import in.testpress.v2_4.models.FolderListResponse;
 import in.testpress.network.RetrofitCall;
 import in.testpress.network.TestpressApiClient;
+import okhttp3.ResponseBody;
 
 public class TestpressExamApiClient extends TestpressApiClient {
 
@@ -152,14 +153,19 @@ public class TestpressExamApiClient extends TestpressApiClient {
 
     public RetrofitCall<CourseAttempt> endContentAttempt(String endAttemptUrlFrag, boolean isExamWindowViolated) {
         if (isExamWindowViolated){
-            Map<String, Object> body = new HashMap<>();
-            Map<String, Object> assessment = new HashMap<>();
-            assessment.put("is_exam_window_violated", true);
-            body.put("assessment", assessment);
-            return getExamService().endContentAttempt(endAttemptUrlFrag, body);
+            Map<String, Object> requestBody = createExamViolationBody();
+            return getExamService().endContentAttempt(endAttemptUrlFrag, requestBody);
         } else {
             return getExamService().endContentAttempt(endAttemptUrlFrag);
         }
+    }
+
+    private Map<String, Object> createExamViolationBody() {
+        Map<String, Object> requestBody = new HashMap<>();
+        Map<String, Object> assessment = new HashMap<>();
+        assessment.put("is_exam_window_violated", true);
+        requestBody.put("assessment", assessment);
+        return requestBody;
     }
 
     public RetrofitCall<TestpressApiResponse<AttemptItem>> getQuestions(

--- a/exam/src/main/java/in/testpress/exam/repository/AttemptRepository.kt
+++ b/exam/src/main/java/in/testpress/exam/repository/AttemptRepository.kt
@@ -291,7 +291,7 @@ class AttemptRepository(val context: Context) {
 
     }
 
-    fun endContentAttempt(attemptEndFrag: String) {
+    fun endContentAttempt(attemptEndFrag: String, isExamWindowViolated: Boolean) {
         _endContentAttemptResource.postValue(Resource.loading(null))
         if (isOfflineExam) {
             CoroutineScope(Dispatchers.IO).launch {
@@ -304,7 +304,7 @@ class AttemptRepository(val context: Context) {
                 _endContentAttemptResource.postValue(Resource.success(offlineCourseAttempt!!.createGreenDoaModel(attempt)))
             }
         } else {
-            apiClient.endContentAttempt(attemptEndFrag)
+            apiClient.endContentAttempt(attemptEndFrag, isExamWindowViolated)
                 .enqueue(object : TestpressCallback<CourseAttempt>() {
                     override fun onSuccess(result: CourseAttempt) {
                         _endContentAttemptResource.postValue(Resource.success(result))

--- a/exam/src/main/java/in/testpress/exam/repository/ExamRepository.kt
+++ b/exam/src/main/java/in/testpress/exam/repository/ExamRepository.kt
@@ -207,7 +207,7 @@ class ExamRepository(val context: Context) {
         }
     }
 
-    fun endContentAttempt(attemptId: Long, attemptEndFrag: String) {
+    fun endContentAttempt(attemptId: Long, attemptEndFrag: String, isExamWindowViolated: Boolean) {
         _contentAttemptResource.postValue(Resource.loading(null))
         if (isOfflineExam){
             CoroutineScope(Dispatchers.IO).launch {
@@ -228,7 +228,7 @@ class ExamRepository(val context: Context) {
                 )
             }
         } else {
-            apiClient.endContentAttempt(attemptEndFrag)
+            apiClient.endContentAttempt(attemptEndFrag, isExamWindowViolated)
                 .enqueue(object : TestpressCallback<CourseAttempt>() {
                     override fun onSuccess(result: CourseAttempt) {
                         _contentAttemptResource.postValue(Resource.success(result))

--- a/exam/src/main/java/in/testpress/exam/ui/TestActivity.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestActivity.java
@@ -559,7 +559,7 @@ public class TestActivity extends BaseToolBarActivity  {
                         @Override
                         public void onLanguageSelected() {
                             if (exam.isAttemptResumeDisabled() || exam.isWindowMonitoringEnabled()) {
-                                endExam();
+                                endExam(exam.isWindowMonitoringEnabled());
                             } else {
                                 startExam(true);
                             }
@@ -622,9 +622,13 @@ public class TestActivity extends BaseToolBarActivity  {
     }
 
     private void endExam() {
+        endExam(false);
+    }
+
+    private void endExam(boolean isExamWindowViolated) {
         progressBar.setVisibility(View.VISIBLE);
         if (courseContent != null){
-            examViewModel.endContentAttempt(attempt.getId(), courseAttempt.getEndAttemptUrl());
+            examViewModel.endContentAttempt(attempt.getId(), courseAttempt.getEndAttemptUrl(), isExamWindowViolated);
         } else {
             examViewModel.endAttempt(attempt.getId(), attempt.getEndUrlFrag());
         }

--- a/exam/src/main/java/in/testpress/exam/ui/TestActivity.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestActivity.java
@@ -498,7 +498,7 @@ public class TestActivity extends BaseToolBarActivity  {
                 assert getSupportActionBar() != null;
                 if (action != null && action.equals(PARAM_VALUE_ACTION_END)) {
                     getSupportActionBar().setTitle(getString(R.string.testpress_end_exam));
-                    endExam();
+                    endExam(exam.isWindowMonitoringEnabled());
                     return;
                 } else {
                     getSupportActionBar().setTitle(getString(R.string.testpress_resume_exam));

--- a/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
@@ -1244,6 +1244,10 @@ public class TestFragment extends BaseFragment implements
     }
 
     void endExam() {
+        endExam(false);
+    }
+
+    void endExam(boolean isExamWindowViolated) {
         stopTimer();
         // Save attemptItem, if option or review is changed
         if (!attemptItemList.isEmpty() && attemptItemList.get(viewPager.getCurrentItem()).hasChanged()) {
@@ -1252,7 +1256,7 @@ public class TestFragment extends BaseFragment implements
         }
         showProgress(R.string.testpress_ending_exam);
         if (courseContent != null) {
-            attemptViewModel.endContentAttempt(courseAttempt.getEndAttemptUrl());
+            attemptViewModel.endContentAttempt(courseAttempt.getEndAttemptUrl(), isExamWindowViolated);
         } else {
             attemptViewModel.endAttempt(attempt.getEndUrlFrag());
         }
@@ -1676,7 +1680,7 @@ public class TestFragment extends BaseFragment implements
 
         if (exceededViolationCount){
             builder.setMessage(R.string.exam_final_violation_message);
-            builder.setPositiveButton("OK", (dialog, which)  -> endExam());
+            builder.setPositiveButton("OK", (dialog, which)  -> endExam(true));
         } else {
             String message = getString(
                     R.string.window_violation_warning,

--- a/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
@@ -1680,7 +1680,7 @@ public class TestFragment extends BaseFragment implements
 
         if (exceededViolationCount){
             builder.setMessage(R.string.exam_final_violation_message);
-            builder.setPositiveButton("OK", (dialog, which)  -> endExam(true));
+            builder.setPositiveButton(R.string.testpress_ok, (dialog, which)  -> endExam(true));
         } else {
             String message = getString(
                     R.string.window_violation_warning,

--- a/exam/src/main/java/in/testpress/exam/ui/viewmodel/AttemptViewModel.kt
+++ b/exam/src/main/java/in/testpress/exam/ui/viewmodel/AttemptViewModel.kt
@@ -49,8 +49,8 @@ class AttemptViewModel(val repository: AttemptRepository) : ViewModel() {
         repository.updateSection(url, action)
     }
 
-    fun endContentAttempt(attemptEndFrag: String) {
-        repository.endContentAttempt(attemptEndFrag)
+    fun endContentAttempt(attemptEndFrag: String, isExamWindowViolated: Boolean) {
+        repository.endContentAttempt(attemptEndFrag, isExamWindowViolated)
     }
 
     fun endAttempt(attemptEndFrag: String) {

--- a/exam/src/main/java/in/testpress/exam/ui/viewmodel/ExamViewModel.kt
+++ b/exam/src/main/java/in/testpress/exam/ui/viewmodel/ExamViewModel.kt
@@ -39,8 +39,8 @@ class ExamViewModel(val repository: ExamRepository) : ViewModel() {
         repository.startAttempt(attemptStartFrag)
     }
 
-    fun endContentAttempt(attemptId: Long, attemptEndFrag: String) {
-        repository.endContentAttempt(attemptId, attemptEndFrag)
+    fun endContentAttempt(attemptId: Long, attemptEndFrag: String, isExamWindowViolated: Boolean) {
+        repository.endContentAttempt(attemptId, attemptEndFrag, isExamWindowViolated)
     }
 
     fun endAttempt(attemptId: Long, attemptEndFrag: String) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for indicating exam window violations when ending an exam attempt. The app now tracks and sends this status if a violation occurs during the exam.

* **Refactor**
  * Updated exam completion flows to handle and propagate the exam window violation flag throughout the app’s user interface and backend interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->