### PR TITLE
fix: App crash when starting custom tests

### DIFF
--- a/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
@@ -1649,7 +1649,7 @@ public class TestFragment extends BaseFragment implements
     public void onResume() {
         super.onResume();
 
-        if (!exam.isWindowMonitoringEnabled()) {
+        if (exam != null && !exam.isWindowMonitoringEnabled()) {
             removeAppBackgroundHandler();
             return;
         }
@@ -1722,7 +1722,7 @@ public class TestFragment extends BaseFragment implements
     public void onStop() {
         super.onStop();
         saveResult(currentQuestionIndex, Action.UPDATE_ANSWER);
-        if (exam.isWindowMonitoringEnabled()) {
+        if (exam != null && exam.isWindowMonitoringEnabled()) {
             currentViolationCount++;
             return;
         }

--- a/exam/src/main/java/in/testpress/exam/ui/TestQuestionFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestQuestionFragment.java
@@ -130,7 +130,7 @@ public class TestQuestionFragment extends Fragment implements PickiTCallbacks, E
 
                 @Override
                 public boolean isWindowMonitoringEnabled() {
-                    return exam.isWindowMonitoringEnabled();
+                    return exam != null && exam.isWindowMonitoringEnabled();
                 }
 
                 @Override


### PR DESCRIPTION
- Users were unable to take custom tests because the app crashed when navigating to or from the test screen.
- This happened because, for custom tests, the exam object is null, but window monitoring checks still tried to access it, leading to a crash.
- This is fixed by adding a null check for the exam object before running window monitoring checks, ensuring custom tests start and run without issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app stability by adding safeguards to prevent errors when certain data is missing during exam monitoring features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->