### PR TITLE
feat: Add product offers display to product detail page

### DIFF
--- a/core/src/main/java/in/testpress/util/StringUtils.kt
+++ b/core/src/main/java/in/testpress/util/StringUtils.kt
@@ -8,6 +8,11 @@ object StringUtils{
     fun isNullOrEmpty(str: String?): Boolean {
         return str.isNullOrBlank()
     }
+
+    @JvmStatic
+    fun trimWhitespace(value: String?): String {
+        return value?.trim().orEmpty()
+    }
 }
 
 fun String.isEmailValid(): Boolean {

--- a/store/src/main/java/in/testpress/store/data/model/NetworkOffer.kt
+++ b/store/src/main/java/in/testpress/store/data/model/NetworkOffer.kt
@@ -1,0 +1,12 @@
+package `in`.testpress.store.data.model
+
+data class NetworkOffer(
+    val id: Int,
+    val name: String? = null,
+    val description: String? = null,
+    val offerPrice: String? = null,
+    val benefitType: String? = null,
+    val benefitValue: String? = null,
+    val endDatetime: String? = null,
+)
+

--- a/store/src/main/java/in/testpress/store/data/model/NetworkProductOffersResponse.kt
+++ b/store/src/main/java/in/testpress/store/data/model/NetworkProductOffersResponse.kt
@@ -1,0 +1,9 @@
+package `in`.testpress.store.data.model
+
+data class NetworkProductOffersResponse(
+    val hasDiscount: Boolean = false,
+    val finalPrice: String? = null,
+    val offers: List<Any> = emptyList(),
+    val appliedDiscountName: String? = null,
+)
+

--- a/store/src/main/java/in/testpress/store/data/model/NetworkProductOffersResponse.kt
+++ b/store/src/main/java/in/testpress/store/data/model/NetworkProductOffersResponse.kt
@@ -3,7 +3,7 @@ package `in`.testpress.store.data.model
 data class NetworkProductOffersResponse(
     val hasDiscount: Boolean = false,
     val finalPrice: String? = null,
-    val offers: List<Any> = emptyList(),
+    val offers: List<NetworkOffer> = emptyList(),
     val appliedDiscountName: String? = null,
 )
 

--- a/store/src/main/java/in/testpress/store/data/repository/ProductDetailRepository.kt
+++ b/store/src/main/java/in/testpress/store/data/repository/ProductDetailRepository.kt
@@ -12,11 +12,13 @@ import `in`.testpress.database.entities.DomainProduct
 import `in`.testpress.models.InstituteSettings
 import `in`.testpress.network.Resource
 import `in`.testpress.store.data.model.NetworkProduct
+import `in`.testpress.store.data.model.NetworkProductOffersResponse
 import `in`.testpress.store.data.model.toPriceEntities
 import `in`.testpress.store.data.model.toProductEntity
 import `in`.testpress.store.models.Order
 import `in`.testpress.store.models.OrderItem
 import `in`.testpress.store.network.StoreApiClient
+import `in`.testpress.enums.Status
 
 class ProductDetailRepository(context: Context, private val productId: Int) :
     BaseDetailRepository<NetworkProduct, DomainProduct>(context) {
@@ -29,8 +31,13 @@ class ProductDetailRepository(context: Context, private val productId: Int) :
     private val _couponStatus = MutableLiveData<Resource<Order>>()
     val couponStatus: LiveData<Resource<Order>> = _couponStatus
 
+    private val _appliedOffers = MutableLiveData<Resource<NetworkProductOffersResponse>>()
+    val appliedOffers: LiveData<Resource<NetworkProductOffersResponse>> = _appliedOffers
+
     private var session: TestpressSession? = TestpressSdk.getTestpressSession(context)
     private var settings: InstituteSettings? = session?.instituteSettings
+
+    private var offersFetchedForSlug: String? = null
 
     init {
         loadFromDatabase()
@@ -79,6 +86,30 @@ class ProductDetailRepository(context: Context, private val productId: Int) :
 
             override fun onException(exception: TestpressException) {
                 _couponStatus.postValue(Resource.error(exception, null))
+            }
+        })
+    }
+
+    fun getAppliedOffers(productSlug: String?) {
+        val safeSlug = productSlug?.trim().orEmpty()
+        if (safeSlug.isEmpty()) return
+
+        val current = _appliedOffers.value
+        if (safeSlug == offersFetchedForSlug &&
+            (current?.status == Status.LOADING || current?.status == Status.SUCCESS)
+        ) {
+            return
+        }
+
+        offersFetchedForSlug = safeSlug
+        _appliedOffers.postValue(Resource.loading(current?.data))
+        apiClient.getProductOffers(safeSlug).enqueue(object : TestpressCallback<NetworkProductOffersResponse>() {
+            override fun onSuccess(result: NetworkProductOffersResponse?) {
+                _appliedOffers.postValue(Resource.success(result))
+            }
+
+            override fun onException(exception: TestpressException) {
+                _appliedOffers.postValue(Resource.error(exception, current?.data))
             }
         })
     }

