### PR TITLE
refactor: Remove redundant save call on expand panel

### DIFF
--- a/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
@@ -1283,9 +1283,6 @@ public class TestFragment extends BaseFragment implements
     }
 
     private void onExpandPanel() {
-        if (!attemptItemList.isEmpty() && attemptItemList.get(viewPager.getCurrentItem()).hasChanged()) {
-            saveResult(viewPager.getCurrentItem(), Action.UPDATE_ANSWER);
-        }
         viewPager.setSwipeEnabled(false);
         previous.setVisibility(View.INVISIBLE);
         next.setVisibility(View.INVISIBLE);


### PR DESCRIPTION
- The `saveResult()` call in `onExpandPanel()` was triggering a save operation even though the panel expansion doesn't require saving the current answer. This logic was unnecessary and could result in unwanted side effects like extra network calls or UI lag.
- Removing it simplifies the method and avoids redundant operations when the user expands the answer sheet panel.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved panel expansion behavior by removing automatic saving of answer changes when expanding the panel. Panel expansion now only disables swipe, hides navigation buttons, and updates the panel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->