### PR TITLE
fix: Hide course tabs when access is restricted

### DIFF
--- a/core/src/main/java/in/testpress/ui/BaseListViewFragment.java
+++ b/core/src/main/java/in/testpress/ui/BaseListViewFragment.java
@@ -441,9 +441,6 @@ public abstract class BaseListViewFragment<E> extends Fragment
      */
     protected BaseListViewFragment<E> setEmptyText(final int title, final int description, final int left) {
         if (emptyView != null) {
-            if (isItemsEmpty()) {
-                swipeRefreshLayout.setEnabled(false);
-            }
             emptyTitleView.setText(title);
             emptyTitleView.setCompoundDrawablesWithIntrinsicBounds(left, 0, 0, 0);
             emptyDescView.setText(description);
@@ -461,9 +458,6 @@ public abstract class BaseListViewFragment<E> extends Fragment
      */
     protected BaseListViewFragment<E> setEmptyText(final int title, final String description, final int left) {
         if (emptyView != null) {
-            if (isItemsEmpty()) {
-                swipeRefreshLayout.setEnabled(false);
-            }
             emptyTitleView.setText(title);
             emptyTitleView.setCompoundDrawablesWithIntrinsicBounds(left, 0, 0, 0);
             emptyDescView.setText(description);

--- a/course/src/main/java/in/testpress/course/ui/ChapterDetailActivity.java
+++ b/course/src/main/java/in/testpress/course/ui/ChapterDetailActivity.java
@@ -103,14 +103,15 @@ public class ChapterDetailActivity extends BaseToolBarActivity {
         showBuyNowButton = getIntent().getBooleanExtra(SHOW_BUY_NOW_BUTTON,false);
         //noinspection ConstantConditions
         instituteSettings = TestpressSdk.getTestpressSession(this).getInstituteSettings();
+        emptyView = (LinearLayout) findViewById(R.id.empty_container);
+        emptyTitleView = (TextView) findViewById(R.id.empty_title);
+        emptyDescView = (TextView) findViewById(R.id.empty_description);
+        retryButton = (Button) findViewById(R.id.retry_button);
+        progressBar = (ProgressBar) findViewById(R.id.pb_loading);
+        UIUtils.setIndeterminateDrawable(this, progressBar, 4);
+
         final String chapterUrl = getIntent().getStringExtra(CHAPTER_URL);
         if (chapterUrl != null) {
-            emptyView = (LinearLayout) findViewById(R.id.empty_container);
-            emptyTitleView = (TextView) findViewById(R.id.empty_title);
-            emptyDescView = (TextView) findViewById(R.id.empty_description);
-            retryButton = (Button) findViewById(R.id.retry_button);
-            progressBar = (ProgressBar) findViewById(R.id.pb_loading);
-            UIUtils.setIndeterminateDrawable(this, progressBar, 4);
             retryButton.setOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {
@@ -272,6 +273,7 @@ public class ChapterDetailActivity extends BaseToolBarActivity {
     void loadCourseTabLayout() {
         findViewById(R.id.fragment_carousel).setVisibility(View.VISIBLE);
         findViewById(R.id.fragment_container).setVisibility(View.GONE);
+        emptyView.setVisibility(View.GONE);
         CourseDetailsTabAdapter adapter =
                 new CourseDetailsTabAdapter(getSupportFragmentManager(), getFragmentList());
 
@@ -375,6 +377,22 @@ public class ChapterDetailActivity extends BaseToolBarActivity {
         emptyTitleView.setText(title);
         emptyDescView.setText(description);
         progressBar.setVisibility(View.GONE);
+    }
+
+    public void showCourseAccessForbidden(String message) {
+        findViewById(R.id.fragment_carousel).setVisibility(View.GONE);
+        findViewById(R.id.fragment_container).setVisibility(View.GONE);
+        emptyView.setVisibility(View.VISIBLE);
+        emptyTitleView.setText(R.string.permission_denied);
+        emptyDescView.setText(message == null || message.trim().isEmpty()
+                ? getString(R.string.testpress_no_permission)
+                : message);
+        retryButton.setVisibility(View.GONE);
+        progressBar.setVisibility(View.GONE);
+    }
+
+    public void showCourseAccessAllowed() {
+        emptyView.setVisibility(View.GONE);
     }
 
     @Override

--- a/course/src/main/java/in/testpress/course/ui/ChaptersListFragment.java
+++ b/course/src/main/java/in/testpress/course/ui/ChaptersListFragment.java
@@ -155,6 +155,7 @@ public class ChaptersListFragment extends BaseDataBaseFragment<Chapter, Long> {
             String serverMessage = getErrorMessageFromResponse(exception);
             if (serverMessage != null && !serverMessage.trim().isEmpty()) {
                 setEmptyText(R.string.permission_denied, serverMessage, R.drawable.ic_error_outline_black_18dp);
+                retryButton.setVisibility(View.GONE);
                 return R.string.permission_denied;
             }
         }
@@ -293,6 +294,8 @@ public class ChaptersListFragment extends BaseDataBaseFragment<Chapter, Long> {
         } else {
             setEmptyText(R.string.permission_denied, serverMessage, R.drawable.ic_error_outline_black_18dp);
         }
+        retryButton.setVisibility(View.GONE);
+        notifyCourseForbidden(serverMessage);
     }
 
     private void markCourseNotAccessibleLocally() {
@@ -343,11 +346,24 @@ public class ChaptersListFragment extends BaseDataBaseFragment<Chapter, Long> {
             deleteExistingChapters();
             getDao().insertOrReplaceInTx(items);
         }
+        notifyCourseAllowed();
         displayDataFromDB();
         hideLoadingPlaceholder();
         swipeRefreshLayout.setEnabled(true);
         showList();
         getLoaderManager().destroyLoader(loader.getId());
+    }
+
+    private void notifyCourseForbidden(String message) {
+        if (getActivity() instanceof ChapterDetailActivity) {
+            ((ChapterDetailActivity) getActivity()).showCourseAccessForbidden(message);
+        }
+    }
+
+    private void notifyCourseAllowed() {
+        if (getActivity() instanceof ChapterDetailActivity) {
+            ((ChapterDetailActivity) getActivity()).showCourseAccessAllowed();
+        }
     }
 
     @Override

--- a/course/src/main/java/in/testpress/course/ui/RankListFragment.java
+++ b/course/src/main/java/in/testpress/course/ui/RankListFragment.java
@@ -2,7 +2,6 @@ package in.testpress.course.ui;
 
 import android.app.Activity;
 import android.widget.ListView;
-import org.json.JSONObject;
 
 import java.util.List;
 
@@ -38,58 +37,6 @@ public class RankListFragment extends PagedItemFragment<Reputation> {
             pager.setQueryParams(COURSE_ID, courseId);
         }
         return pager;
-    }
-
-    @Override
-    public void onLoadFinished(final androidx.loader.content.Loader<List<Reputation>> loader, final List<Reputation> reputations) {
-        final TestpressException exception = getException(loader);
-        getLoaderManager().destroyLoader(loader.getId());
-
-        if (exception != null) {
-            this.exception = exception;
-
-            if (exception.isForbidden()) {
-                String message = getForbiddenMessage(exception);
-                if (message == null || message.trim().isEmpty()) {
-                    setEmptyText(R.string.permission_denied, R.string.testpress_no_permission,
-                            R.drawable.ic_error_outline_black_18dp);
-                } else {
-                    setEmptyText(R.string.permission_denied, message, R.drawable.ic_error_outline_black_18dp);
-                }
-                items.clear();
-                getListAdapter().getWrappedAdapter().setItems(items.toArray());
-                retryButton.setVisibility(android.view.View.GONE);
-                showList();
-                return;
-            }
-
-            int errorMessage = getErrorMessage(exception);
-            if (!reputations.isEmpty()) {
-                showError(errorMessage);
-            }
-            showList();
-            return;
-        }
-
-        this.exception = null;
-        updateItems(reputations);
-    }
-
-    private String getForbiddenMessage(TestpressException exception) {
-        try {
-            String raw = exception.getErrorBodyString();
-            if (raw == null || raw.trim().isEmpty()) {
-                return null;
-            }
-            JSONObject json = new JSONObject(raw);
-            if (json.has("message")) {
-                return json.getString("message");
-            }
-            if (json.has("detail")) {
-                return json.getString("detail");
-            }
-        } catch (Exception ignore) {}
-        return null;
     }
 
     @Override

--- a/course/src/main/java/in/testpress/course/ui/RankListFragment.java
+++ b/course/src/main/java/in/testpress/course/ui/RankListFragment.java
@@ -2,6 +2,7 @@ package in.testpress.course.ui;
 
 import android.app.Activity;
 import android.widget.ListView;
+import org.json.JSONObject;
 
 import java.util.List;
 
@@ -37,6 +38,58 @@ public class RankListFragment extends PagedItemFragment<Reputation> {
             pager.setQueryParams(COURSE_ID, courseId);
         }
         return pager;
+    }
+
+    @Override
+    public void onLoadFinished(final androidx.loader.content.Loader<List<Reputation>> loader, final List<Reputation> reputations) {
+        final TestpressException exception = getException(loader);
+        getLoaderManager().destroyLoader(loader.getId());
+
+        if (exception != null) {
+            this.exception = exception;
+
+            if (exception.isForbidden()) {
+                String message = getForbiddenMessage(exception);
+                if (message == null || message.trim().isEmpty()) {
+                    setEmptyText(R.string.permission_denied, R.string.testpress_no_permission,
+                            R.drawable.ic_error_outline_black_18dp);
+                } else {
+                    setEmptyText(R.string.permission_denied, message, R.drawable.ic_error_outline_black_18dp);
+                }
+                items.clear();
+                getListAdapter().getWrappedAdapter().setItems(items.toArray());
+                retryButton.setVisibility(android.view.View.GONE);
+                showList();
+                return;
+            }
+
+            int errorMessage = getErrorMessage(exception);
+            if (!reputations.isEmpty()) {
+                showError(errorMessage);
+            }
+            showList();
+            return;
+        }
+
+        this.exception = null;
+        updateItems(reputations);
+    }
+
+    private String getForbiddenMessage(TestpressException exception) {
+        try {
+            String raw = exception.getErrorBodyString();
+            if (raw == null || raw.trim().isEmpty()) {
+                return null;
+            }
+            JSONObject json = new JSONObject(raw);
+            if (json.has("message")) {
+                return json.getString("message");
+            }
+            if (json.has("detail")) {
+                return json.getString("detail");
+            }
+        } catch (Exception ignore) {}
+        return null;
     }
 
     @Override


### PR DESCRIPTION
- Issue: Restricted (web-only) courses could still show Running/Upcoming/Leaderboard content, and the
  Learn screen could surface a misleading retry affordance after tab switching
- Cause: Access restriction was enforced by the chapters endpoint, while other tabs/endpoints could
  still return data or generic errors
-Fix: When Learn detects a 403 restriction, hide the entire tab UI and show a single Permission
Denied screen with the backend message. Keep pull-to-refresh enabled even when the list is empty
so users can refresh after access changes.
