### PR TITLE
fix: Add WAKE_LOCK permission and keep screen awake in TestFragment

### DIFF
--- a/exam/src/main/AndroidManifest.xml
+++ b/exam/src/main/AndroidManifest.xml
@@ -15,6 +15,8 @@
          or higher if your app targets Android 14 (API level 34) or higher.  -->
     <uses-permission android:name="android.permission.READ_MEDIA_VISUAL_USER_SELECTED" />
 
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
+
     <application
         android:allowBackup="true"
         android:supportsRtl="true" >
@@ -27,6 +29,7 @@
         <activity android:name=".ui.TestActivity"
             android:label="@string/testpress_start_exam"
             android:theme="@style/TestpressTheme"
+            android:keepScreenOn="true"
             android:configChanges="orientation|keyboard|screenSize" />
 
         <activity android:name=".ui.AccessCodeActivity"

--- a/exam/src/main/AndroidManifest.xml
+++ b/exam/src/main/AndroidManifest.xml
@@ -29,7 +29,6 @@
         <activity android:name=".ui.TestActivity"
             android:label="@string/testpress_start_exam"
             android:theme="@style/TestpressTheme"
-            android:keepScreenOn="true"
             android:configChanges="orientation|keyboard|screenSize" />
 
         <activity android:name=".ui.AccessCodeActivity"

--- a/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
@@ -1703,6 +1703,19 @@ public class TestFragment extends BaseFragment implements
         }
     }
 
+    @Override
+    public void onPause() {
+        super.onPause();
+        enableScreenTimeout();
+    }
+
+    private void enableScreenTimeout() {
+        if (isAdded() && exam != null && exam.isWindowMonitoringEnabled()) {
+            requireActivity().getWindow()
+                    .clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+        }
+    }
+
     void removeAppBackgroundHandler() {
         if (appBackgroundStateHandler != null) {
             appBackgroundStateHandler.removeCallbacks(stopTimerTask);

--- a/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
@@ -25,6 +25,7 @@ import android.text.Html;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.WindowManager;
 import android.widget.AbsListView;
 import android.widget.AdapterView;
 import android.widget.ImageButton;
@@ -1663,6 +1664,7 @@ public class TestFragment extends BaseFragment implements
         } else if (currentViolationCount > 0) {
             showViolationAlertDialog(false);
         }
+        disableScreenTimeOut();
     }
 
     private void showViolationAlertDialog(boolean exceededViolationCount) {
@@ -1693,6 +1695,12 @@ public class TestFragment extends BaseFragment implements
         builder.setCancelable(false);
         windowViolationDialog = builder.create();
         windowViolationDialog.show();
+    }
+
+    private void disableScreenTimeOut() {
+        if (isAdded() && exam != null && exam.isWindowMonitoringEnabled()) {
+            requireActivity().getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+        }
     }
 
     void removeAppBackgroundHandler() {


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The app now keeps the screen on during exams to prevent the device from sleeping.  
* **Chores**
  * Added permission to allow the app to keep the device awake.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->