--- a/store/src/main/java/in/testpress/store/network/ProductService.java
+++ b/store/src/main/java/in/testpress/store/network/ProductService.java
@@ -8,6 +8,7 @@ import in.testpress.network.RetrofitCall;
 import in.testpress.store.data.model.NetworkProduct;
 import in.testpress.store.data.model.NetworkProductCategory;
 import in.testpress.store.data.model.NetworkProductListResponse;
+import in.testpress.store.data.model.NetworkProductOffersResponse;
 import in.testpress.store.models.NetworkHash;
 import in.testpress.store.models.NetworkOrderStatus;
 import in.testpress.store.models.Order;
@@ -83,6 +84,11 @@ public interface ProductService {
     @GET(V3_PRODUCT_PATH + "{product_id}")
     RetrofitCall<NetworkProduct> getProductDetailV3(
             @Path(value = "product_id", encoded = true) int productId
+    );
+
+    @GET("api/v2.4/products/{product_slug}/offers/")
+    RetrofitCall<NetworkProductOffersResponse> getProductOffers(
+            @Path(value = "product_slug", encoded = true) String productSlug
     );
 }
 

--- a/store/src/main/java/in/testpress/store/network/StoreApiClient.java
+++ b/store/src/main/java/in/testpress/store/network/StoreApiClient.java
@@ -11,6 +11,7 @@ import in.testpress.network.TestpressApiClient;
 import in.testpress.store.data.model.NetworkProduct;
 import in.testpress.store.data.model.NetworkProductCategory;
 import in.testpress.store.data.model.NetworkProductListResponse;
+import in.testpress.store.data.model.NetworkProductOffersResponse;
 import in.testpress.store.models.NetworkHash;
 import in.testpress.store.models.NetworkOrderStatus;
 import in.testpress.store.models.Order;
@@ -119,5 +120,9 @@ public class StoreApiClient extends TestpressApiClient {
 
     public RetrofitCall<NetworkProduct> getProductDetailV3(int productId) {
         return getProductService().getProductDetailV3(productId);
+    }
+
+    public RetrofitCall<NetworkProductOffersResponse> getProductOffers(String productSlug) {
+        return getProductService().getProductOffers(productSlug);
     }
 }

--- a/store/src/main/java/in/testpress/store/ui/ProductDetailFragment.kt
+++ b/store/src/main/java/in/testpress/store/ui/ProductDetailFragment.kt
@@ -27,12 +27,14 @@ import `in`.testpress.enums.Status
 import `in`.testpress.fragments.EmptyViewFragment
 import `in`.testpress.fragments.EmptyViewListener
 import `in`.testpress.store.TestpressStore
+import `in`.testpress.store.data.model.NetworkProductOffersResponse
 import `in`.testpress.store.data.model.mapping.asProduct
 import `in`.testpress.store.databinding.DialogProgressBinding
 import `in`.testpress.store.databinding.TestpressProductDetailsFragmentBinding
 import `in`.testpress.store.models.Order
 import `in`.testpress.store.ui.viewmodel.ProductViewModel
 import `in`.testpress.store.util.generateRandom10CharString
+import `in`.testpress.util.StringUtils
 import `in`.testpress.util.ImageUtils
 import `in`.testpress.util.UILImageGetter
 import `in`.testpress.util.ZoomableImageString
