### PR TITLE
fix: Prevent progress callback after cancel or complete

### DIFF
--- a/course/src/main/java/in/testpress/course/fragments/DocumentViewerFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/DocumentViewerFragment.kt
@@ -121,7 +121,7 @@ class DocumentViewerFragment : BaseContentDetailFragment(), PdfDownloadListener,
             encryptionProgress.visibility = View.VISIBLE
             PDFViewer(requireContext(), displayPDFListener = this@DocumentViewerFragment).display(
                 file = pdfDownloadManager.get(),
-                pdfView = binding.pdfView
+                pdfView = this.pdfView
             )
         }
     }

--- a/course/src/main/java/in/testpress/course/fragments/DocumentViewerFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/DocumentViewerFragment.kt
@@ -117,13 +117,11 @@ class DocumentViewerFragment : BaseContentDetailFragment(), PdfDownloadListener,
     }
 
     private fun displayPDF() {
-        _binding?.apply {
-            encryptionProgress.visibility = View.VISIBLE
-            PDFViewer(requireContext(), displayPDFListener = this@DocumentViewerFragment).display(
-                file = pdfDownloadManager.get(),
-                pdfView = this.pdfView
-            )
-        }
+        binding.encryptionProgress.visibility = View.VISIBLE
+        PDFViewer(requireContext(), displayPDFListener = this).display(
+            file = pdfDownloadManager.get(),
+            pdfView = binding.pdfView
+        )
     }
 
     override fun onDownloadFailed() {
@@ -132,13 +130,11 @@ class DocumentViewerFragment : BaseContentDetailFragment(), PdfDownloadListener,
     }
 
     override fun downloadProgress(progress: Int) {
-        _binding?.apply {
-            showDownloadProgress(progress)
-            encryptionProgress.visibility = View.GONE
-            if (progress == completeProgress) {
-                hideDownloadProgress()
-                encryptionProgress.visibility = View.VISIBLE
-            }
+        showDownloadProgress(progress)
+        binding.encryptionProgress.visibility = View.GONE
+        if (progress == completeProgress) {
+            hideDownloadProgress()
+            binding.encryptionProgress.visibility = View.VISIBLE
         }
     }
 
@@ -151,9 +147,7 @@ class DocumentViewerFragment : BaseContentDetailFragment(), PdfDownloadListener,
     }
 
     override fun onPDFLoaded() {
-        _binding?.apply {
-            encryptionProgress.visibility = View.GONE
-        }
+        binding.encryptionProgress.visibility = View.GONE
         if (::fullScreenMenu.isInitialized) {
             fullScreenMenu.isVisible = true
         }
@@ -164,26 +158,20 @@ class DocumentViewerFragment : BaseContentDetailFragment(), PdfDownloadListener,
     }
 
     private fun showDownloadProgress(progress: Int) {
-        _binding?.apply {
-            downloadProgress.visibility = View.VISIBLE
-            progressPercentage.visibility = View.VISIBLE
-            downloadProgress.progress = progress
-            progressPercentage.text = "$progress%"
-        }
+            binding.downloadProgress.visibility = View.VISIBLE
+            binding.progressPercentage.visibility = View.VISIBLE
+            binding.downloadProgress.progress = progress
+            binding.progressPercentage.text = "$progress%"
     }
 
     private fun hideDownloadProgress() {
-        _binding?.apply {
-            downloadProgress.visibility = View.GONE
-            progressPercentage.visibility = View.GONE
-        }
-    }
+        binding.downloadProgress.visibility = View.GONE
+        binding.progressPercentage.visibility = View.GONE
+}
 
     private fun showErrorView() {
-        _binding?.apply {
-            pdfView.visibility = View.GONE
-            emptyContainer.visibility = View.VISIBLE
-        }
+        binding.pdfView.visibility = View.GONE
+        binding.emptyContainer.visibility = View.VISIBLE
     }
 
     override fun onDetach() {

--- a/course/src/main/java/in/testpress/course/fragments/DocumentViewerFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/DocumentViewerFragment.kt
@@ -119,8 +119,8 @@ class DocumentViewerFragment : BaseContentDetailFragment(), PdfDownloadListener,
     private fun displayPDF() {
         binding.encryptionProgress.visibility = View.VISIBLE
         PDFViewer(requireContext(), displayPDFListener = this).display(
-            file = pdfDownloadManager.get(),
-            pdfView = binding.pdfView
+                file = pdfDownloadManager.get(),
+                pdfView = binding.pdfView
         )
     }
 
@@ -158,16 +158,16 @@ class DocumentViewerFragment : BaseContentDetailFragment(), PdfDownloadListener,
     }
 
     private fun showDownloadProgress(progress: Int) {
-            binding.downloadProgress.visibility = View.VISIBLE
-            binding.progressPercentage.visibility = View.VISIBLE
-            binding.downloadProgress.progress = progress
-            binding.progressPercentage.text = "$progress%"
+        binding.downloadProgress.visibility = View.VISIBLE
+        binding.progressPercentage.visibility = View.VISIBLE
+        binding.downloadProgress.progress = progress
+        binding.progressPercentage.text = "$progress%"
     }
 
     private fun hideDownloadProgress() {
         binding.downloadProgress.visibility = View.GONE
         binding.progressPercentage.visibility = View.GONE
-}
+    }
 
     private fun showErrorView() {
         binding.pdfView.visibility = View.GONE

--- a/course/src/main/java/in/testpress/course/fragments/DocumentViewerFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/DocumentViewerFragment.kt
@@ -117,11 +117,13 @@ class DocumentViewerFragment : BaseContentDetailFragment(), PdfDownloadListener,
     }
 
     private fun displayPDF() {
-        binding.encryptionProgress.visibility = View.VISIBLE
-        PDFViewer(requireContext(),displayPDFListener = this).display(
+        _binding?.apply {
+            encryptionProgress.visibility = View.VISIBLE
+            PDFViewer(requireContext(), displayPDFListener = this@DocumentViewerFragment).display(
                 file = pdfDownloadManager.get(),
                 pdfView = binding.pdfView
-        )
+            )
+        }
     }
 
     override fun onDownloadFailed() {
@@ -130,11 +132,13 @@ class DocumentViewerFragment : BaseContentDetailFragment(), PdfDownloadListener,
     }
 
     override fun downloadProgress(progress: Int) {
-        showDownloadProgress(progress)
-        binding.encryptionProgress.visibility = View.GONE
-        if (progress == completeProgress) {
-            hideDownloadProgress()
-            binding.encryptionProgress.visibility = View.VISIBLE
+        _binding?.apply {
+            showDownloadProgress(progress)
+            encryptionProgress.visibility = View.GONE
+            if (progress == completeProgress) {
+                hideDownloadProgress()
+                encryptionProgress.visibility = View.VISIBLE
+            }
         }
     }
 
@@ -147,7 +151,9 @@ class DocumentViewerFragment : BaseContentDetailFragment(), PdfDownloadListener,
     }
 
     override fun onPDFLoaded() {
-        binding.encryptionProgress.visibility = View.GONE
+        _binding?.apply {
+            encryptionProgress.visibility = View.GONE
+        }
         if (::fullScreenMenu.isInitialized) {
             fullScreenMenu.isVisible = true
         }
@@ -158,20 +164,26 @@ class DocumentViewerFragment : BaseContentDetailFragment(), PdfDownloadListener,
     }
 
     private fun showDownloadProgress(progress: Int) {
-        binding.downloadProgress.visibility = View.VISIBLE
-        binding.progressPercentage.visibility = View.VISIBLE
-        binding.downloadProgress.progress = progress
-        binding.progressPercentage.text = "$progress%"
+        _binding?.apply {
+            downloadProgress.visibility = View.VISIBLE
+            progressPercentage.visibility = View.VISIBLE
+            downloadProgress.progress = progress
+            progressPercentage.text = "$progress%"
+        }
     }
 
     private fun hideDownloadProgress() {
-        binding.downloadProgress.visibility = View.GONE
-        binding.progressPercentage.visibility = View.GONE
+        _binding?.apply {
+            downloadProgress.visibility = View.GONE
+            progressPercentage.visibility = View.GONE
+        }
     }
 
     private fun showErrorView() {
-        binding.pdfView.visibility = View.GONE
-        binding.emptyContainer.visibility = View.VISIBLE
+        _binding?.apply {
+            pdfView.visibility = View.GONE
+            emptyContainer.visibility = View.VISIBLE
+        }
     }
 
     override fun onDetach() {

--- a/course/src/main/java/in/testpress/course/fragments/DocumentViewerFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/DocumentViewerFragment.kt
@@ -118,7 +118,7 @@ class DocumentViewerFragment : BaseContentDetailFragment(), PdfDownloadListener,
 
     private fun displayPDF() {
         binding.encryptionProgress.visibility = View.VISIBLE
-        PDFViewer(requireContext(), displayPDFListener = this).display(
+        PDFViewer(requireContext(),displayPDFListener = this).display(
                 file = pdfDownloadManager.get(),
                 pdfView = binding.pdfView
         )

--- a/course/src/main/java/in/testpress/course/fragments/DocumentViewerFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/DocumentViewerFragment.kt
@@ -54,6 +54,10 @@ class DocumentViewerFragment : BaseContentDetailFragment(), PdfDownloadListener,
 
     override fun onDestroyView() {
         super.onDestroyView()
+        if (::pdfDownloadManager.isInitialized) {
+            pdfDownloadManager.cancel()
+            pdfDownloadManager.cleanup()
+        }
         _binding = null
     }
 
@@ -172,13 +176,5 @@ class DocumentViewerFragment : BaseContentDetailFragment(), PdfDownloadListener,
     private fun showErrorView() {
         binding.pdfView.visibility = View.GONE
         binding.emptyContainer.visibility = View.VISIBLE
-    }
-
-    override fun onDetach() {
-        super.onDetach()
-        if (::pdfDownloadManager.isInitialized) {
-            pdfDownloadManager.cancel()
-            pdfDownloadManager.cleanup()
-        }
     }
 }

--- a/course/src/main/java/in/testpress/course/util/PDFDownloadManager.kt
+++ b/course/src/main/java/in/testpress/course/util/PDFDownloadManager.kt
@@ -6,6 +6,7 @@ import com.downloader.Error
 import com.downloader.OnDownloadListener
 import com.downloader.PRDownloader
 import com.downloader.request.DownloadRequest
+import com.downloader.Status;
 import `in`.testpress.util.getRootDirPath
 import java.io.File
 
@@ -46,8 +47,10 @@ open class PDFDownloadManager(
         })
 
         prDownloader.setOnProgressListener {
-            val progress = ((it.currentBytes*100)/it.totalBytes)
-            pdfDownloadListener.downloadProgress(progress.toInt())
+            if (prDownloader.status == Status.RUNNING) {
+                val progress = ((it.currentBytes * 100) / it.totalBytes)
+                pdfDownloadListener.downloadProgress(progress.toInt())
+            }
         }
     }
 


### PR DESCRIPTION
- Verify PRDownloader status before invoking progress updates.
- Ensure downloadProgress is called only when download is running.
- Prevent NullPointerException in DocumentViewerFragment after view is destroyed.