### PR TITLE
fix: Verify paid installment count to determine active plans

### DIFF
--- a/store/src/main/java/in/testpress/store/ui/ProductDetailsActivity.java
+++ b/store/src/main/java/in/testpress/store/ui/ProductDetailsActivity.java
@@ -378,7 +378,11 @@ public class ProductDetailsActivity extends BaseToolBarActivity {
     }
 
     private boolean hasActiveInstallmentPlan(InstallmentPlansResponse response) {
-        return response.getUserInstallmentPlans() != null && !response.getUserInstallmentPlans().isEmpty();
+        if (response.getUserInstallmentPlans() == null || response.getUserInstallmentPlans().isEmpty()) {
+            return false;
+        }
+        UserInstallmentPlan userPlan = response.getUserInstallmentPlans().get(0);
+        return userPlan.getPaidInstallmentCount() != null && userPlan.getPaidInstallmentCount() > 0;
     }
 
     private void setupActiveInstallmentUi(UserInstallmentPlan userPlan) {

--- a/store/src/main/java/in/testpress/store/ui/ProductDetailsActivity.java
+++ b/store/src/main/java/in/testpress/store/ui/ProductDetailsActivity.java
@@ -378,11 +378,12 @@ public class ProductDetailsActivity extends BaseToolBarActivity {
     }
 
     private boolean hasActiveInstallmentPlan(InstallmentPlansResponse response) {
-        if (response.getUserInstallmentPlans() == null || response.getUserInstallmentPlans().isEmpty()) {
+        List<UserInstallmentPlan> userPlans = response.getUserInstallmentPlans();
+        if (userPlans == null || userPlans.isEmpty()) {
             return false;
         }
-        UserInstallmentPlan userPlan = response.getUserInstallmentPlans().get(0);
-        return userPlan.getPaidInstallmentCount() != null && userPlan.getPaidInstallmentCount() > 0;
+        UserInstallmentPlan userPlan = userPlans.get(0);
+        return userPlan != null && userPlan.getPaidInstallmentCount() != null && userPlan.getPaidInstallmentCount() > 0;
     }
 
     private void setupActiveInstallmentUi(UserInstallmentPlan userPlan) {


### PR DESCRIPTION
- What was the issue? When a user was assigned an installment plan but had paid zero installments, the UI incorrectly initialized the active installment UI instead of the new installment flow.

- What caused the issue? hasActiveInstallmentPlan() only checked if the user installment plans list was non-empty. It did not verify whether the user had actually made any payments on the plan.

- How is it fixed? Modified hasActiveInstallmentPlan() to retrieve the user's plan and verify that paidInstallmentCount is both non-null and greater than zero before considering the plan active.