### PR TITLE
feat: Integrate Fermion livestream provider support

### DIFF
--- a/course/src/main/java/in/testpress/course/fragments/FermionLiveStreamFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/FermionLiveStreamFragment.kt
@@ -1,0 +1,118 @@
+package `in`.testpress.course.fragments
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.webkit.PermissionRequest
+import android.webkit.WebChromeClient
+import android.webkit.WebResourceRequest
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.fragment.app.Fragment
+import `in`.testpress.course.R
+
+class FermionLiveStreamFragment : Fragment() {
+
+    private var initialLoadComplete = false
+    private lateinit var streamUrl: String
+    private var webView: WebView? = null
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        return inflater.inflate(R.layout.fragment_fermion_live_stream, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        streamUrl = arguments?.getString(ARG_STREAM_URL) ?: return
+        setupWebView()
+    }
+
+    private fun setupWebView() {
+        val container = requireView() as ViewGroup
+        webView = WebView(requireContext()).apply {
+            configureSettings()
+            webChromeClient = buildChromeClient()
+            webViewClient = buildWebViewClient()
+            loadUrl(streamUrl)
+        }
+        container.addView(webView, ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT)
+    }
+
+    private fun WebView.configureSettings() {
+        settings.javaScriptEnabled = true
+        settings.domStorageEnabled = true
+        settings.loadWithOverviewMode = true
+        settings.useWideViewPort = true
+        settings.allowFileAccess = false
+        settings.mediaPlaybackRequiresUserGesture = false
+    }
+
+    private fun buildChromeClient() = object : WebChromeClient() {
+        override fun onPermissionRequest(request: PermissionRequest) {
+            val allowedResources = arrayOf(
+                PermissionRequest.RESOURCE_VIDEO_CAPTURE,
+                PermissionRequest.RESOURCE_AUDIO_CAPTURE
+            )
+            val filteredResources = request.resources.filter { it in allowedResources }.toTypedArray()
+            if (filteredResources.isNotEmpty()) {
+                request.grant(filteredResources)
+            } else {
+                request.deny()
+            }
+        }
+    }
+
+    private fun buildWebViewClient() = object : WebViewClient() {
+        override fun onPageFinished(view: WebView, url: String) {
+            initialLoadComplete = true
+            view.evaluateJavascript(VIEWPORT_FIT_SCRIPT, null)
+        }
+
+        override fun shouldOverrideUrlLoading(view: WebView, request: WebResourceRequest): Boolean {
+            return handleNavigation(request.url.toString())
+        }
+
+        @Suppress("DEPRECATION")
+        override fun shouldOverrideUrlLoading(view: WebView, url: String): Boolean {
+            return handleNavigation(url)
+        }
+    }
+
+    private fun handleNavigation(url: String): Boolean {
+        if (initialLoadComplete && url != streamUrl && isAdded) {
+            requireActivity().finish()
+            return true
+        }
+        return false
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        webView?.destroy()
+        webView = null
+    }
+
+    companion object {
+        const val ARG_STREAM_URL = "ARG_STREAM_URL"
+        const val ARG_TITLE = "ARG_TITLE"
+
+        private val VIEWPORT_FIT_SCRIPT = """
+            (function() {
+                var meta = document.querySelector('meta[name="viewport"]');
+                if (!meta) {
+                    meta = document.createElement('meta');
+                    meta.name = 'viewport';
+                    document.head.appendChild(meta);
+                }
+                meta.content = 'width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no';
+                document.documentElement.style.cssText += 'width:100%!important;height:100%!important;overflow:hidden!important;';
+                document.body.style.cssText += 'width:100%!important;height:100%!important;overflow:hidden!important;margin:0!important;padding:0!important;';
+            })();
+        """.trimIndent()
+    }
+}

--- a/course/src/main/java/in/testpress/course/fragments/FermionLiveStreamFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/FermionLiveStreamFragment.kt
@@ -15,7 +15,7 @@ import `in`.testpress.course.R
 class FermionLiveStreamFragment : Fragment() {
 
     private var initialLoadComplete = false
-    private lateinit var streamUrl: String
+    private var streamUrl: String? = null
     private var webView: WebView? = null
 
     override fun onCreateView(
@@ -28,7 +28,11 @@ class FermionLiveStreamFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        streamUrl = arguments?.getString(ARG_STREAM_URL) ?: return
+        streamUrl = arguments?.getString(ARG_STREAM_URL)
+        if (streamUrl == null) {
+            view.findViewById<View>(R.id.error_message).visibility = View.VISIBLE
+            return
+        }
         setupWebView()
     }
 
@@ -38,7 +42,7 @@ class FermionLiveStreamFragment : Fragment() {
             configureSettings()
             webChromeClient = buildChromeClient()
             webViewClient = buildWebViewClient()
-            loadUrl(streamUrl)
+            streamUrl?.let { loadUrl(it) }
         }
         container.addView(webView, ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT)
     }
