### PR TITLE
feat: Implement pre-exam mindset reflection as WebView

### DIFF
--- a/core/src/main/java/in/testpress/fragments/WebViewFragment.kt
+++ b/core/src/main/java/in/testpress/fragments/WebViewFragment.kt
@@ -84,7 +84,10 @@ class WebViewFragment : Fragment(), EmptyViewListener {
             arguments?.getBoolean(ALLOW_NON_INSTITUTE_URL_IN_WEB_VIEW) ?: false
         allowZoomControl = arguments?.getBoolean(ALLOW_ZOOM_CONTROLS) ?: false
         enableSwipeRefresh = arguments?.getBoolean(ENABLE_SWIPE_REFRESH) ?: false
+        allowValidationErrors = arguments?.getBoolean("allow_validation_errors", false) ?: false
     }
+
+    private var allowValidationErrors = false
 
     private fun initializedSwipeRefresh(){
         layout.swipeRefreshLayout.isEnabled = enableSwipeRefresh
@@ -165,6 +168,14 @@ class WebViewFragment : Fragment(), EmptyViewListener {
     fun showErrorView(exception: TestpressException) {
         hideWebViewShowEmptyView()
         emptyViewFragment.displayError(exception)
+    }
+
+    open fun shouldShowHttpError(statusCode: Int): Boolean {
+        // Allow 400 for validation errors if configured
+        if (statusCode == 400 && allowValidationErrors) {
+            return false
+        }
+        return true
     }
 
     fun hideEmptyViewShowWebView() {

--- a/core/src/main/java/in/testpress/fragments/WebViewFragment.kt
+++ b/core/src/main/java/in/testpress/fragments/WebViewFragment.kt
@@ -84,7 +84,7 @@ class WebViewFragment : Fragment(), EmptyViewListener {
             arguments?.getBoolean(ALLOW_NON_INSTITUTE_URL_IN_WEB_VIEW) ?: false
         allowZoomControl = arguments?.getBoolean(ALLOW_ZOOM_CONTROLS) ?: false
         enableSwipeRefresh = arguments?.getBoolean(ENABLE_SWIPE_REFRESH) ?: false
-        allowValidationErrors = arguments?.getBoolean("allow_validation_errors", false) ?: false
+        allowValidationErrors = arguments?.getBoolean(ALLOW_VALIDATION_ERRORS, false) ?: false
     }
 
     private var allowValidationErrors = false
@@ -233,6 +233,7 @@ class WebViewFragment : Fragment(), EmptyViewListener {
         const val ALLOW_NON_INSTITUTE_URL_IN_WEB_VIEW = "ALLOW_NON_INSTITUTE_URL_IN_WEB_VIEW"
         const val ALLOW_ZOOM_CONTROLS = "ALLOW_ZOOM_CONTROLS"
         const val ENABLE_SWIPE_REFRESH = "ENABLE_SWIPE_REFRESH"
+        const val ALLOW_VALIDATION_ERRORS = "ALLOW_VALIDATION_ERRORS"
     }
 
 }

--- a/core/src/main/java/in/testpress/ui/AbstractWebViewActivity.kt
+++ b/core/src/main/java/in/testpress/ui/AbstractWebViewActivity.kt
@@ -57,7 +57,7 @@ abstract class AbstractWebViewActivity: BaseToolBarActivity(), WebViewFragment.L
             this.putString(WebViewFragment.URL_TO_OPEN, urlPath)
             this.putBoolean(WebViewFragment.IS_AUTHENTICATION_REQUIRED, isAuthenticationRequired)
             this.putBoolean(WebViewFragment.ALLOW_NON_INSTITUTE_URL_IN_WEB_VIEW, allowNonInstituteUrl)
-            this.putBoolean("allow_validation_errors", allowValidationErrors)
+            this.putBoolean(ALLOW_VALIDATION_ERRORS, allowValidationErrors)
         }
     }
 
