### PR TITLE
fix: AI PDF fullscreen respects device orientation

### DIFF
--- a/core/src/main/java/in/testpress/fragments/WebViewFragment.kt
+++ b/core/src/main/java/in/testpress/fragments/WebViewFragment.kt
@@ -39,6 +39,7 @@ class WebViewFragment : Fragment(), EmptyViewListener {
     private var allowZoomControl: Boolean = false
     private var enableSwipeRefresh: Boolean = false
     var session: TestpressSession? = null
+    var isPdfContent: Boolean = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/core/src/main/java/in/testpress/util/webview/CustomWebChromeClient.kt
+++ b/core/src/main/java/in/testpress/util/webview/CustomWebChromeClient.kt
@@ -165,11 +165,16 @@ class CustomWebChromeClient(val fragment: WebViewFragment) : WebChromeClient() {
 
         // Remember current state and switch to landscape
         previousOrientation = fragment.requireActivity().requestedOrientation
-        fragment.requireActivity().requestedOrientation =
-            ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE
-
         previousSystemUiVisibility = fragment.requireActivity().window.decorView.systemUiVisibility
-        hideSystemUI()
+
+        if (!fragment.isPdfContent) {
+            fragment.requireActivity().requestedOrientation =
+                ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE
+            hideSystemUI()
+        } else {
+            fragment.requireActivity().requestedOrientation =
+                ActivityInfo.SCREEN_ORIENTATION_SENSOR
+        }
 
         fragment.webView.visibility = View.GONE
 

--- a/course/src/main/java/in/testpress/course/fragments/AIChatPdfFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/AIChatPdfFragment.kt
@@ -39,6 +39,7 @@ class AIChatPdfFragment : Fragment() {
         }
         
         val webViewFragment = WebViewFragment()
+        webViewFragment.isPdfContent = true
         
         val pdfUrl = getPdfUrl(courseId, contentId)
     


### PR DESCRIPTION
- PDFs can now be viewed in either portrait or landscape mode in fullscreen.
- Videos continue to display in landscape as intended.