### PR TITLE
build: Upgrade payUCheckoutPro dependency to version 2.0.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -94,7 +94,7 @@ ext {
     jwtdecode = "com.auth0.android:jwtdecode:2.0.2"
 
     // Payment Dependencies
-    payUCheckoutPro = "in.payu:payu-checkout-pro:1.9.0"
+    payUCheckoutPro = "in.payu:payu-checkout-pro:2.0.1"
     payUGpay = "in.payu:payu-gpay:1.4.0"
     razorpayAndroidCheckoutSDK = "com.razorpay:checkout:1.6.33"
     stripeAndroidSDK = "com.stripe:stripe-android:20.32.0"


### PR DESCRIPTION
- Updated payu-checkout-pro from 1.9.0 to 2.0.1 to incorporate the latest features and improvements.