@@ -68,7 +68,7 @@ abstract class AbstractWebViewActivity: BaseToolBarActivity(), WebViewFragment.L
         const val URL_TO_OPEN = "URL"
         const val IS_AUTHENTICATION_REQUIRED = "IS_AUTHENTICATION_REQUIRED"
         const val ALLOW_NON_INSTITUTE_URL_IN_WEB_VIEW = "ALLOW_NON_INSTITUTE_URL_IN_WEB_VIEW"
-        const val ALLOW_VALIDATION_ERRORS = "allow_validation_errors"
+        const val ALLOW_VALIDATION_ERRORS = "ALLOW_VALIDATION_ERRORS"
 
         fun createIntent(
             currentContext: Context,

--- a/core/src/main/java/in/testpress/ui/AbstractWebViewActivity.kt
+++ b/core/src/main/java/in/testpress/ui/AbstractWebViewActivity.kt
@@ -11,11 +11,12 @@ abstract class AbstractWebViewActivity: BaseToolBarActivity(), WebViewFragment.L
 
     private var _layout: BaseTestpressWebviewContainerLayoutBinding? = null
     private val layout: BaseTestpressWebviewContainerLayoutBinding get() = _layout!!
-    protected lateinit var webViewFragment: WebViewFragment
+    open lateinit var webViewFragment: WebViewFragment
     private lateinit var title: String
-    private lateinit var urlPath: String
+    open lateinit var urlPath: String
     private var isAuthenticationRequired: Boolean = true
     private var allowNonInstituteUrl: Boolean = false
+    private var allowValidationErrors: Boolean = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -39,9 +40,10 @@ abstract class AbstractWebViewActivity: BaseToolBarActivity(), WebViewFragment.L
         urlPath = intent.getStringExtra(URL_TO_OPEN)!!
         isAuthenticationRequired = intent.getBooleanExtra(IS_AUTHENTICATION_REQUIRED,true)
         allowNonInstituteUrl = intent.getBooleanExtra(ALLOW_NON_INSTITUTE_URL_IN_WEB_VIEW, false)
+        allowValidationErrors = intent.getBooleanExtra(ALLOW_VALIDATION_ERRORS, false)
     }
 
-    private fun initializeWebViewFragment() {
+    open fun initializeWebViewFragment() {
         webViewFragment = WebViewFragment()
         webViewFragment.arguments = getWebViewArguments()
         webViewFragment.setListener(this)
@@ -55,6 +57,7 @@ abstract class AbstractWebViewActivity: BaseToolBarActivity(), WebViewFragment.L
             this.putString(WebViewFragment.URL_TO_OPEN, urlPath)
             this.putBoolean(WebViewFragment.IS_AUTHENTICATION_REQUIRED, isAuthenticationRequired)
             this.putBoolean(WebViewFragment.ALLOW_NON_INSTITUTE_URL_IN_WEB_VIEW, allowNonInstituteUrl)
+            this.putBoolean("allow_validation_errors", allowValidationErrors)
         }
     }
 
@@ -65,6 +68,7 @@ abstract class AbstractWebViewActivity: BaseToolBarActivity(), WebViewFragment.L
         const val URL_TO_OPEN = "URL"
         const val IS_AUTHENTICATION_REQUIRED = "IS_AUTHENTICATION_REQUIRED"
         const val ALLOW_NON_INSTITUTE_URL_IN_WEB_VIEW = "ALLOW_NON_INSTITUTE_URL_IN_WEB_VIEW"