@@ -54,6 +58,14 @@ class FermionLiveStreamFragment : Fragment() {
 
     private fun buildChromeClient() = object : WebChromeClient() {
         override fun onPermissionRequest(request: PermissionRequest) {
+            val expectedHost = streamUrl?.let { android.net.Uri.parse(it).host }
+            val requestHost = request.origin.host
+
+            if (expectedHost == null || requestHost != expectedHost) {
+                request.deny()
+                return
+            }
+
             val allowedResources = arrayOf(
                 PermissionRequest.RESOURCE_VIDEO_CAPTURE,
                 PermissionRequest.RESOURCE_AUDIO_CAPTURE
@@ -84,9 +96,16 @@ class FermionLiveStreamFragment : Fragment() {
     }
 
     private fun handleNavigation(url: String): Boolean {
-        if (initialLoadComplete && url != streamUrl && isAdded) {
-            requireActivity().finish()
-            return true
+        val currentUri = streamUrl?.let { android.net.Uri.parse(it) }
+        val newUri = android.net.Uri.parse(url)
+
+        if (initialLoadComplete && currentUri != null && isAdded) {
+            val isSamePage = currentUri.host == newUri.host && currentUri.path == newUri.path
+
+            if (!isSamePage) {
+                requireActivity().finish()
+                return true
+            }
         }
         return false
     }

--- a/course/src/main/java/in/testpress/course/fragments/LiveStreamFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/LiveStreamFragment.kt
@@ -38,9 +38,13 @@ class LiveStreamFragment : BaseContentDetailFragment(), LiveStreamCallbackListen
     private val requestPermissionsLauncher = registerForActivityResult(
         ActivityResultContracts.RequestMultiplePermissions()
     ) { results ->
-        if (pendingFermionLaunch && results.values.all { it }) {
-            pendingFermionLaunch = false
-            showFermionPlayer()
+        if (pendingFermionLaunch) {
+            if (results.values.all { it }) {
+                pendingFermionLaunch = false
+                showFermionPlayer()
+            } else {
+                displayPermissionDeniedNotice()
+            }
         }
     }
 
@@ -118,6 +122,37 @@ class LiveStreamFragment : BaseContentDetailFragment(), LiveStreamCallbackListen
         }
     }
 
+    private fun hasCameraAndMicPermissions(): Boolean {
+        return ContextCompat.checkSelfPermission(requireContext(), Manifest.permission.CAMERA) == PackageManager.PERMISSION_GRANTED &&
+                ContextCompat.checkSelfPermission(requireContext(), Manifest.permission.RECORD_AUDIO) == PackageManager.PERMISSION_GRANTED
+    }
+
+    private fun displayPermissionDeniedNotice() {
+        emptyViewFragment.setEmptyText(
+            R.string.testpress_permission_denied,
+            R.string.testpress_permission_denied_message,
+            null
+        )
+        emptyViewFragment.showOrHideButton(true)
+    }
+
+    private fun displayErrorNotice() {
+        emptyViewFragment.setEmptyText(
+            R.string.testpress_error_loading_contents,
+            R.string.testpress_some_thing_went_wrong_try_again,
+            null
+        )
+        emptyViewFragment.showOrHideButton(true)
+    }
+
+    override fun onRetryClick() {
+        if (isFermionProvider() && !hasCameraAndMicPermissions()) {
+            requestCameraAndMicPermissions()
+        } else {
+            super.onRetryClick()
+        }
+    }
+
     private fun showFermionPlayer() {
         setupFermionPlayer()
         setupChatWebView()
@@ -127,8 +162,13 @@ class LiveStreamFragment : BaseContentDetailFragment(), LiveStreamCallbackListen
     }
 
     private fun setupFermionPlayer() {
-        val streamUrl = content.liveStream?.streamUrl ?: return
-        val container = view?.findViewById<ViewGroup>(R.id.fermion_player_container) ?: return
+        val streamUrl = content.liveStream?.streamUrl
+        val container = view?.findViewById<ViewGroup>(R.id.fermion_player_container)
+
+        if (streamUrl == null || container == null) {
+            displayErrorNotice()
+            return
+        }
         container.visibility = View.VISIBLE
 
         val fermionFragment = FermionLiveStreamFragment()

--- a/course/src/main/java/in/testpress/course/fragments/LiveStreamFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/LiveStreamFragment.kt
@@ -1,11 +1,15 @@
 package `in`.testpress.course.fragments
 
+import android.Manifest
+import android.content.pm.PackageManager
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import `in`.testpress.course.R
 import `in`.testpress.course.domain.getGreenDaoContent
+import `in`.testpress.course.fragments.FermionLiveStreamFragment.Companion.ARG_STREAM_URL
+import `in`.testpress.course.fragments.FermionLiveStreamFragment.Companion.ARG_TITLE
 import `in`.testpress.course.util.ExoPlayerUtil
 import `in`.testpress.course.util.ExoplayerFullscreenHelper
 import `in`.testpress.fragments.WebViewFragment
@@ -16,6 +20,8 @@ import android.os.Handler
 import android.os.Looper
 import android.widget.RelativeLayout
 import android.widget.TextView
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.content.ContextCompat
 import com.google.android.exoplayer2.ui.AspectRatioFrameLayout
 import kotlinx.coroutines.*
 import java.lang.Runnable
@@ -27,6 +33,16 @@ class LiveStreamFragment : BaseContentDetailFragment(), LiveStreamCallbackListen
     private lateinit var exoplayerFullscreenHelper: ExoplayerFullscreenHelper
     private var exoPlayerUtil: ExoPlayerUtil? = null
     private val coroutineScope = CoroutineScope(Dispatchers.IO)
+    private var pendingFermionLaunch = false
+
+    private val requestPermissionsLauncher = registerForActivityResult(
+        ActivityResultContracts.RequestMultiplePermissions()
+    ) { results ->
+        if (pendingFermionLaunch && results.values.all { it }) {
+            pendingFermionLaunch = false
+            showFermionPlayer()
+        }
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -50,21 +66,73 @@ class LiveStreamFragment : BaseContentDetailFragment(), LiveStreamCallbackListen
         }
     }
 
+    private fun isFermionProvider(): Boolean {
+        return content.liveStream?.provider == FERMION_PROVIDER
+    }
+
     private fun initializeExoplayerFullscreenHelper() {
         exoplayerFullscreenHelper = ExoplayerFullscreenHelper(activity)
         exoplayerFullscreenHelper.initializeOrientationListener()
     }
 
     private fun displayPlayerViewWithChat(){
+        if (isFermionProvider()) {
+            requestCameraAndMicPermissions()
+        } else {
+            displayExoPlayerWithChat()
+        }
+    }
+
+    private fun displayExoPlayerWithChat() {
         initializePlayerView()
         initializeExoPlayer()
         setupChatWebView()
         viewModel.createContentAttempt(contentId)
-
-        // Disabling swipe to refresh because  it prevents users from scrolling the chat
-        // and temporarily hiding the bottom navigation as it hides the chat's send button..
         swipeRefresh.isEnabled = false
         hideBottomNavigationBar()
+    }
+
+    private fun requestCameraAndMicPermissions() {
+        val permissions = mutableListOf<String>()
+        if (ContextCompat.checkSelfPermission(requireContext(), Manifest.permission.CAMERA)
+            != PackageManager.PERMISSION_GRANTED
+        ) {
+            permissions.add(Manifest.permission.CAMERA)
+        }
+        if (ContextCompat.checkSelfPermission(requireContext(), Manifest.permission.RECORD_AUDIO)
+            != PackageManager.PERMISSION_GRANTED
+        ) {
+            permissions.add(Manifest.permission.RECORD_AUDIO)
+        }
+        if (permissions.isEmpty()) {
+            showFermionPlayer()
+        } else {
+            pendingFermionLaunch = true
+            requestPermissionsLauncher.launch(permissions.toTypedArray())
+        }
+    }
+
+    private fun showFermionPlayer() {
+        setupFermionPlayer()
+        setupChatWebView()
+        viewModel.createContentAttempt(contentId)
+        swipeRefresh.isEnabled = false
+        hideBottomNavigationBar()
+    }
+
+    private fun setupFermionPlayer() {
+        val streamUrl = content.liveStream?.streamUrl ?: return
+        val container = view?.findViewById<ViewGroup>(R.id.fermion_player_container) ?: return
+        container.visibility = View.VISIBLE
+
+        val fermionFragment = FermionLiveStreamFragment()
+        fermionFragment.arguments = Bundle().apply {
+            putString(ARG_STREAM_URL, streamUrl)
+            putString(ARG_TITLE, content.title ?: "")
+        }
+        childFragmentManager.beginTransaction()
+            .replace(R.id.fermion_player_container, fermionFragment)
+            .commitAllowingStateLoss()
     }
 
     private fun displayNotStartedNotice(){
@@ -113,7 +181,7 @@ class LiveStreamFragment : BaseContentDetailFragment(), LiveStreamCallbackListen
             webViewFragment.arguments = bundle
             childFragmentManager.beginTransaction()
                 .replace(R.id.chat_view_fragment, webViewFragment)
-                .commit()
+                .commitAllowingStateLoss()
         }
     }
 
@@ -178,6 +246,10 @@ class LiveStreamFragment : BaseContentDetailFragment(), LiveStreamCallbackListen
     override fun onDestroyView() {
         super.onDestroyView()
         coroutineScope.cancel()
+    }
+
+    companion object {
+        private const val FERMION_PROVIDER = "Fermion"
     }
 }
 

--- a/course/src/main/java/in/testpress/course/fragments/LiveStreamFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/LiveStreamFragment.kt
@@ -181,7 +181,7 @@ class LiveStreamFragment : BaseContentDetailFragment(), LiveStreamCallbackListen
             webViewFragment.arguments = bundle
             childFragmentManager.beginTransaction()
                 .replace(R.id.chat_view_fragment, webViewFragment)
-                .commitAllowingStateLoss()
+                .commit()
         }
     }
 

