### PR TITLE
refactor: Centralize system bar color logic via activity lifecycle callbacks

### DIFF
--- a/core/src/main/java/in/testpress/ui/BaseToolBarActivity.kt
+++ b/core/src/main/java/in/testpress/ui/BaseToolBarActivity.kt
@@ -15,7 +15,6 @@ import android.widget.ImageView
 import androidx.annotation.StringRes
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
-import `in`.testpress.util.applySystemBarColors
 
 /**
  * Base activity used to support the toolbar & handle backpress.
@@ -32,11 +31,6 @@ open class BaseToolBarActivity: AppCompatActivity() {
     private var session: TestpressSession? = null
     protected lateinit var logo: ImageView
     protected lateinit var toolbar: Toolbar
-
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        applySystemBarColors(window.decorView.rootView)
-    }
 
     override fun setContentView(layoutResId: Int) {
         super.setContentView(layoutResId)

--- a/course/src/main/java/in/testpress/course/ui/CustomMeetingActivity.kt
+++ b/course/src/main/java/in/testpress/course/ui/CustomMeetingActivity.kt
@@ -17,7 +17,6 @@ import android.widget.Button
 import android.widget.EditText
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
-import `in`.testpress.util.applySystemBarColors
 import us.zoom.sdk.*
 
 
@@ -34,7 +33,6 @@ class CustomMeetingActivity : FragmentActivity(), MeetingUserCallback.UserEvent,
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        applySystemBarColors(window.decorView.rootView)
         setUpWindow()
 
         customMeetingBinding = ActivityCustomMeetingBinding.inflate(layoutInflater)

--- a/course/src/main/java/in/testpress/course/ui/ZoomMeetActivity.kt
+++ b/course/src/main/java/in/testpress/course/ui/ZoomMeetActivity.kt
@@ -1,19 +1,12 @@
 package `in`.testpress.course.ui
 
-import android.os.Bundle
 import `in`.testpress.core.TestpressSdk
 import android.view.View
 import android.view.WindowManager
-import `in`.testpress.util.applySystemBarColors
 import us.zoom.sdk.NewMeetingActivity
 
 class ZoomMeetActivity: NewMeetingActivity() {
     val session = TestpressSdk.getTestpressSession(this)
-
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        applySystemBarColors(window.decorView.rootView)
-    }
 
     override fun setContentView(layoutResID: Int) {
         disableScreenRecording()

--- a/samples/src/main/java/in/testpress/samples/SampleApplication.kt
+++ b/samples/src/main/java/in/testpress/samples/SampleApplication.kt
@@ -1,9 +1,12 @@
 package `in`.testpress.samples
 
+import android.app.Activity
 import android.app.Application
+import android.os.Bundle
 import android.util.Log
 import `in`.testpress.course.helpers.OfflineAttachmentSyncManager
 import `in`.testpress.database.TestpressDatabase
+import `in`.testpress.util.applySystemBarColors
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -14,6 +17,7 @@ class SampleApplication : Application() {
     override fun onCreate() {
         super.onCreate()
         syncDownloads()
+        registerActivityLifecycleCallbacks(activityLifecycleCallbacks)
     }
 
     private fun syncDownloads() {
@@ -26,5 +30,19 @@ class SampleApplication : Application() {
                 Log.e("SampleApplication", "Failed to sync downloads", e)
             }
         }
+    }
+
+    private val activityLifecycleCallbacks = object : ActivityLifecycleCallbacks {
+        override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
+            activity.applySystemBarColors(activity.window.decorView)
+        }
+
+        override fun onActivityStarted(activity: Activity) {}
+        override fun onActivityResumed(activity: Activity) {}
+        override fun onActivityPaused(activity: Activity) {}
+        override fun onActivityStopped(activity: Activity) {}
+        override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) {}
+        override fun onActivityDestroyed(activity: Activity) {}
+
     }
 }


### PR DESCRIPTION
- System bar colors were inconsistently applied across activities, as each one had to manually invoke the theming logic.
- This happened because the styling was applied in individual activity onCreate() methods, leading to duplication and potential omissions.
- This is fixed by moving the logic to a centralized ActivityLifecycleCallbacks in the application class, ensuring consistent behavior across all activities automatically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized the application of system bar colors by moving this functionality to a global activity lifecycle callback.
  * Removed redundant system bar color logic from individual activities for a more consistent and maintainable approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->