### PR TITLE
fix: Wait for trophy calculation before showing results screen

### DIFF
--- a/core/src/main/java/in/testpress/models/greendao/CourseAttempt.java
+++ b/core/src/main/java/in/testpress/models/greendao/CourseAttempt.java
@@ -359,6 +359,10 @@ public class CourseAttempt implements android.os.Parcelable {
         return CONTENT_ATTEMPTS_PATH + id + END_EXAM_PATH;
     }
 
+    public String getAttemptUrl() {
+        return CONTENT_ATTEMPTS_PATH + id + "/";
+    }
+
     public Attempt getRawAssessment() {
         if (myDao == null || assessment != null) {
             return assessment;

--- a/exam/src/main/java/in/testpress/exam/api/ExamService.java
+++ b/exam/src/main/java/in/testpress/exam/api/ExamService.java
@@ -121,6 +121,9 @@ public interface ExamService {
     RetrofitCall<TestpressApiResponse<CourseAttempt>> getContentAttempts(@Url String attemptsUrl);
 
     @GET
+    RetrofitCall<CourseAttempt> getCourseAttempt(@Url String attemptUrl);
+
+    @GET
     RetrofitCall<TestpressApiResponse<ReviewItem>> getReviewItems(
             @Url String reviewUrl,
             @QueryMap Map<String, Object> options);

--- a/exam/src/main/java/in/testpress/exam/api/TestpressExamApiClient.java
+++ b/exam/src/main/java/in/testpress/exam/api/TestpressExamApiClient.java
@@ -181,6 +181,10 @@ public class TestpressExamApiClient extends TestpressApiClient {
         return getExamService().getContentAttempts(url);
     }
 
+    public RetrofitCall<CourseAttempt> getCourseAttempt(String url) {
+        return getExamService().getCourseAttempt(url);
+    }
+
     public RetrofitCall<TestpressApiResponse<ReviewItem>> getReviewItems(
             String urlFrag, Map<String, Object> queryParams) {
         return getExamService().getReviewItems(urlFrag, queryParams);

--- a/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
@@ -1164,20 +1164,20 @@ public class TestFragment extends BaseFragment implements
         if (getActivity() == null) {
             return;
         }
-        if (!initialAttempt.getTrophies().equals("NA") || retryCount >= 5) {
+        if (!"NA".equals(initialAttempt.getTrophies()) || retryCount >= 5) {
             initialAttempt.saveInDB(getActivity(), courseContent);
             hideProgressBar();
             showReview(ReviewStatsActivity.createIntent(getActivity(), exam, initialAttempt));
             return;
         }
 
-        showProgress("Calculating results...");
+        showProgress(R.string.testpress_calculating_results);
 
         new Handler().postDelayed(new Runnable() {
             @Override
             public void run() {
                 if (getActivity() == null) return;
-                new TestpressExamApiClient(getActivity()).getCourseAttempt(initialAttempt.getAttemptUrl())
+                apiClient.getCourseAttempt(initialAttempt.getAttemptUrl())
                         .enqueue(new TestpressCallback<CourseAttempt>() {
                             @Override
                             public void onSuccess(CourseAttempt updatedAttempt) {

--- a/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
@@ -1160,6 +1160,39 @@ public class TestFragment extends BaseFragment implements
         attemptViewModel.updateSection(sectionStartUrlFrag,Action.START_SECTION);
     }
 
+    private void pollCourseAttemptForGamification(final CourseAttempt initialAttempt, final int retryCount) {
+        if (getActivity() == null) {
+            return;
+        }
+        if (!initialAttempt.getTrophies().equals("NA") || retryCount >= 5) {
+            initialAttempt.saveInDB(getActivity(), courseContent);
+            hideProgressBar();
+            showReview(ReviewStatsActivity.createIntent(getActivity(), exam, initialAttempt));
+            return;
+        }
+
+        showProgress("Calculating results...");
+
+        new Handler().postDelayed(new Runnable() {
+            @Override
+            public void run() {
+                if (getActivity() == null) return;
+                new TestpressExamApiClient(getActivity()).getCourseAttempt(initialAttempt.getAttemptUrl())
+                        .enqueue(new TestpressCallback<CourseAttempt>() {
+                            @Override
+                            public void onSuccess(CourseAttempt updatedAttempt) {
+                                pollCourseAttemptForGamification(updatedAttempt, retryCount + 1);
+                            }
+
+                            @Override
+                            public void onException(TestpressException exception) {
+                                pollCourseAttemptForGamification(initialAttempt, retryCount + 1);
+                            }
+                        });
+            }
+        }, 1500);
+    }
+
     private void observeEndContentAttemptResources(){
         attemptViewModel.getEndContentAttemptResource().observe(getViewLifecycleOwner(), new Observer<Resource<CourseAttempt>>() {
             @Override
@@ -1176,9 +1209,12 @@ public class TestFragment extends BaseFragment implements
                             returnToHistory();
                             return;
                         }
-                        courseAttempt.saveInDB(getActivity(), courseContent);
-                        showReview(ReviewStatsActivity.createIntent(getActivity(), exam,
-                                courseAttempt));
+                        if (TestpressSdk.getTestpressSession(getActivity()).getInstituteSettings().isCoursesGamificationEnabled()) {
+                            pollCourseAttemptForGamification(courseAttempt, 0);
+                        } else {
+                            courseAttempt.saveInDB(getActivity(), courseContent);
+                            showReview(ReviewStatsActivity.createIntent(getActivity(), exam, courseAttempt));
+                        }
                         break;
                     }
                     case LOADING:{

--- a/exam/src/main/res/values/strings.xml
+++ b/exam/src/main/res/values/strings.xml
@@ -275,4 +275,5 @@
     <string name="testpress_pdf_preview">PDF Preview</string>
     <string name="testpress_floating_window_detected">Floating window detected. Please close it.</string>
     <string name="testpress_mindset_insights">Mindset Insights</string>
+    <string name="testpress_calculating_results">Calculating results…</string>
 </resources>


### PR DESCRIPTION
- What was the issue?
	- Trophy count was displaying as '0' on the results screen immediately after an exam, even though trophies were correctly assigned in the backend.

- What caused the issue?
	- The backend calculates trophies asynchronously in a background task. The app was fetching the attempt data immediately after ending the exam, before the background task finished, resulting in stale 'NA' trophy values.

- How is it fixed?
  - Implemented a polling mechanism in TestFragment that waits for trophy calculation to complete before proceeding to the results screen.
  - Added a getCourseAttempt endpoint to fetch updated attempt data.
  - Added a helper method in CourseAttempt to construct the attempt URL.