### PR TITLE
feat: Add Mindset Insights button to post-exam review screen

### DIFF
--- a/core/src/main/java/in/testpress/fragments/WebViewFragment.kt
+++ b/core/src/main/java/in/testpress/fragments/WebViewFragment.kt
@@ -85,9 +85,12 @@ class WebViewFragment : Fragment(), EmptyViewListener {
         allowZoomControl = arguments?.getBoolean(ALLOW_ZOOM_CONTROLS) ?: false
         enableSwipeRefresh = arguments?.getBoolean(ENABLE_SWIPE_REFRESH) ?: false
         allowValidationErrors = arguments?.getBoolean(ALLOW_VALIDATION_ERRORS, false) ?: false
+        cacheMode = arguments?.getInt(CACHE_MODE, WebSettings.LOAD_CACHE_ELSE_NETWORK)
+            ?: WebSettings.LOAD_CACHE_ELSE_NETWORK
     }
 
     private var allowValidationErrors = false
+    private var cacheMode: Int = WebSettings.LOAD_CACHE_ELSE_NETWORK
 
     private fun initializedSwipeRefresh(){
         layout.swipeRefreshLayout.isEnabled = enableSwipeRefresh
@@ -115,7 +118,7 @@ class WebViewFragment : Fragment(), EmptyViewListener {
         webView.settings.domStorageEnabled = true
         // Disable pinch to zoom without the zoom buttons
         webView.settings.builtInZoomControls = false
-        webView.settings.cacheMode = WebSettings.LOAD_CACHE_ELSE_NETWORK
+        webView.settings.cacheMode = cacheMode
         webView.settings.setSupportZoom(allowZoomControl)
         webView.webViewClient = CustomWebViewClient(this)
         webView.webChromeClient = CustomWebChromeClient(this)
@@ -234,6 +237,7 @@ class WebViewFragment : Fragment(), EmptyViewListener {
         const val ALLOW_ZOOM_CONTROLS = "ALLOW_ZOOM_CONTROLS"
         const val ENABLE_SWIPE_REFRESH = "ENABLE_SWIPE_REFRESH"
         const val ALLOW_VALIDATION_ERRORS = "ALLOW_VALIDATION_ERRORS"
+        const val CACHE_MODE = "CACHE_MODE"
     }
 
 }

--- a/exam/src/main/AndroidManifest.xml
+++ b/exam/src/main/AndroidManifest.xml
@@ -98,6 +98,11 @@
             android:theme="@style/TestpressTheme"
             android:configChanges="orientation|screenSize"
             android:windowSoftInputMode="adjustResize" />
+
+        <activity android:name=".ui.MindsetInsightsActivity"
+            android:label="@string/testpress_mindset_insights"
+            android:theme="@style/TestpressTheme"
+            android:configChanges="orientation|screenSize" />
     </application>
 
 </manifest>

--- a/exam/src/main/java/in/testpress/exam/ui/MindsetInsightsActivity.kt
+++ b/exam/src/main/java/in/testpress/exam/ui/MindsetInsightsActivity.kt
@@ -56,7 +56,7 @@ class MindsetInsightsActivity : AbstractWebViewActivity() {
                 val separator = if (ssoUrl.contains("?")) "&" else "?"
                 val cleanBaseUrl = session.instituteSettings.baseUrl.trimEnd('/')
                 val cleanSsoUrl = if (ssoUrl.startsWith("/")) ssoUrl else "/$ssoUrl"
-                urlPath = "$cleanBaseUrl$cleanSsoUrl$separator&next=$nextUrl"
+                urlPath = "$cleanBaseUrl$cleanSsoUrl${separator}next=$nextUrl"
                 isSsoUrlFetched = true
                 initializeWebViewFragment()
             }

--- a/exam/src/main/java/in/testpress/exam/ui/MindsetInsightsActivity.kt
+++ b/exam/src/main/java/in/testpress/exam/ui/MindsetInsightsActivity.kt
@@ -1,0 +1,93 @@
+package `in`.testpress.exam.ui
+
+import `in`.testpress.core.TestpressCallback
+import `in`.testpress.core.TestpressException
+import `in`.testpress.core.TestpressSdk
+import `in`.testpress.models.SSOUrl
+import `in`.testpress.network.TestpressApiClient
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.webkit.WebSettings
+import `in`.testpress.ui.AbstractWebViewActivity
+import `in`.testpress.fragments.WebViewFragment
+import `in`.testpress.R
+
+class MindsetInsightsActivity : AbstractWebViewActivity() {
+
+    private var isSsoUrlFetched = false
+
+    override fun onCreate(savedInstanceState: android.os.Bundle?) {
+        super.onCreate(savedInstanceState)
+        fetchSsoLink()
+    }
+
+    override fun initializeWebViewFragment() {
+        if (!isSsoUrlFetched) return
+        webViewFragment = WebViewFragment()      
+        webViewFragment.arguments = android.os.Bundle().apply {
+            putString(WebViewFragment.URL_TO_OPEN, urlPath)
+            putBoolean(WebViewFragment.IS_AUTHENTICATION_REQUIRED, true)
+            putInt(WebViewFragment.CACHE_MODE, WebSettings.LOAD_NO_CACHE)
+        }
+        webViewFragment.setListener(this)
+        supportFragmentManager.beginTransaction()
+            .replace(R.id.fragment_container, webViewFragment)
+            .commitAllowingStateLoss()
+    }
+
+    private fun fetchSsoLink() {
+        val session = TestpressSdk.getTestpressSession(this)
+        if (session == null) {
+            isSsoUrlFetched = true
+            initializeWebViewFragment()
+            return
+        }
+
+        TestpressApiClient(this, session).ssourl.enqueue(object : TestpressCallback<SSOUrl>() {
+            override fun onSuccess(result: SSOUrl?) {
+                val ssoUrl = result?.ssoUrl
+                if (ssoUrl.isNullOrBlank()) {
+                    isSsoUrlFetched = true
+                    initializeWebViewFragment()
+                    return
+                }
+                val nextUrl = Uri.encode(urlPath)
+                val separator = if (ssoUrl.contains("?")) "&" else "?"
+                val cleanBaseUrl = session.instituteSettings.baseUrl.trimEnd('/')
+                val cleanSsoUrl = if (ssoUrl.startsWith("/")) ssoUrl else "/$ssoUrl"
+                urlPath = "$cleanBaseUrl$cleanSsoUrl$separator&next=$nextUrl"
+                isSsoUrlFetched = true
+                initializeWebViewFragment()
+            }
+
+            override fun onException(exception: TestpressException?) {
+                isSsoUrlFetched = true
+                initializeWebViewFragment()
+            }
+        })
+    }
+
+    override fun onWebViewInitializationSuccess() {
+        // No additional setup needed for this read-only insights page.
+    }
+
+    companion object {
+        @JvmStatic
+        fun createIntent(
+            context: Context,
+            baseUrl: String,
+            userExamId: Long
+        ): Intent {
+            val cleanBaseUrl = baseUrl.trimEnd('/')
+            val url = "$cleanBaseUrl/exams/review/$userExamId/mindset_insights/"
+            return AbstractWebViewActivity.createIntent(
+                context,
+                title = "",
+                urlPath = url,
+                isAuthenticationRequired = true,
+                activityToOpen = MindsetInsightsActivity::class.java
+            )
+        }
+    }
+}

--- a/exam/src/main/java/in/testpress/exam/ui/ReviewStatsFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/ReviewStatsFragment.java
@@ -100,6 +100,8 @@ public class ReviewStatsFragment extends BaseFragment {
     private TextView analyticsButton;
     private TextView advancedAnalyticsButton;
     private LinearLayout advancedAnalyticsLayout;
+    private TextView mindsetInsightsButton;
+    private LinearLayout mindsetInsightsLayout;
     private TextView retakeButton;
     private LinearLayout retakeButtonLayout;
     private LinearLayout timeAnalyticsButtonLayout;
@@ -200,6 +202,8 @@ public class ReviewStatsFragment extends BaseFragment {
         analyticsButton = (TextView) view.findViewById(R.id.analytics);
         advancedAnalyticsButton = (TextView) view.findViewById(R.id.advanced_analytics);
         advancedAnalyticsLayout = (LinearLayout) view.findViewById(R.id.advanced_analytics_layout);
+        mindsetInsightsButton = (TextView) view.findViewById(R.id.mindset_insights);
+        mindsetInsightsLayout = (LinearLayout) view.findViewById(R.id.mindset_insights_layout);
         retakeButton = (TextView) view.findViewById(R.id.retake);
         emailPdfButton = (TextView) view.findViewById(R.id.email_mcqs);
         retakeButtonLayout = (LinearLayout) view.findViewById(R.id.retake_button_layout);
@@ -280,6 +284,7 @@ public class ReviewStatsFragment extends BaseFragment {
         showOrHideReviewQuestionButton();
         showOrHideAnalyticsButton();
         showOrHideAdvancedAnalyticsButton();
+        showOrHideMindsetInsightsButton();
         showOrHideEmailPDFButton();
         showOrHideRetakButton();
         setTotalMarks();
@@ -415,6 +420,25 @@ public class ReviewStatsFragment extends BaseFragment {
                 }
             });
         }
+    }
+
+    private void showOrHideMindsetInsightsButton() {
+        if (!isExamNotNull() || !Boolean.TRUE.equals(exam.getEnableMindsetReflections())) {
+            return;
+        }
+        mindsetInsightsLayout.setVisibility(View.VISIBLE);
+        mindsetInsightsButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                in.testpress.core.TestpressSession session =
+                        TestpressSdk.getTestpressSession(requireContext());
+                if (session == null) return;
+                String baseUrl = session.getInstituteSettings().getBaseUrl();
+                requireActivity().startActivity(
+                        MindsetInsightsActivity.createIntent(requireContext(), baseUrl, attempt.getId())
+                );
+            }
+        });
     }
 
     private void showOrHideEmailPDFButton() {

--- a/exam/src/main/res/layout/testpress_fragment_review_stats.xml
+++ b/exam/src/main/res/layout/testpress_fragment_review_stats.xml
@@ -626,7 +626,7 @@
         android:id="@+id/button_layout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_above="@+id/advanced_analytics_layout"
+        android:layout_above="@+id/mindset_insights_layout"
         android:layout_marginLeft="10dp"
         android:layout_marginRight="10dp"
         android:layout_marginBottom="8dp"
@@ -660,6 +660,33 @@
             android:text="@string/testpress_solutions"
             android:textColor="@color/testpress_green_light"
             android:textSize="16sp" />
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/mindset_insights_layout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_above="@+id/advanced_analytics_layout"
+        android:gravity="center_horizontal"
+        android:visibility="gone"
+        android:layout_marginLeft="10dp"
+        android:layout_marginRight="10dp"
+        android:layout_marginBottom="8dp"
+        android:orientation="horizontal" >
+
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/mindset_insights"
+            android:layout_width="match_parent"
+            android:layout_height="37dp"
+            android:layout_marginLeft="8dp"
+            android:layout_marginRight="8dp"
+            android:paddingLeft="8dp"
+            android:paddingRight="8dp"
+            android:background="@drawable/testpress_green_stroke"
+            android:text="@string/testpress_mindset_insights"
+            android:textColor="@color/testpress_green_light"
+            android:textSize="16sp"/>
 
     </LinearLayout>
 

--- a/exam/src/main/res/values/strings.xml
+++ b/exam/src/main/res/values/strings.xml
@@ -274,4 +274,5 @@
     <string name="storage_permission_to_upload_file">The photos and videos permission is required to upload files.</string>
     <string name="testpress_pdf_preview">PDF Preview</string>
     <string name="testpress_floating_window_detected">Floating window detected. Please close it.</string>
+    <string name="testpress_mindset_insights">Mindset Insights</string>
 </resources>


### PR DESCRIPTION
- A Mindset Insights button is conditionally shown on the post-exam review screen based on an exam-level flag
- Tapping the button opens an authenticated in-app web view pointing to the attempt-specific insights URL
- The web view bypasses cache to ensure fresh content is always loaded
- SSO authentication is handled before loading the insights page
- A new string resource is added for the button label