### PR TITLE
build: Update dependencies to prevent runtime crash

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,7 +76,7 @@ ext {
     // Others / Network / Analytics / UI / Misc Dependencies
     retrofit2 = 'com.squareup.retrofit2:retrofit:2.9.0'
     gsonConverter = 'com.squareup.retrofit2:converter-gson:2.9.0'
-    httpLogInterceptor = 'com.squareup.okhttp3:logging-interceptor:4.0.0'
+    httpLogInterceptor = 'com.squareup.okhttp3:logging-interceptor:4.3.1'
     design = 'com.google.android.material:material:1.1.0'
     chart = 'com.github.testpress:MPAndroidChart:v3.0.0-beta2'
     greendao = 'org.greenrobot:greendao:3.2.0'
@@ -94,7 +94,7 @@ ext {
     jwtdecode = "com.auth0.android:jwtdecode:2.0.2"
 
     // Payment Dependencies
-    payUCheckoutPro = "in.payu:payu-checkout-pro:1.8.9"
+    payUCheckoutPro = "in.payu:payu-checkout-pro:1.9.0"
     payUGpay = "in.payu:payu-gpay:1.4.0"
     razorpayAndroidCheckoutSDK = "com.razorpay:checkout:1.6.33"
     stripeAndroidSDK = "com.stripe:stripe-android:20.32.0"


### PR DESCRIPTION
- Upgraded PayUCheckoutPro to 1.9.0.
- Updated OkHttp logging-interceptor to 4.3.1 to resolve NoSuchMethodError at runtime.
- These changes fix crashes caused by PayUCheckoutPro using an incompatible internal logging-interceptor version.