### PR TITLE
feat: Resolve scrolling conflicts and remove pull-to-refresh in notes

### DIFF
--- a/course/src/main/java/in/testpress/course/fragments/HtmlContentFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/HtmlContentFragment.kt
@@ -60,12 +60,10 @@ class HtmlContentFragment : BaseContentDetailFragment() {
     inner class HtmlViewUtils(webView: WebView) : WebViewUtils(webView) {
         override fun onPageStarted() {
             super.onPageStarted()
-            swipeRefresh.isRefreshing = true
         }
 
         override fun onLoadFinished() {
             super.onLoadFinished()
-            swipeRefresh.isRefreshing = false
             webView.visibility = View.VISIBLE
             viewModel.createContentAttempt(contentId).observe(viewLifecycleOwner, Observer {
                 checkAndUnlockNextContent()

--- a/course/src/main/res/layout/html_content_detail.xml
+++ b/course/src/main/res/layout/html_content_detail.xml
@@ -1,84 +1,70 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/main_content"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-
     <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
         android:id="@+id/swipe_container"
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        android:layout_marginBottom="70dp"
+        android:enabled="false">
 
-        <androidx.core.widget.NestedScrollView
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="#ffffff"
+        android:orientation="vertical">
+
+        <LinearLayout
+            android:id="@+id/title_layout"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:background="#ffffff"
-            android:fillViewport="true">
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:paddingLeft="10dp"
+            android:paddingRight="10dp"
+            android:visibility="gone">
 
-            <LinearLayout
+            <TextView
+                android:id="@+id/title"
                 android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:orientation="vertical"
-                android:paddingTop="20dp"
-                tools:ignore="ScrollViewSize">
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="10dp"
+                android:gravity="center"
+                android:lineSpacingExtra="6dp"
+                android:text="Lorem ipsum dolor sit amet, consectetur"
+                android:textColor="@color/testpress_black"
+                android:textSize="24sp"
+                android:textStyle="bold" />
 
-                <LinearLayout
-                    android:id="@+id/title_layout"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:orientation="vertical"
-                    android:paddingLeft="10dp"
-                    android:paddingRight="10dp"
-                    android:visibility="gone">
+            <FrameLayout
+                android:id="@+id/bookmark_fragment_layout"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
 
-                    <TextView
-                        android:id="@+id/title"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginBottom="10dp"
-                        android:gravity="center"
-                        android:lineSpacingExtra="6dp"
-                        android:text="Lorem ipsum dolor sit amet, consectetur"
-                        android:textColor="@color/testpress_black"
-                        android:textSize="24sp"
-                        android:textStyle="bold" />
+            <View
+                android:id="@+id/title_separator"
+                android:layout_width="match_parent"
+                android:layout_height="1dp"
+                android:layout_gravity="center"
+                android:layout_marginLeft="10dp"
+                android:layout_marginTop="10dp"
+                android:layout_marginRight="10dp"
+                android:layout_marginBottom="5dp"
+                android:background="#e6e6e6" />
 
-                    <FrameLayout
-                        android:id="@+id/bookmark_fragment_layout"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content" />
+        </LinearLayout>
 
-                    <View
-                        android:id="@+id/title_separator"
-                        android:layout_width="match_parent"
-                        android:layout_height="1dp"
-                        android:layout_gravity="center"
-                        android:layout_marginLeft="10dp"
-                        android:layout_marginTop="10dp"
-                        android:layout_marginRight="10dp"
-                        android:layout_marginBottom="5dp"
-                        android:background="#e6e6e6" />
+        <WebView
+            android:id="@+id/web_view"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:visibility="gone" />
 
-                </LinearLayout>
-
-                <WebView
-                    android:id="@+id/web_view"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginBottom="70dp"
-                    android:visibility="gone" />
-
-                <!-- Empty layout to keep the navigation button in bottom -->
-                <View
-                    android:layout_width="match_parent"
-                    android:layout_height="0dp"
-                    android:layout_weight="1" />
-
-            </LinearLayout>
-        </androidx.core.widget.NestedScrollView>
+    </LinearLayout>
 
     </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 


### PR DESCRIPTION
**Issue:**
- Embedded scrollable content within notes (such as YouTube/Vimeo iframes or divs with overflow:auto) was not receiving touch events correctly, making it difficult for users to interact with or scroll that content.

**Cause:**
- The WebView was wrapped inside a NestedScrollView. This nesting caused  the parent container to intercept touch events before they could reach the WebView, preventing the embedded web content from handling native touch interactions.

**Fix:**
- Removed the NestedScrollView to make the WebView the sole scrollable container in the notes layout.
- Updated the WebView layout parameters to fill the available space natively.
- Disabled and removed pull-to-refresh (SwipeRefreshLayout) logic for notes to eliminate interaction conflicts and ensure smooth scrolling.