### PR TITLE
build: Downgrade Razorpay SDK to 1.6.38

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,7 @@ ext {
     // Payment Dependencies
     payUCheckoutPro = "in.payu:payu-checkout-pro:1.8.9"
     payUGpay = "in.payu:payu-gpay:1.4.0"
-    razorpayAndroidCheckoutSDK = "com.razorpay:checkout:1.6.41"
+    razorpayAndroidCheckoutSDK = "com.razorpay:checkout:1.6.38"
     stripeAndroidSDK = "com.stripe:stripe-android:20.32.0"
 
     // Testing Dependencies


### PR DESCRIPTION
- Downgrade Razorpay SDK in the SDK module from 1.6.41 to 1.6.38.
- The app using this SDK was failing to compile due to unresolved references in the Google Credentials API caused by the updated transitive dependency on play-services-auth in Razorpay 1.6.41.
- This downgrade ensures the SDK provides a compatible play-services-auth version, fixing app compilation.
