### PR TITLE
build: Update payUCheckoutPro dependency to version 1.8.9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -94,7 +94,7 @@ ext {
     jwtdecode = "com.auth0.android:jwtdecode:2.0.2"
 
     // Payment Dependencies
-    payUCheckoutPro = "in.payu:payu-checkout-pro:1.8.0"
+    payUCheckoutPro = "in.payu:payu-checkout-pro:1.8.9"
     payUGpay = "in.payu:payu-gpay:1.4.0"
     razorpayAndroidCheckoutSDK = "com.razorpay:checkout:1.6.33"
     stripeAndroidSDK = "com.stripe:stripe-android:20.32.0"


### PR DESCRIPTION
- Updated in.payu:payu-checkout-pro dependency from previous version to 1.8.9
- New version unlocks additional banks that were missing earlier