### PR TITLE
fix: Use whiteLabeledHostUrl for PDF retrieval

### DIFF
--- a/course/src/main/java/in/testpress/course/fragments/AIChatPdfFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/AIChatPdfFragment.kt
@@ -55,7 +55,7 @@ class AIChatPdfFragment : Fragment() {
     private fun getPdfUrl(courseId: Long, contentId: Long): String {
         val session = TestpressSdk.getTestpressSession(requireContext()) 
             ?: throw IllegalStateException("User session not found.")
-        val baseUrl = session.instituteSettings?.baseUrl.takeIf { !it.isNullOrEmpty() } 
+        val baseUrl = session.instituteSettings?.whiteLabeledHostUrl.takeIf { !it.isNullOrEmpty() }
             ?: throw IllegalStateException("Base URL not configured.")
         return "$baseUrl/courses/$courseId/contents/$contentId/?content_detail_v2=true"
     }


### PR DESCRIPTION
- Updated AIChatPdfFragment to fetch the PDF URL using instituteSettings.whiteLabeledHostUrl instead of instituteSettings.baseUrl
- Ensures correct configuration handling for white-labeled setups