### PR TITLE
feat: Bypass overlay detection for Brilliant Pala practice exams

### DIFF
--- a/core/src/main/java/in/testpress/models/InstituteSettings.java
+++ b/core/src/main/java/in/testpress/models/InstituteSettings.java
@@ -504,4 +504,8 @@ public class InstituteSettings {
         this.questionReportDescriptionMinLength = questionReportDescriptionMinLength;
         return this;
     }
+
+    public boolean isBrilliantPalaELearn() {
+        return baseUrl != null && baseUrl.contains("brilliantpala");
+    }
 }

--- a/core/src/main/java/in/testpress/models/InstituteSettings.java
+++ b/core/src/main/java/in/testpress/models/InstituteSettings.java
@@ -506,6 +506,6 @@ public class InstituteSettings {
     }
 
     public boolean isBrilliantPalaELearn() {
-        return baseUrl != null && baseUrl.contains("brilliantpala");
+        return getDomainUrl().toLowerCase().contains("brilliantpala");
     }
 }

--- a/exam/src/main/java/in/testpress/exam/ui/TestActivity.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestActivity.java
@@ -12,6 +12,8 @@ import androidx.annotation.StringRes;
 import androidx.appcompat.app.AlertDialog;
 import androidx.lifecycle.Observer;
 
+import in.testpress.models.InstituteSettings;
+
 import android.view.MotionEvent;
 import android.view.View;
 import android.widget.Button;
@@ -183,7 +185,10 @@ public class TestActivity extends BaseToolBarActivity  {
 
     @Override
     public boolean dispatchTouchEvent(MotionEvent ev) {
-        if (isOverlayDetected(ev)) return true;
+        InstituteSettings instituteSettings = TestpressSdk.getTestpressSession(this).getInstituteSettings();
+        if (isKioskModeRequired() || !instituteSettings.isBrilliantPalaELearn()) {
+            if (isOverlayDetected(ev)) return true;
+        }
         if (blockInputIfUnpinned(ev)) return true;
         return super.dispatchTouchEvent(ev);
     }

--- a/exam/src/main/java/in/testpress/exam/ui/TestActivity.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestActivity.java
@@ -108,6 +108,7 @@ public class TestActivity extends BaseToolBarActivity  {
     private ExamViewModel examViewModel;
     private boolean reflectionCompleted = false;
     private static final int REFLECTION_REQUEST_CODE = 1001;
+    private boolean isBrilliantPala;
 
     @Override
     protected void onCreate(final Bundle savedInstanceState) {
@@ -136,6 +137,8 @@ public class TestActivity extends BaseToolBarActivity  {
                 TestpressSdk.getRubikMediumFont(this));
         UIUtils.setIndeterminateDrawable(this, findViewById(R.id.progress_bar), 4);
         apiClient = new TestpressExamApiClient(this);
+        TestpressSession session = TestpressSdk.getTestpressSession(this);
+        isBrilliantPala = session != null && session.getInstituteSettings().isBrilliantPalaELearn();
         final Intent intent = getIntent();
         Bundle data = intent.getExtras();
         assert data != null;
@@ -185,8 +188,7 @@ public class TestActivity extends BaseToolBarActivity  {
 
     @Override
     public boolean dispatchTouchEvent(MotionEvent ev) {
-        InstituteSettings instituteSettings = TestpressSdk.getTestpressSession(this).getInstituteSettings();
-        if (isKioskModeRequired() || !instituteSettings.isBrilliantPalaELearn()) {
+        if (isKioskModeRequired() || !isBrilliantPala) {
             if (isOverlayDetected(ev)) return true;
         }
         if (blockInputIfUnpinned(ev)) return true;


### PR DESCRIPTION
- Students at Brilliant Pala require the use of floating windows (like calculators) during unmonitored practice exams.
- The SDK previously blocked all overlays in TestActivity regardless of the exam settings.
- Added isBrilliantPalaELearn() helper to InstituteSettings and updated TestActivity to bypass overlay detection if monitoring is disabled and the institute is Brilliant Pala.