### PR TITLE
feat: Add FAB to open AI chat PDF from standard viewer

### DIFF
--- a/core/src/main/res/values/color.xml
+++ b/core/src/main/res/values/color.xml
@@ -52,5 +52,5 @@
 
     <color name="testpress_blue_text">#3b99d8</color>
     <color name="testpress_blue_image">#3598db</color>
-
+    <color name="ai_fab_background">#089669</color>
 </resources>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -53,6 +53,8 @@
     <string name="failed_loading_pdf"> Failed to load the PDF </string>
     <string name="hint"><font size="14">Type message</font></string>
 
+    <string name="AI">AI</string>
+    <string name="Ask_AI">Ask AI</string>
 
 
     <string-array name="discussions_author_filter">

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -54,7 +54,7 @@
     <string name="hint"><font size="14">Type message</font></string>
 
     <string name="AI">AI</string>
-    <string name="Ask_AI">Ask AI</string>
+    <string name="Switch_to_AI">Switch to AI</string>
 
 
     <string-array name="discussions_author_filter">

--- a/course/src/main/java/in/testpress/course/fragments/ContentLoadingFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/ContentLoadingFragment.kt
@@ -159,7 +159,6 @@ open class ContentFragmentFactory {
                 "Video" -> VideoContentFragment()
                 "Attachment" -> {
                     when {
-                        content?.isAIEnabled == true -> AIChatPdfFragment()
                         content?.attachment?.isRenderable == true -> DocumentViewerFragment()
                         else -> AttachmentContentFragment()
                     }

--- a/course/src/main/java/in/testpress/course/fragments/DocumentViewerFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/DocumentViewerFragment.kt
@@ -56,7 +56,7 @@ class DocumentViewerFragment : BaseContentDetailFragment(), PdfDownloadListener,
     override fun onBackPressed() {
         if (isAIView) {
             showDocumentView()
-            (activity as ContentActivity).setBackPressedHandled(true)
+            (activity as? ContentActivity)?.setBackPressedHandled(true)
         } else {
             super.onBackPressed()
             pdfDownloadManager.cancel()
@@ -81,14 +81,16 @@ class DocumentViewerFragment : BaseContentDetailFragment(), PdfDownloadListener,
     }
 
     private fun updateAskAIFABVisibility() {
-        try {
-            val isAIEnabled = content?.isAIEnabled == true
-            val isPDFAttachment = content?.contentType == "Attachment" && content?.attachment != null
-
-            binding.askAiFab.visibility = if (isAIEnabled && isPDFAttachment && !isAIView) View.VISIBLE else View.GONE
-        } catch (e: UninitializedPropertyAccessException) {
+        if (!isContentInitialized()) {
             binding.askAiFab.visibility = View.GONE
+            return
         }
+
+        val isAIEnabled = content.isAIEnabled == true
+        val isPDFAttachment = content.contentType == "Attachment" && content.attachment != null
+        val courseIdExists = content.courseId != null
+
+        binding.askAiFab.visibility = if (isAIEnabled && isPDFAttachment && !isAIView && courseIdExists) View.VISIBLE else View.GONE
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
@@ -121,9 +123,9 @@ class DocumentViewerFragment : BaseContentDetailFragment(), PdfDownloadListener,
         }
 
         binding.pdfView.visibility = View.GONE
-        binding.root.findViewById<View>(R.id.bottom_navigation_fragment).visibility = View.GONE
+        binding.bottomNavigationFragment.visibility = View.GONE
         binding.askAiFab.visibility = View.GONE
-        binding.root.findViewById<View>(R.id.aiPdf_view_fragment).visibility = View.VISIBLE
+        binding.aiPdfViewFragment.visibility = View.VISIBLE
 
         childFragmentManager.beginTransaction()
             .replace(R.id.aiPdf_view_fragment, aiChatFragment!!)

--- a/course/src/main/java/in/testpress/course/fragments/DocumentViewerFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/DocumentViewerFragment.kt
@@ -31,6 +31,8 @@ class DocumentViewerFragment : BaseContentDetailFragment(), PdfDownloadListener,
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     lateinit var fullScreenMenu: MenuItem
     private val completeProgress = 100
+    private var isAIView = false
+    private var aiChatFragment: AIChatPdfFragment? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -43,13 +45,23 @@ class DocumentViewerFragment : BaseContentDetailFragment(), PdfDownloadListener,
             savedInstanceState: Bundle?
     ): View {
         _binding = LayoutDocumentViewerBinding.inflate(inflater, container, false)
+        
+        binding.askAiFab.setOnClickListener {
+            showAIView()
+        }
+        
         return binding.root
     }
 
     override fun onBackPressed() {
-        super.onBackPressed()
-        pdfDownloadManager.cancel()
-        pdfDownloadManager.cleanup()
+        if (isAIView) {
+            showDocumentView()
+            (activity as ContentActivity).setBackPressedHandled(true)
+        } else {
+            super.onBackPressed()
+            pdfDownloadManager.cancel()
+            pdfDownloadManager.cleanup()
+        }
     }
 
     override fun onDestroyView() {
@@ -65,7 +77,18 @@ class DocumentViewerFragment : BaseContentDetailFragment(), PdfDownloadListener,
         super.onCreateOptionsMenu(menu, inflater)
         inflater.inflate(R.menu.full_screen_menu, menu)
         fullScreenMenu = menu.findItem(R.id.fullScreen)
-        fullScreenMenu.isVisible = false
+        fullScreenMenu.isVisible = !isAIView
+    }
+
+    private fun updateAskAIFABVisibility() {
+        try {
+            val isAIEnabled = content?.isAIEnabled == true
+            val isPDFAttachment = content?.contentType == "Attachment" && content?.attachment != null
+
+            binding.askAiFab.visibility = if (isAIEnabled && isPDFAttachment && !isAIView) View.VISIBLE else View.GONE
+        } catch (e: UninitializedPropertyAccessException) {
+            binding.askAiFab.visibility = View.GONE
+        }
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
@@ -87,10 +110,52 @@ class DocumentViewerFragment : BaseContentDetailFragment(), PdfDownloadListener,
         })
     }
 
+
+    private fun showAIView() {
+        if (aiChatFragment == null) {
+            aiChatFragment = AIChatPdfFragment()
+            val args = Bundle()
+            args.putLong("contentId", contentId)
+            args.putLong("courseId", content.courseId ?: -1L)
+            aiChatFragment?.arguments = args
+        }
+
+        binding.pdfView.visibility = View.GONE
+        binding.root.findViewById<View>(R.id.bottom_navigation_fragment).visibility = View.GONE
+        binding.askAiFab.visibility = View.GONE
+        binding.root.findViewById<View>(R.id.aiPdf_view_fragment).visibility = View.VISIBLE
+
+        childFragmentManager.beginTransaction()
+            .replace(R.id.aiPdf_view_fragment, aiChatFragment!!)
+            .commit()
+
+        isAIView = true
+        activity?.invalidateOptionsMenu()
+    }
+
+    fun showDocumentView() {
+        binding.pdfView.visibility = View.VISIBLE
+        binding.bottomNavigationFragment.visibility = View.VISIBLE
+        binding.askAiFab.visibility = View.VISIBLE
+        binding.aiPdfViewFragment.visibility = View.GONE
+
+        aiChatFragment?.let {
+            childFragmentManager.beginTransaction()
+                .remove(it)
+                .commitNow()
+        }
+
+        isAIView = false
+        activity?.invalidateOptionsMenu()
+    }
+
     override fun display() {
         (activity as ContentActivity).setActionBarTitle(content.attachment?.title?:DEFAULT_ATTACHMENT_TITLE)
         fileName = getFileName()
         pdfDownloadManager = PDFDownloadManager(this,requireContext(),fileName)
+
+        updateAskAIFABVisibility()
+
         if (pdfDownloadManager.isDownloaded()) {
             displayPDF()
             viewModel.createContentAttempt(contentId).observe(viewLifecycleOwner, Observer {

--- a/course/src/main/java/in/testpress/course/ui/ContentActivity.java
+++ b/course/src/main/java/in/testpress/course/ui/ContentActivity.java
@@ -71,10 +71,11 @@ public class ContentActivity extends BaseToolBarActivity implements ContentFragm
     @Override
     public boolean onOptionsItemSelected(final MenuItem item) {
         if(item.getItemId() == android.R.id.home) {
+            backPressedHandled = false;
             delegateBackPressToFragments();
             if (getCallingActivity() != null) {
                 return false;
-            } else {
+            } else if (!backPressedHandled) {
                 super.onBackPressed();
             }
             return true;
@@ -82,10 +83,16 @@ public class ContentActivity extends BaseToolBarActivity implements ContentFragm
         return super.onOptionsItemSelected(item);
     }
 
+    private boolean backPressedHandled = false;
+    
     @Override
     public void onBackPressed() {
-        super.onBackPressed();
+        backPressedHandled = false;
         delegateBackPressToFragments();
+        
+        if (!backPressedHandled) {
+            super.onBackPressed();
+        }
     }
 
     private void delegateBackPressToFragments() {
@@ -94,6 +101,10 @@ public class ContentActivity extends BaseToolBarActivity implements ContentFragm
                 ((OnBackPressedListener)fragment).onBackPressed();
             }
         }
+    }
+    
+    public void setBackPressedHandled(boolean handled) {
+        this.backPressedHandled = handled;
     }
 
     @Override

--- a/course/src/main/res/drawable/ask_ai_fab_background.xml
+++ b/course/src/main/res/drawable/ask_ai_fab_background.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
-    <solid android:color="#089669" />
+    <solid android:color="@color/ai_fab_background" />
     <corners android:radius="25dp" />
     <stroke android:width="0dp" />
 </shape>

--- a/course/src/main/res/drawable/ask_ai_fab_background.xml
+++ b/course/src/main/res/drawable/ask_ai_fab_background.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="#089669" />
+    <corners android:radius="25dp" />
+    <stroke android:width="0dp" />
+</shape>

--- a/course/src/main/res/drawable/ic_ai.xml
+++ b/course/src/main/res/drawable/ic_ai.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="18dp"
+    android:height="18dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <group android:pivotX="12" android:pivotY="12" android:scaleX="1.30" android:scaleY="1.26">
+        <path
+            android:fillColor="#FFFFFF"
+            android:pathData="M12,2 L13.8,7.2 L19,9 L13.8,10.8 L12,16 L10.2,10.8 L5,9 L10.2,7.2 Z"/>
+        <path
+            android:fillColor="#FFFFFF"
+            android:pathData="M6,14 L7,16 L9,17 L7,18 L6,20 L5,18 L3,17 L5,16 Z"/>
+        <path
+            android:fillColor="#FFFFFF"
+            android:pathData="M18,14 L19,16 L21,17 L19,18 L18,20 L17,18 L15,17 L17,16 Z"/>
+    </group>
+</vector>

--- a/course/src/main/res/drawable/ic_ai.xml
+++ b/course/src/main/res/drawable/ic_ai.xml
@@ -6,13 +6,13 @@
     android:viewportHeight="24">
     <group android:pivotX="12" android:pivotY="12" android:scaleX="1.30" android:scaleY="1.26">
         <path
-            android:fillColor="#FFFFFF"
+            android:fillColor="@color/testpress_white"
             android:pathData="M12,2 L13.8,7.2 L19,9 L13.8,10.8 L12,16 L10.2,10.8 L5,9 L10.2,7.2 Z"/>
         <path
-            android:fillColor="#FFFFFF"
+            android:fillColor="@color/testpress_white"
             android:pathData="M6,14 L7,16 L9,17 L7,18 L6,20 L5,18 L3,17 L5,16 Z"/>
         <path
-            android:fillColor="#FFFFFF"
+            android:fillColor="@color/testpress_white"
             android:pathData="M18,14 L19,16 L21,17 L19,18 L18,20 L17,18 L15,17 L17,16 Z"/>
     </group>
 </vector>

--- a/course/src/main/res/layout/layout_document_viewer.xml
+++ b/course/src/main/res/layout/layout_document_viewer.xml
@@ -120,9 +120,55 @@
         android:layout_height="match_parent" />
 
     <FrameLayout
+        android:id="@+id/aiPdf_view_fragment"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_above="@id/bottom_navigation_fragment"
+        android:visibility="gone" />
+
+    <FrameLayout
         android:id="@+id/bottom_navigation_fragment"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_alignParentBottom="true"/>
+
+    <!-- Custom Floating Action Button for Ask AI -->
+    <LinearLayout
+        android:id="@+id/ask_ai_fab"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentEnd="true"
+        android:layout_alignParentBottom="true"
+        android:layout_marginEnd="16dp"
+        android:layout_marginBottom="100dp"
+        android:orientation="horizontal"
+        android:background="@drawable/ask_ai_fab_background"
+        android:gravity="center_vertical"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp"
+        android:paddingTop="10dp"
+        android:paddingBottom="10dp"
+        android:elevation="8dp"
+        android:visibility="visible"
+        android:minWidth="100dp">
+
+        <ImageView
+            android:id="@+id/ai_icon_fab"
+            android:layout_width="18dp"
+            android:layout_height="18dp"
+            android:src="@drawable/ic_ai"
+            android:contentDescription="AI"
+            android:layout_marginEnd="8dp" />
+
+        <TextView
+            android:id="@+id/ai_text_fab"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Ask AI"
+            android:textColor="#FFFFFF"
+            android:textStyle="bold"
+            android:textSize="14sp" />
+
+    </LinearLayout>
 
 </RelativeLayout>

--- a/course/src/main/res/layout/layout_document_viewer.xml
+++ b/course/src/main/res/layout/layout_document_viewer.xml
@@ -140,15 +140,15 @@
         android:layout_alignParentEnd="true"
         android:layout_alignParentBottom="true"
         android:layout_marginEnd="16dp"
-        android:layout_marginBottom="100dp"
+        android:layout_marginBottom="80dp"
         android:orientation="horizontal"
         android:background="@drawable/ask_ai_fab_background"
         android:gravity="center_vertical"
         android:paddingStart="16dp"
         android:paddingEnd="16dp"
-        android:paddingTop="10dp"
-        android:paddingBottom="10dp"
-        android:elevation="8dp"
+        android:paddingTop="14dp"
+        android:paddingBottom="14dp"
+        android:elevation="6dp"
         android:visibility="visible"
         android:minWidth="100dp">
 
@@ -164,9 +164,8 @@
             android:id="@+id/ai_text_fab"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/Ask_AI"
+            android:text="@string/Switch_to_AI"
             android:textColor="@color/testpress_white"
-            android:textStyle="bold"
             android:textSize="14sp" />
 
     </LinearLayout>

--- a/course/src/main/res/layout/layout_document_viewer.xml
+++ b/course/src/main/res/layout/layout_document_viewer.xml
@@ -157,15 +157,15 @@
             android:layout_width="18dp"
             android:layout_height="18dp"
             android:src="@drawable/ic_ai"
-            android:contentDescription="AI"
+            android:contentDescription="@string/AI"
             android:layout_marginEnd="8dp" />
 
         <TextView
             android:id="@+id/ai_text_fab"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="Ask AI"
-            android:textColor="#FFFFFF"
+            android:text="@string/Ask_AI"
+            android:textColor="@color/testpress_white"
             android:textStyle="bold"
             android:textSize="14sp" />
 


### PR DESCRIPTION
- Changed flow so AI-enabled PDFs open in DocumentViewerFragment by default instead of jumping straight to the AI PDF.
- Added a Floating Action Button (FAB) to switch to the AI PDF when needed.
- Updated navigation, layout, and resources to support this new flow.