@@ -85,10 +87,12 @@ class ProductDetailFragment : Fragment(), EmptyViewListener {
             when (resource?.status) {
                 Status.LOADING ->{
                     this.domainProduct = resource.data
+                    productViewModel.getAppliedOffers(domainProduct?.product?.slug)
                     showLoadingState()
                 }
                 Status.SUCCESS ->{
                     this.domainProduct = resource.data
+                    productViewModel.getAppliedOffers(domainProduct?.product?.slug)
                     renderProductDetails()
                 }
                 Status.ERROR -> showErrorState(resource.exception)
@@ -125,6 +129,84 @@ class ProductDetailFragment : Fragment(), EmptyViewListener {
                 else -> Unit
             }
         }
+
+        productViewModel.offers.observe(viewLifecycleOwner) { resource ->
+            when (resource?.status) {
+                Status.SUCCESS -> updateOffersUi(resource.data)
+                Status.ERROR -> Unit
+                else -> Unit
+            }
+        }
+    }
+
+    private fun updateOffersUi(offers: NetworkProductOffersResponse?) {
+        if (!shouldRenderAppliedOffers(offers)) return
+
+        val product = domainProduct?.product ?: return
+        val originalPrice = product.price.orEmpty()
+        val finalPrice = StringUtils.trimWhitespace(offers?.finalPrice)
+
+        if (!hasDiscount(offers, finalPrice)) {
+            hideAppliedOfferName()
+            showOriginalPrice(originalPrice)
+            return
+        }
+
+        renderAppliedOfferName(StringUtils.trimWhitespace(offers?.appliedDiscountName))
+        renderDiscountedPrice(finalPrice, originalPrice)
+    }
+
+    private fun shouldRenderAppliedOffers(offers: NetworkProductOffersResponse?): Boolean {
+        return offers != null && order == null && !binding.couponAppliedText.isVisible
+    }
+
+    private fun hasDiscount(offers: NetworkProductOffersResponse?, finalPrice: String): Boolean {
+        return offers?.hasDiscount == true && finalPrice.isNotEmpty()
+    }
+
+    private fun showOriginalPrice(originalPrice: String) {
+        binding.detailLayout.price.text = originalPrice
+    }
+
+    private fun renderDiscountedPrice(finalPrice: String, originalPrice: String) {
+        if (originalPrice.isEmpty()) {
+            binding.detailLayout.price.text = finalPrice
+            return
+        }
+
+        val originalPriceStrikethrough = buildStrikethrough(originalPrice)
+        val finalText = SpannableStringBuilder()
+            .append(finalPrice)
+            .append("  ")
+            .append(originalPriceStrikethrough)
+        binding.detailLayout.price.text = finalText
+    }
+
+    private fun buildStrikethrough(text: String): SpannableString {
+        return SpannableString(text).apply {
+            setSpan(
+                StrikethroughSpan(),
+                0,
+                text.length,
+                Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
+            )
+        }
+    }
+
+    private fun renderAppliedOfferName(offerName: String) {
+        if (offerName.isEmpty()) {
+            hideAppliedOfferName()
+            return
+        }
+        binding.detailLayout.appliedDiscountName.text = getString(
+            `in`.testpress.store.R.string.testpress_offer_applied_name,
+            offerName
+        )
+        binding.detailLayout.appliedDiscountName.isVisible = true
+    }
+
+    private fun hideAppliedOfferName() {
+        binding.detailLayout.appliedDiscountName.isVisible = false
     }
 
     private fun showLoadingState() {
@@ -278,6 +360,7 @@ class ProductDetailFragment : Fragment(), EmptyViewListener {
 
     private fun updateApplyCouponUI(){
         updateCouponAppliedText(binding.couponInputEditText.text.toString(), order)
+        binding.detailLayout.appliedDiscountName.isVisible = false
         updatePriceDisplay()
         loadingDialog?.dismiss()
     }

--- a/store/src/main/java/in/testpress/store/ui/ProductDetailsActivity.java
+++ b/store/src/main/java/in/testpress/store/ui/ProductDetailsActivity.java
@@ -13,6 +13,7 @@ import android.text.SpannableString;
 import android.text.SpannableStringBuilder;
 import android.text.Spanned;
 import android.text.TextWatcher;
+import android.text.TextUtils;
 import android.text.method.LinkMovementMethod;
 import android.text.style.StrikethroughSpan;
 import android.view.View;
@@ -41,6 +42,7 @@ import in.testpress.core.TestpressSession;
 import in.testpress.exam.TestpressExam;
 import in.testpress.models.InstituteSettings;
 import in.testpress.store.R;
+import in.testpress.store.data.model.NetworkProductOffersResponse;
 import in.testpress.store.models.Order;
 import in.testpress.store.models.OrderItem;
 import in.testpress.store.models.Product;
@@ -51,6 +53,7 @@ import in.testpress.util.EventsTrackerFacade;
 import in.testpress.util.ImageUtils;
 import in.testpress.util.UILImageGetter;
 import in.testpress.util.UIUtils;
+import in.testpress.util.StringUtils;
 import in.testpress.util.ViewUtils;
 import in.testpress.util.ZoomableImageString;
 import io.sentry.Scope;
@@ -82,6 +85,7 @@ public class ProductDetailsActivity extends BaseToolBarActivity {
     private LinearLayout discountContainer;
     private TextView discountPrompt;
     private TextView couponAppliedText;
+    private TextView appliedDiscountNameText;
     private EditText couponEditText;
     private Button applyCouponButton;
 
@@ -111,6 +115,7 @@ public class ProductDetailsActivity extends BaseToolBarActivity {
         emptyDescView = (TextView) findViewById(R.id.empty_description);
         retryButton = (Button) findViewById(R.id.retry_button);
         couponAppliedText = (TextView) findViewById(R.id.coupon_applied_text);
+        appliedDiscountNameText = (TextView) findViewById(R.id.applied_discount_name);
         couponEditText = (EditText) findViewById(R.id.coupon);
         applyCouponButton = (Button) findViewById(R.id.apply_coupon);
         discountPrompt = findViewById(R.id.discount_prompt);
@@ -273,6 +278,9 @@ public class ProductDetailsActivity extends BaseToolBarActivity {
 
         // Price
         priceText.setText(product.getPrice());
+        if (appliedDiscountNameText != null) {
+            appliedDiscountNameText.setVisibility(View.GONE);
+        }
 
         // Update product description
         if(product.getDescription().isEmpty()) {
@@ -316,6 +324,88 @@ public class ProductDetailsActivity extends BaseToolBarActivity {
 
         ProductDetailsActivity.this.product = product;
         logEvent(EventsTrackerFacade.VIEWED_PRODUCT_EVENT);
+        getAppliedOffers();
+    }
+
+    private void getAppliedOffers() {
+        if (!hasValidProductSlug()) return;
+
+        apiClient.getProductOffers(getProductSlug()).enqueue(new TestpressCallback<NetworkProductOffersResponse>() {
+            @Override
+            public void onSuccess(NetworkProductOffersResponse result) {
+                updateOffersUi(result);
+            }
+
+            @Override
+            public void onException(TestpressException exception) {
+                // Ignore silently; PDP will continue showing the original price.
+            }
+        });
+    }
+
+    private void updateOffersUi(NetworkProductOffersResponse offers) {
+        if (!shouldRenderAppliedOffers(offers)) return;
+
+        String finalPrice = StringUtils.trimWhitespace(offers.getFinalPrice());
+        if (!offers.getHasDiscount() || finalPrice.isEmpty()) {
+            hideAppliedOfferName();
+            return;
+        }
+
+        renderDiscountedPrice(finalPrice, getOriginalPrice());
+        renderAppliedOfferName(StringUtils.trimWhitespace(offers.getAppliedDiscountName()));
+    }
+
+    private boolean shouldRenderAppliedOffers(NetworkProductOffersResponse offers) {
+        return offers != null && order == null && couponAppliedText.getVisibility() != View.VISIBLE;
+    }
+
+    private void renderDiscountedPrice(String finalPrice, String originalPrice) {
+        TextView priceText = findViewById(R.id.price);
+        if (originalPrice.isEmpty()) {
+            priceText.setText(finalPrice);
+            return;
+        }
+
+        SpannableString originalPriceStrikethrough = new SpannableString(originalPrice);
+        originalPriceStrikethrough.setSpan(
+                new StrikethroughSpan(),
+                0,
+                originalPrice.length(),
+                Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
+        );
+
+        SpannableStringBuilder finalText = new SpannableStringBuilder();
+        finalText.append(finalPrice).append("  ").append(originalPriceStrikethrough);
+        priceText.setText(finalText);
+    }
+
+    private void renderAppliedOfferName(String offerName) {
+        if (appliedDiscountNameText == null) return;
+        if (offerName.isEmpty()) {
+            hideAppliedOfferName();
+            return;
+        }
+        appliedDiscountNameText.setText(getString(R.string.testpress_offer_applied_name, offerName));
+        appliedDiscountNameText.setVisibility(View.VISIBLE);
+    }
+
+    private void hideAppliedOfferName() {
+        if (appliedDiscountNameText != null) {
+            appliedDiscountNameText.setVisibility(View.GONE);
+        }
+    }
+
+    private boolean hasValidProductSlug() {
+        return !TextUtils.isEmpty(getProductSlug());
+    }
+
+    private String getProductSlug() {
+        return product != null ? StringUtils.trimWhitespace(product.getSlug()) : "";
+    }
+
+    private String getOriginalPrice() {
+        return product != null ? StringUtils.trimWhitespace(product.getPrice()) : "";
     }
 
     void createOrder() {
@@ -412,6 +502,9 @@ public class ProductDetailsActivity extends BaseToolBarActivity {
 
     private void updatePriceDisplay(Order createdOrder) {
         TextView priceText = findViewById(R.id.price);
+        if (appliedDiscountNameText != null) {
+            appliedDiscountNameText.setVisibility(View.GONE);
+        }
         String newPrice = createdOrder.getOrderItems().get(0).getPrice();
         String oldPrice = product.getPrice();
 

--- a/store/src/main/java/in/testpress/store/ui/viewmodel/ProductViewModel.kt
+++ b/store/src/main/java/in/testpress/store/ui/viewmodel/ProductViewModel.kt
@@ -14,6 +14,7 @@ class ProductViewModel(private val repository: ProductDetailRepository) : ViewMo
     val product = repository.resource
     val order = repository.orderStatus
     val coupon = repository.couponStatus
+    val offers = repository.appliedOffers
 
     fun refresh() {
         repository.loadFromDatabase()
@@ -33,6 +34,10 @@ class ProductViewModel(private val repository: ProductDetailRepository) : ViewMo
 
     fun applyCoupon(orderId: Long, couponString: String){
         repository.applyCoupon(orderId, couponString)
+    }
+
+    fun getAppliedOffers(productSlug: String?) {
+        repository.getAppliedOffers(productSlug)
     }
 
     private fun createOrderItem(product: DomainProduct): OrderItem {

--- a/store/src/main/res/layout/testpress_product_details_content_scrolling.xml
+++ b/store/src/main/res/layout/testpress_product_details_content_scrolling.xml
@@ -57,6 +57,20 @@
                 android:textAppearance="@style/TextAppearance.AppCompat.Small"
                 android:textColor="#212121" />
 
+            <TextView
+                android:id="@+id/applied_discount_name"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_below="@id/price"
+                android:layout_marginTop="4dp"
+                android:layout_marginStart="@dimen/testpress_horizontal_margin"
+                android:layout_marginLeft="@dimen/testpress_horizontal_margin"
+                android:layout_toEndOf="@id/price_icon"
+                android:layout_toRightOf="@id/price_icon"
+                android:textColor="@color/testpress_text_gray"
+                android:textSize="12sp"
+                android:visibility="gone" />
+
         </RelativeLayout>
 
         <RelativeLayout

--- a/store/src/main/res/values/strings.xml
+++ b/store/src/main/res/values/strings.xml
@@ -68,5 +68,6 @@
     <string name="retry">Retry</string>
     <string name="buy_now_button_text">Buy Now</string>
     <string name="product_thumbnail_description">Product thumbnail image</string>
+    <string name="testpress_offer_applied_name">Offer applied: %1$s</string>
 
 </resources>


### PR DESCRIPTION
- Integrates the new product offers API endpoint (/api/v2.4/products/<slug>/offers/) ) to fetch dynamic pricing and applied discount names for products
- Updates the product detail view to display the final price after offers and show the name of the applied discount
- Implements in-memory data handling in the ViewModel and Repository to manage offer information without requiring database changes
- Enhances visual feedback by dynamically showing the applied offer name and updating the price display when offers are available