### PR TITLE
refactor: Replace repeated dialog dismiss with method

### DIFF
--- a/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
@@ -705,9 +705,7 @@ public class TestFragment extends BaseFragment implements
                         if (getActivity() == null) {
                             return;
                         }
-                        if (progressDialog.isShowing()) {
-                            progressDialog.dismiss();
-                        }
+                        hideProgressBar();
 
                         if (listResource.getData() == null || listResource.getData().isEmpty()) { // Display alert if no questions exist
                             new AlertDialog.Builder(getActivity(), R.style.TestpressAppCompatAlertDialogStyle)
@@ -775,9 +773,7 @@ public class TestFragment extends BaseFragment implements
                         if (getActivity() == null) {
                             return;
                         }
-                        if (progressDialog.isShowing()) {
-                            progressDialog.dismiss();
-                        }
+                        hideProgressBar();
 
                         AlertDialog.Builder builder = new AlertDialog.Builder(getActivity(),
                                 R.style.TestpressAppCompatAlertDialogStyle);
@@ -1167,9 +1163,7 @@ public class TestFragment extends BaseFragment implements
                             return;
                         }
                         logEvent(EventsTrackerFacade.ENDED_EXAM);
-                        if (progressDialog.isShowing()) {
-                            progressDialog.dismiss();
-                        }
+                        hideProgressBar();
                         if (isOfflineExam()){
                             returnToHistory();
                             return;
@@ -1184,9 +1178,7 @@ public class TestFragment extends BaseFragment implements
                         break;
                     }
                     case ERROR:{
-                        if (progressDialog.isShowing()) {
-                            progressDialog.dismiss();
-                        }
+                        hideProgressBar();
                         showException(
                                 courseAttemptResource.getException(),
                                 R.string.testpress_exam_paused_check_internet_to_end,
@@ -1211,9 +1203,7 @@ public class TestFragment extends BaseFragment implements
                             return;
                         }
                         logEvent(EventsTrackerFacade.ENDED_EXAM);
-                        if (progressDialog.isShowing()) {
-                            progressDialog.dismiss();
-                        }
+                        hideProgressBar();
                         if (isOfflineExam()){
                             returnToHistory();
                             return;
@@ -1226,9 +1216,7 @@ public class TestFragment extends BaseFragment implements
                         break;
                     }
                     case ERROR:{
-                        if (progressDialog.isShowing()) {
-                            progressDialog.dismiss();
-                        }
+                        hideProgressBar();
                         showException(
                                 attemptResource.getException(),
                                 R.string.testpress_exam_paused_check_internet_to_end,
@@ -1498,6 +1486,12 @@ public class TestFragment extends BaseFragment implements
         progressDialog.setMessage(message);
         if (!progressDialog.isShowing()) {
             progressDialog.show();
+        }
+    }
+
+    private void hideProgressBar() {
+        if (progressDialog.isShowing()) {
+            progressDialog.dismiss();
         }
     }
 

--- a/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
@@ -1490,7 +1490,7 @@ public class TestFragment extends BaseFragment implements
     }
 
     private void hideProgressBar() {
-        if (progressDialog.isShowing()) {
+        if (progressDialog != null && progressDialog.isShowing()) {
             progressDialog.dismiss();
         }
     }


### PR DESCRIPTION
- Reduce code duplication by introducing a `hideProgressBar()` method  to handle `ProgressDialog` dismissal consistently. This improves readability and maintainability of `TestFragment` by replacing multiple  inline checks with a centralized utility method.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of progress dialog dismissal for a smoother and more consistent user experience. No changes to visible functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->