### PR TITLE
fix: Resolve cache issue in domain restricted playback

### DIFF
--- a/course/src/main/java/in/testpress/course/fragments/DomainRestrictedVideoFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/DomainRestrictedVideoFragment.kt
@@ -1,6 +1,5 @@
 package `in`.testpress.course.fragments
 
-import android.webkit.WebSettings
 import `in`.testpress.core.TestpressSdk
 import `in`.testpress.course.api.TestpressCourseApiClient
 import `in`.testpress.course.domain.DomainContent
@@ -19,10 +18,6 @@ class DomainRestrictedVideoFragment: WebViewVideoFragment() {
     }
 
     private fun disableWebViewCache() {
-        webView.settings.apply {
-            cacheMode = WebSettings.LOAD_NO_CACHE
-            domStorageEnabled = false
-        }
         webView.clearCache(true)
         webView.clearHistory()
     }

--- a/course/src/main/java/in/testpress/course/fragments/DomainRestrictedVideoFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/DomainRestrictedVideoFragment.kt
@@ -1,5 +1,6 @@
 package `in`.testpress.course.fragments
 
+import android.webkit.WebSettings
 import `in`.testpress.core.TestpressSdk
 import `in`.testpress.course.api.TestpressCourseApiClient
 import `in`.testpress.course.domain.DomainContent
@@ -13,6 +14,16 @@ class DomainRestrictedVideoFragment: WebViewVideoFragment() {
         jsonObject.addProperty(TestpressCourseApiClient.EMBED_CODE, content.video!!.embedCode)
         val url = "${session!!.instituteSettings.baseUrl}/${TestpressCourseApiClient.EMBED_DOMAIN_RESTRICTED_VIDEO_PATH}"
         webViewUtils.initWebViewAndPostUrl(url, jsonObject.toString(), activity)
+        disableWebViewCache()
         webView.webChromeClient = fullScreenChromeClient
+    }
+
+    private fun disableWebViewCache() {
+        webView.settings.apply {
+            cacheMode = WebSettings.LOAD_NO_CACHE
+            domStorageEnabled = false
+        }
+        webView.clearCache(true)
+        webView.clearHistory()
     }
 }


### PR DESCRIPTION
- Domain restricted videos were failing to load in WebView  
- Cached data was bypassing domain validation  
- Disabled WebView cache, storage, and history