### PR TITLE
fix: Enable support for non-HTTP(S) URL schemes in WebView

### DIFF
--- a/core/src/main/java/in/testpress/util/extension/Fragment.kt
+++ b/core/src/main/java/in/testpress/util/extension/Fragment.kt
@@ -1,14 +1,13 @@
 package `in`.testpress.util.extension
 
 import `in`.testpress.util.ViewUtils
-import `in`.testpress.util.isValidUrl
 import android.content.Intent
 import android.net.Uri
 import androidx.fragment.app.Fragment
 
 fun Fragment.openUrlInBrowser(url: String?) {
     val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
-    if (intent.resolveActivity(this.requireContext().packageManager) != null && url.isValidUrl()) {
+    if (intent.resolveActivity(this.requireContext().packageManager) != null) {
         this.requireActivity().startActivity(intent)
     } else {
         ViewUtils.toast(this.requireContext(),"No suitable app was found to open this URL. Please install any browser app")

--- a/core/src/main/java/in/testpress/util/extension/Fragment.kt
+++ b/core/src/main/java/in/testpress/util/extension/Fragment.kt
@@ -1,15 +1,17 @@
 package `in`.testpress.util.extension
 
 import `in`.testpress.util.ViewUtils
+import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.net.Uri
 import androidx.fragment.app.Fragment
 
 fun Fragment.openUrlInBrowser(url: String?) {
+    if (url == null) return
     val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
-    if (intent.resolveActivity(this.requireContext().packageManager) != null) {
+    try {
         this.requireActivity().startActivity(intent)
-    } else {
-        ViewUtils.toast(this.requireContext(),"No suitable app was found to open this URL. Please install any browser app")
+    } catch (e: ActivityNotFoundException) {
+        ViewUtils.toast(this.requireContext(), "No suitable app found to open this link")
     }
 }

--- a/core/src/main/java/in/testpress/util/webview/CustomWebViewClient.kt
+++ b/core/src/main/java/in/testpress/util/webview/CustomWebViewClient.kt
@@ -37,10 +37,10 @@ class CustomWebViewClient(val fragment: WebViewFragment) : AndroidWebViewClient(
         if (!fragment.allowNonInstituteUrlInWebView) {
             return false
         }
-        return isHttpOrHttpsUrl(url)
+        return hasHttpScheme(url)
     }
 
-    private fun isHttpOrHttpsUrl(url: String): Boolean {
+    private fun hasHttpScheme(url: String): Boolean {
         return url.startsWith("http://", ignoreCase = true) ||
                url.startsWith("https://", ignoreCase = true)
     }

--- a/core/src/main/java/in/testpress/util/webview/CustomWebViewClient.kt
+++ b/core/src/main/java/in/testpress/util/webview/CustomWebViewClient.kt
@@ -30,11 +30,18 @@ class CustomWebViewClient(val fragment: WebViewFragment) : AndroidWebViewClient(
     private fun isPDFUrl(url: String?) = url?.contains(".pdf") ?: false
 
     private fun shouldLoadInWebView(url: String?):Boolean {
-        return if (fragment.isInstituteUrl(url)){
-            true
-        } else {
-            fragment.allowNonInstituteUrlInWebView
+        if (fragment.isInstituteUrl(url)) {
+            return true
         }
+        if (!fragment.allowNonInstituteUrlInWebView) {
+            return false
+        }
+        return url?.let { isHttpOrHttpsUrl(it) } ?: false
+    }
+
+    private fun isHttpOrHttpsUrl(url: String): Boolean {
+        return url.startsWith("http://", ignoreCase = true) ||
+               url.startsWith("https://", ignoreCase = true)
     }
 
     override fun onPageStarted(view: AndroidWebView?, url: String?, favicon: Bitmap?) {

--- a/core/src/main/java/in/testpress/util/webview/CustomWebViewClient.kt
+++ b/core/src/main/java/in/testpress/util/webview/CustomWebViewClient.kt
@@ -30,13 +30,14 @@ class CustomWebViewClient(val fragment: WebViewFragment) : AndroidWebViewClient(
     private fun isPDFUrl(url: String?) = url?.contains(".pdf") ?: false
 
     private fun shouldLoadInWebView(url: String?):Boolean {
+        if (url == null) return true
         if (fragment.isInstituteUrl(url)) {
             return true
         }
         if (!fragment.allowNonInstituteUrlInWebView) {
             return false
         }
-        return url?.let { isHttpOrHttpsUrl(it) } ?: false
+        return isHttpOrHttpsUrl(url)
     }
 
     private fun isHttpOrHttpsUrl(url: String): Boolean {


### PR DESCRIPTION
- Update CustomWebViewClient to restrict non-institute URLs to http and https protocols when allowed in WebView. This prevents unsupported URI schemes  (upi, tel, mailto) from attempting to load internally, routing them to appropriate external apps instead.
- Remove isValidUrl check from Fragment.openUrlInBrowser since it was redundant. 
- Replace resolveActivity() check with try-catch using ActivityNotFoundException to properly handle non-browser URL schemes on Android 11+.
- Add null check for URL parameter to prevent Uri.parse(null) crash.