+        const val ALLOW_VALIDATION_ERRORS = "allow_validation_errors"
 
         fun createIntent(
             currentContext: Context,

--- a/core/src/main/java/in/testpress/util/webview/CustomWebViewClient.kt
+++ b/core/src/main/java/in/testpress/util/webview/CustomWebViewClient.kt
@@ -75,9 +75,11 @@ class CustomWebViewClient(val fragment: WebViewFragment) : AndroidWebViewClient(
             val currentWebViewUrl = fragment.webView.url.toString()
             if (requestUrl == currentWebViewUrl) {
                 val statusCode = error.value?.statusCode ?: -1
-                val reasonPhrase = error.value?.reasonPhrase ?: "Unknown Error"
-                val httpError = TestpressException.httpError(statusCode, reasonPhrase)
-                fragment.showErrorView(httpError)
+                if (fragment.shouldShowHttpError(statusCode)) {
+                    val reasonPhrase = error.value?.reasonPhrase ?: "Unknown Error"
+                    val httpError = TestpressException.httpError(statusCode, reasonPhrase)
+                    fragment.showErrorView(httpError)
+                }
                 errorList.clear()
             }
         }

--- a/course/src/main/java/in/testpress/course/fragments/BaseExamWidgetFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/BaseExamWidgetFragment.kt
@@ -26,9 +26,11 @@ import `in`.testpress.database.mapping.createGreenDoaModel
 import `in`.testpress.exam.TestpressExam
 import `in`.testpress.exam.api.TestpressExamApiClient
 import `in`.testpress.exam.domain.ExamTemplateType.CTET_TEMPLATE
+import `in`.testpress.exam.ui.PreExamReflectionActivity
 import `in`.testpress.exam.util.MultiLanguagesUtil
 import `in`.testpress.exam.util.RetakeExamUtil
 import `in`.testpress.models.greendao.Attempt
+import android.app.Activity
 import android.content.Context
 import android.content.DialogInterface
 import android.content.Intent
@@ -37,6 +39,7 @@ import android.view.View
 import android.widget.Button
 import android.widget.TextView
 import android.widget.Toast
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AlertDialog
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
@@ -66,6 +69,16 @@ open class BaseExamWidgetFragment : Fragment() {
     var offlineAttemptSectionList: List<OfflineAttemptSection>? = null
     private var isOfflineExamSupportEnables = false
     var offlineAttemptUploaded = false
+    private var reflectionCompleted = false
+    private val preExamReflectionLauncher = registerForActivityResult(
+        ActivityResultContracts.StartActivityForResult()
+    ) { result ->
+        if (result.resultCode == Activity.RESULT_OK) {
+            reflectionCompleted = true
+            val exam = content.exam ?: return@registerForActivityResult
+            showExamModesOrStartExam(exam, shouldShowExamDetails(exam), isPartial = false)
+        }
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -400,7 +413,11 @@ open class BaseExamWidgetFragment : Fragment() {
             startButton.setOnClickListener {startExamInWebview(content)}
         } else if (contentAttempts.isEmpty()) {
             MultiLanguagesUtil.supportMultiLanguage(requireActivity(), exam.asGreenDaoModel(), startButton) {
-                showExamModesOrStartExam(exam, shouldShowExamDetails(exam), isPartial = false)
+                if (shouldShowPreExamReflection(exam)) {
+                    openPreExamReflection(exam)
+                } else {
+                    showExamModesOrStartExam(exam, shouldShowExamDetails(exam), isPartial = false)
+                }
             }
         } else {
             startButton.setOnClickListener {
@@ -416,6 +433,22 @@ open class BaseExamWidgetFragment : Fragment() {
         // display the Exam Detail page. Otherwise, we return true to start the exam without
         // displaying the Exam Detail page.
         return !(exam.isAttemptResumeDisabled() || exam.isWindowMonitoringEnabled())
+    }
+
+    private fun shouldShowPreExamReflection(exam: DomainExamContent): Boolean {
+        if (reflectionCompleted) return false
+        if (exam.isOfflineExam) return false
+        return exam.enableMindsetReflections == true && exam.preExamReflectionForm != null
+    }
+
+    private fun openPreExamReflection(exam: DomainExamContent) {
+        val form = exam.preExamReflectionForm ?: return
+        val session = TestpressSdk.getTestpressSession(requireContext()) ?: return
+        val baseUrl = session.instituteSettings.baseUrl
+        val intent = PreExamReflectionActivity.createIntent(
+            requireContext(), baseUrl, exam.id, form.id, form.submissionMandatory ?: false
+        )
+        preExamReflectionLauncher.launch(intent)
     }
 
     private fun showExamModesOrStartExam(

--- a/exam/src/main/AndroidManifest.xml
+++ b/exam/src/main/AndroidManifest.xml
@@ -93,6 +93,11 @@
             android:label="@string/testpress_share"
             android:theme="@style/TestpressTheme"
             android:configChanges="orientation|keyboard|screenSize" />
+
+        <activity android:name=".ui.PreExamReflectionActivity"
+            android:theme="@style/TestpressTheme"
+            android:configChanges="orientation|screenSize"
+            android:windowSoftInputMode="adjustResize" />
     </application>
 
 </manifest>

--- a/exam/src/main/java/in/testpress/exam/ui/PreExamReflectionActivity.kt
+++ b/exam/src/main/java/in/testpress/exam/ui/PreExamReflectionActivity.kt
@@ -52,7 +52,10 @@ class PreExamReflectionActivity : AbstractWebViewActivity() {
                     return
                 }
                 val nextUrl = Uri.encode(urlPath)
-                urlPath = "${session.instituteSettings.baseUrl}$ssoUrl&next=$nextUrl"
+                val separator = if (ssoUrl.contains("?")) "&" else "?"
+                val cleanBaseUrl = session.instituteSettings.baseUrl.trimEnd('/')
+                val cleanSsoUrl = if (ssoUrl.startsWith("/")) ssoUrl else "/$ssoUrl"
+                urlPath = "$cleanBaseUrl$cleanSsoUrl$separator&next=$nextUrl"
                 isSsoUrlFetched = true
                 initializeWebViewFragment()
             }
@@ -103,22 +106,12 @@ class PreExamReflectionActivity : AbstractWebViewActivity() {
             webViewFragment.goBack()
             return
         }
-        if (isMandatory) {
-            Toast.makeText(
-                this,
-                "Please complete the reflection before starting the exam.",
-                Toast.LENGTH_SHORT
-            ).show()
-        } else {
-            setResult(Activity.RESULT_CANCELED)
-            finish()
-        }
+        setResult(Activity.RESULT_CANCELED)
+        finish()
     }
 
     companion object {
         const val IS_MANDATORY = "IS_MANDATORY"
-        const val ALLOW_VALIDATION_ERRORS = "allow_validation_errors"
-        const val REQUEST_CODE = 1001
         const val RESULT_ACTION = "RESULT_ACTION"
         const val ACTION_SUBMITTED = "ACTION_SUBMITTED"
         const val ACTION_SKIPPED = "ACTION_SKIPPED"

--- a/exam/src/main/java/in/testpress/exam/ui/PreExamReflectionActivity.kt
+++ b/exam/src/main/java/in/testpress/exam/ui/PreExamReflectionActivity.kt
@@ -1,0 +1,159 @@
+package `in`.testpress.exam.ui
+
+import `in`.testpress.core.TestpressCallback
+import `in`.testpress.core.TestpressException
+import `in`.testpress.core.TestpressSdk
+import `in`.testpress.models.SSOUrl
+import `in`.testpress.network.TestpressApiClient
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.webkit.JavascriptInterface
+import android.widget.Toast
+import `in`.testpress.ui.AbstractWebViewActivity
+import `in`.testpress.util.BaseJavaScriptInterface
+
+class PreExamReflectionActivity : AbstractWebViewActivity() {
+
+    private var isMandatory = false
+    private var isSsoUrlFetched = false
+    private var isWebViewFragmentInitialized = false
+    private var allowValidationErrors = false
+
+    override fun onCreate(savedInstanceState: android.os.Bundle?) {
+        super.onCreate(savedInstanceState)
+        isMandatory = intent.getBooleanExtra(IS_MANDATORY, false)
+        allowValidationErrors = intent.getBooleanExtra(ALLOW_VALIDATION_ERRORS, false)
+        fetchSsoLink()
+    }
+
+    override fun initializeWebViewFragment() {
+        if (isSsoUrlFetched) {
+            isWebViewFragmentInitialized = true
+            super.initializeWebViewFragment()
+        }
+    }
+
+    private fun fetchSsoLink() {
+        val session = TestpressSdk.getTestpressSession(this)
+        if (session == null) {
+            isSsoUrlFetched = true
+            initializeWebViewFragment()
+            return
+        }
+
+        TestpressApiClient(this, session).ssourl.enqueue(object : TestpressCallback<SSOUrl>() {
+            override fun onSuccess(result: SSOUrl?) {
+                val ssoUrl = result?.ssoUrl
+                if (ssoUrl.isNullOrBlank()) {
+                    isSsoUrlFetched = true
+                    initializeWebViewFragment()
+                    return
+                }
+                val nextUrl = Uri.encode(urlPath)
+                urlPath = "${session.instituteSettings.baseUrl}$ssoUrl&next=$nextUrl"
+                isSsoUrlFetched = true
+                initializeWebViewFragment()
+            }
+
+            override fun onException(exception: TestpressException?) {
+                isSsoUrlFetched = true
+                initializeWebViewFragment()
+            }
+        })
+    }
+
+    override fun onWebViewInitializationSuccess() {
+        webViewFragment.addJavascriptInterface(
+            ReflectionJsInterface(this), "AndroidInterface"
+        )
+    }
+
+    fun onReflectionSubmitted() {
+        runOnUiThread {
+            setResult(
+                Activity.RESULT_OK,
+                Intent().putExtra(RESULT_ACTION, ACTION_SUBMITTED)
+            )
+            finish()
+        }
+    }
+
+    fun onReflectionSkipped() {
+        runOnUiThread {
+            if (isMandatory) {
+                Toast.makeText(
+                    this,
+                    "Please complete the reflection before starting the exam.",
+                    Toast.LENGTH_SHORT
+                ).show()
+            } else {
+                setResult(
+                    Activity.RESULT_OK,
+                    Intent().putExtra(RESULT_ACTION, ACTION_SKIPPED)
+                )
+                finish()
+            }
+        }
+    }
+
+    override fun onBackPressed() {
+        if (isWebViewFragmentInitialized && webViewFragment.canGoBack()) {
+            webViewFragment.goBack()
+            return
+        }
+        if (isMandatory) {
+            Toast.makeText(
+                this,
+                "Please complete the reflection before starting the exam.",
+                Toast.LENGTH_SHORT
+            ).show()
+        } else {
+            setResult(Activity.RESULT_CANCELED)
+            finish()
+        }
+    }
+
+    companion object {
+        const val IS_MANDATORY = "IS_MANDATORY"
+        const val ALLOW_VALIDATION_ERRORS = "allow_validation_errors"
+        const val REQUEST_CODE = 1001
+        const val RESULT_ACTION = "RESULT_ACTION"
+        const val ACTION_SUBMITTED = "ACTION_SUBMITTED"
+        const val ACTION_SKIPPED = "ACTION_SKIPPED"
+
+        @JvmStatic
+        fun createIntent(
+            context: Context,
+            baseUrl: String,
+            examId: Long,
+            formId: Long,
+            isMandatory: Boolean
+        ): Intent {
+            val cleanBaseUrl = baseUrl.trimEnd('/')
+            val url = "$cleanBaseUrl/exam-mindset/$examId/reflection/$formId/"
+            return AbstractWebViewActivity.createIntent(
+                context,
+                title = "",
+                urlPath = url,
+                isAuthenticationRequired = true,
+                activityToOpen = PreExamReflectionActivity::class.java
+            ).apply {
+                putExtra(IS_MANDATORY, isMandatory)
+                putExtra(ALLOW_VALIDATION_ERRORS, true)
+            }
+        }
+    }
+}
+
+class ReflectionJsInterface(
+    private val activity: PreExamReflectionActivity
+) : BaseJavaScriptInterface(activity) {
+
+    @JavascriptInterface
+    fun onReflectionSubmitted() = activity.onReflectionSubmitted()
+
+    @JavascriptInterface
+    fun onReflectionSkipped() = activity.onReflectionSkipped()
+}

--- a/exam/src/main/java/in/testpress/exam/ui/TestActivity.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestActivity.java
@@ -40,6 +40,7 @@ import in.testpress.exam.models.Permission;
 import in.testpress.exam.api.TestpressExamApiClient;
 import in.testpress.exam.ui.viewmodel.ExamViewModel;
 import in.testpress.exam.util.MultiLanguagesUtil;
+import in.testpress.models.ReflectionForm;
 import in.testpress.models.TestpressApiResponse;
 import in.testpress.models.greendao.Attempt;
 import in.testpress.models.greendao.Content;
@@ -103,6 +104,8 @@ public class TestActivity extends BaseToolBarActivity  {
     private RetrofitCall<TestpressApiResponse<Attempt>> attemptsApiRequest;
     private RetrofitCall<ApiResponse<List<Language>>> languagesApiRequest;
     private ExamViewModel examViewModel;
+    private boolean reflectionCompleted = false;
+    private static final int REFLECTION_REQUEST_CODE = 1001;
 
     @Override
     protected void onCreate(final Bundle savedInstanceState) {
@@ -652,6 +655,11 @@ public class TestActivity extends BaseToolBarActivity  {
     }
 
     private void showWarningAlertOrStartExam() {
+        if (shouldShowPreExamReflection()) {
+            openPreExamReflection();
+            return;
+        }
+
         boolean isResumeDisabled = exam.isAttemptResumeDisabled();
         boolean isWindowMonitoringEnabled = exam.isWindowMonitoringEnabled();
 
@@ -803,12 +811,40 @@ public class TestActivity extends BaseToolBarActivity  {
 
     @Override
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
+        if (requestCode == REFLECTION_REQUEST_CODE) {
+            if (resultCode == Activity.RESULT_OK) {
+                reflectionCompleted = true;
+                showWarningAlertOrStartExam();
+            }
+            return;
+        }
         if ((requestCode == CarouselFragment.TEST_TAKEN_REQUEST_CODE) && (Activity.RESULT_OK == resultCode)) {
             setResult(resultCode);
             finish();
         } else {
             super.onActivityResult(requestCode, resultCode, data);
         }
+    }
+
+    private boolean shouldShowPreExamReflection() {
+        if (reflectionCompleted) return false;
+        if (attempt != null) return false;
+        if (isOfflineExam()) return false;
+        if (exam.getPreExamReflectionForm() == null) return false;
+        return Boolean.TRUE.equals(exam.getEnableMindsetReflections());
+    }
+
+    private void openPreExamReflection() {
+        ReflectionForm form = exam.getPreExamReflectionForm();
+        TestpressSession session = TestpressSdk.getTestpressSession(this);
+        if (session == null) {
+            Toast.makeText(this, "Session is null. Please login again.", Toast.LENGTH_SHORT).show();
+            return;
+        }
+        String baseUrl = session.getInstituteSettings().getBaseUrl();
+        Intent intent = PreExamReflectionActivity.createIntent(
+                this, baseUrl, exam.getId(), form.getId(), form.getSubmissionMandatory() != null && form.getSubmissionMandatory());
+        startActivityForResult(intent, REFLECTION_REQUEST_CODE);
     }
 
     void handleError(TestpressException exception, @StringRes int errorMessage) {


### PR DESCRIPTION
- Intercept exam start action in TestActivity and BaseExamWidgetFragment to show reflection form via WebView if enabled
- Add PreExamReflectionActivity to host the reflection form with SSO authentication for seamless access
- Implement a JavaScript bridge to handle form submission and skipping events from the web-based form
- Update WebViewFragment to support suppressing native error views for form validation errors (HTTP 400/422)
- Refactor AbstractWebViewActivity to allow delayed initialization for SSO-based WebView loads