--- a/course/src/main/java/in/testpress/course/fragments/LiveStreamFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/LiveStreamFragment.kt
@@ -54,9 +54,15 @@ class LiveStreamFragment : BaseContentDetailFragment(), LiveStreamCallbackListen
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         initializeExoplayerFullscreenHelper()
+        showLoading()
+    }
+
+    private fun showLoading() {
+        view?.findViewById<View>(R.id.loading_screen)?.visibility = View.VISIBLE
     }
 
     override fun display() {
+        view?.findViewById<View>(R.id.loading_screen)?.visibility = View.GONE
         when (content.liveStream?.status) {
             "Running" -> {
                 displayPlayerViewWithChat()

--- a/course/src/main/java/in/testpress/course/repository/ContentRepository.kt
+++ b/course/src/main/java/in/testpress/course/repository/ContentRepository.kt
@@ -62,7 +62,9 @@ open class ContentRepository(
             }
 
             override fun shouldFetch(data: DomainContent?): Boolean {
-                return forceRefresh || getContentFromDB(contentId) == null
+                val dbContent = getContentFromDB(contentId)
+                val isLiveStream = dbContent?.liveStreamId != null
+                return forceRefresh || dbContent == null || isLiveStream
             }
 
             override fun loadFromDb(): LiveData<DomainContent> {

--- a/course/src/main/res/layout/fragment_fermion_live_stream.xml
+++ b/course/src/main/res/layout/fragment_fermion_live_stream.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@android:color/black" />

--- a/course/src/main/res/layout/fragment_fermion_live_stream.xml
+++ b/course/src/main/res/layout/fragment_fermion_live_stream.xml
@@ -2,4 +2,15 @@
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@android:color/black" />
+    android:background="@android:color/black">
+
+    <TextView
+        android:id="@+id/error_message"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:textColor="@android:color/white"
+        android:visibility="gone"
+        android:text="@string/testpress_error_loading_contents" />
+
+</FrameLayout>

--- a/course/src/main/res/layout/fragment_live_stream.xml
+++ b/course/src/main/res/layout/fragment_live_stream.xml
@@ -48,4 +48,12 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_alignParentBottom="true"/>
+
+    <ProgressBar
+        android:id="@+id/loading_screen"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_centerInParent="true"
+        android:visibility="gone" />
+
 </RelativeLayout>

--- a/course/src/main/res/layout/fragment_live_stream.xml
+++ b/course/src/main/res/layout/fragment_live_stream.xml
@@ -24,6 +24,13 @@
                 layout="@layout/testpress_exo_player_view" />
 
             <FrameLayout
+                android:id="@+id/fermion_player_container"
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_weight="1"
+                android:visibility="gone" />
+
+            <FrameLayout
                 android:id="@+id/chat_view_fragment"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content" />


### PR DESCRIPTION
- Support for the Fermion livestream provider has been added, enabling interactive web-based live streaming within the SDK.
- This change was necessary because Fermion streams require camera and microphone permissions which were not handled by the existing ExoPlayer-based implementation.

Key modifications:

- Added FermionLiveStreamFragment and FermionLiveStreamActivity to handle the Fermion web player.
- Implemented runtime permission checks for Camera and Microphone in LiveStreamFragment before launching the Fermion player.
- Updated LiveStream GreenDAO model and network/repository layers to include provider and streamUrl fields.
- Modified the DAO generator to include new fields in the schema.