### PR TITLE
fix: Refresh purchased courses list on purchase completion

### DIFF
--- a/course/src/main/java/in/testpress/course/AvailableCourseListAdapter.java
+++ b/course/src/main/java/in/testpress/course/AvailableCourseListAdapter.java
@@ -93,7 +93,7 @@ public class AvailableCourseListAdapter extends SingleTypeAdapter<Product> {
 
     private void showProductDetail(Product product) {
         if (product.getCourseIds().size() >= 1) {
-            activity.startActivity(CoursePreviewActivity.createIntent(product.getCourseIds(), activity, product.getSlug()));
+            activity.startActivityForResult(CoursePreviewActivity.createIntent(product.getCourseIds(), activity, product.getSlug()), TestpressStore.STORE_REQUEST_CODE);
         } else {
             Intent intent = new Intent(activity, ProductDetailsActivity.class);
             intent.putExtra(ProductDetailsActivity.PRODUCT_SLUG, product.getSlug());

--- a/course/src/main/java/in/testpress/course/ui/CourseListActivity.kt
+++ b/course/src/main/java/in/testpress/course/ui/CourseListActivity.kt
@@ -22,10 +22,8 @@ class CourseListActivity : BaseToolBarActivity() {
         super.onActivityResult(requestCode, resultCode, data)
         if (requestCode == TestpressStore.STORE_REQUEST_CODE && resultCode == Activity.RESULT_OK){
             data?.let {  intentData ->
-                if (!intentData.getBooleanExtra(TestpressStore.CONTINUE_PURCHASE, false)) {
-                    supportFragmentManager.fragments.forEach { fragment ->
-                        fragment.onActivityResult(requestCode, resultCode, intentData)
-                    }
+                supportFragmentManager.fragments.forEach { fragment ->
+                    fragment.onActivityResult(requestCode, resultCode, intentData)
                 }
             }
         }

--- a/course/src/main/java/in/testpress/course/ui/CourseListFragment.java
+++ b/course/src/main/java/in/testpress/course/ui/CourseListFragment.java
@@ -163,10 +163,14 @@ public class CourseListFragment extends BaseFragment {
     @Override
     public void onActivityResult(int requestCode, int resultCode, @Nullable Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
-        if (requestCode == TestpressStore.STORE_REQUEST_CODE && resultCode == Activity.RESULT_OK && data != null && !data.getBooleanExtra(TestpressStore.CONTINUE_PURCHASE, false)) {
-            tabs.getTabAt(0).select();
+        if (requestCode == TestpressStore.STORE_REQUEST_CODE && resultCode == Activity.RESULT_OK && data != null) {
             MyCoursesFragment fragment = (MyCoursesFragment) adapter.getItem(0);
-            fragment.clearItemsAndRefresh();
+            if (fragment != null) {
+                fragment.clearItemsAndRefresh();
+            }
+            if (!data.getBooleanExtra(TestpressStore.CONTINUE_PURCHASE, false)) {
+                tabs.getTabAt(0).select();
+            }
         }
     }
 }

--- a/course/src/main/java/in/testpress/course/ui/CourseListFragment.java
+++ b/course/src/main/java/in/testpress/course/ui/CourseListFragment.java
@@ -164,11 +164,13 @@ public class CourseListFragment extends BaseFragment {
     public void onActivityResult(int requestCode, int resultCode, @Nullable Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
         if (requestCode == TestpressStore.STORE_REQUEST_CODE && resultCode == Activity.RESULT_OK && data != null) {
-            MyCoursesFragment fragment = (MyCoursesFragment) adapter.getItem(0);
-            if (fragment != null) {
-                fragment.clearItemsAndRefresh();
+            if (adapter != null && adapter.getCount() > 0) {
+                Fragment fragment = adapter.getItem(0);
+                if (fragment instanceof MyCoursesFragment) {
+                    ((MyCoursesFragment) fragment).clearItemsAndRefresh();
+                }
             }
-            if (!data.getBooleanExtra(TestpressStore.CONTINUE_PURCHASE, false)) {
+            if (!data.getBooleanExtra(TestpressStore.CONTINUE_PURCHASE, false) && tabs != null && tabs.getTabAt(0) != null) {
                 tabs.getTabAt(0).select();
             }
         }

--- a/course/src/main/java/in/testpress/course/ui/CoursePreviewActivity.kt
+++ b/course/src/main/java/in/testpress/course/ui/CoursePreviewActivity.kt
@@ -5,9 +5,12 @@ import android.content.Intent
 import android.os.Bundle
 import `in`.testpress.course.R
 import `in`.testpress.course.TestpressCourse
+import `in`.testpress.store.TestpressStore
 import `in`.testpress.ui.BaseToolBarActivity
 
 class CoursePreviewActivity: BaseToolBarActivity() {
+    private var isPurchaseSuccessful = false
+    private var continuePurchase = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -16,6 +19,29 @@ class CoursePreviewActivity: BaseToolBarActivity() {
         fragment.arguments = intent.extras
         supportFragmentManager.beginTransaction().replace(R.id.fragment_container, fragment)
             .commitAllowingStateLoss()
+    }
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        super.onActivityResult(requestCode, resultCode, data)
+        if (requestCode == TestpressStore.STORE_REQUEST_CODE && resultCode == RESULT_OK && data != null) {
+            isPurchaseSuccessful = true
+            continuePurchase = data.getBooleanExtra(TestpressStore.CONTINUE_PURCHASE, false)
+            if (!continuePurchase) {
+                setResult(RESULT_OK, data)
+                finish()
+            }
+        }
+    }
+
+    override fun finish() {
+        if (isPurchaseSuccessful) {
+            val intent = Intent().apply {
+                putExtra(TestpressStore.PAYMENT_SUCCESS, true)
+                putExtra(TestpressStore.CONTINUE_PURCHASE, continuePurchase)
+            }
+            setResult(RESULT_OK, intent)
+        }
+        super.finish()
     }
 
     companion object {

--- a/course/src/main/java/in/testpress/course/ui/CoursePreviewActivity.kt
+++ b/course/src/main/java/in/testpress/course/ui/CoursePreviewActivity.kt
@@ -9,8 +9,7 @@ import `in`.testpress.store.TestpressStore
 import `in`.testpress.ui.BaseToolBarActivity
 
 class CoursePreviewActivity: BaseToolBarActivity() {
-    private var isPurchaseSuccessful = false
-    private var continuePurchase = false
+    private var resultData: Intent? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -19,13 +18,22 @@ class CoursePreviewActivity: BaseToolBarActivity() {
         fragment.arguments = intent.extras
         supportFragmentManager.beginTransaction().replace(R.id.fragment_container, fragment)
             .commitAllowingStateLoss()
+
+        if (savedInstanceState != null) {
+            resultData = savedInstanceState.getParcelable("resultData")
+        }
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        outState.putParcelable("resultData", resultData)
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
         if (requestCode == TestpressStore.STORE_REQUEST_CODE && resultCode == RESULT_OK && data != null) {
-            isPurchaseSuccessful = true
-            continuePurchase = data.getBooleanExtra(TestpressStore.CONTINUE_PURCHASE, false)
+            resultData = data
+            val continuePurchase = data.getBooleanExtra(TestpressStore.CONTINUE_PURCHASE, false)
             if (!continuePurchase) {
                 setResult(RESULT_OK, data)
                 finish()
@@ -34,12 +42,8 @@ class CoursePreviewActivity: BaseToolBarActivity() {
     }
 
     override fun finish() {
-        if (isPurchaseSuccessful) {
-            val intent = Intent().apply {
-                putExtra(TestpressStore.PAYMENT_SUCCESS, true)
-                putExtra(TestpressStore.CONTINUE_PURCHASE, continuePurchase)
-            }
-            setResult(RESULT_OK, intent)
+        resultData?.let {
+            setResult(RESULT_OK, it)
         }
         super.finish()
     }

--- a/course/src/main/java/in/testpress/course/util/UIUtils.kt
+++ b/course/src/main/java/in/testpress/course/util/UIUtils.kt
@@ -3,7 +3,10 @@ package `in`.testpress.course.util
 import `in`.testpress.course.R
 import `in`.testpress.course.util.ProductUtils.getPriceForProduct
 import `in`.testpress.store.ui.ProductDetailsActivity
+import `in`.testpress.store.TestpressStore
+import android.app.Activity
 import android.content.Context
+import android.content.ContextWrapper
 import android.content.Intent
 import android.view.View
 import android.widget.Button
@@ -22,7 +25,23 @@ object UIUtils {
         button.setOnClickListener {
             val intent = Intent(context, ProductDetailsActivity::class.java)
             intent.putExtra(ProductDetailsActivity.PRODUCT_SLUG, productSlug)
-            context.startActivity(intent)
+            val activity = context.getActivity()
+            if (activity != null) {
+                activity.startActivityForResult(intent, TestpressStore.STORE_REQUEST_CODE)
+            } else {
+                context.startActivity(intent)
+            }
         }
+    }
+
+    private fun Context.getActivity(): Activity? {
+        var context = this
+        while (context is ContextWrapper) {
+            if (context is Activity) {
+                return context
+            }
+            context = context.baseContext
+        }
+        return null
     }
 }

--- a/course/src/main/java/in/testpress/course/util/UIUtils.kt
+++ b/course/src/main/java/in/testpress/course/util/UIUtils.kt
@@ -29,6 +29,7 @@ object UIUtils {
             if (activity != null) {
                 activity.startActivityForResult(intent, TestpressStore.STORE_REQUEST_CODE)
             } else {
+                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
                 context.startActivity(intent)
             }
         }


### PR DESCRIPTION
- When users completed a course purchase and selected "Continue purchase" or returned from the course preview, their purchased courses list did not refresh to show the new course.
- This occurred because the course list only cleared and refreshed when continue_purchase was false, and the CoursePreviewActivity and UIUtils did not launch or propagate activity results via startActivityForResult with the STORE_REQUEST_CODE.
- Fixed by calling startActivityForResult when launching the store/preview from the list adapter and utility class. Also updated CoursePreviewActivity to capture and propagate the successful purchase result even when continuePurchase is true, ensuring CourseListFragment always refreshes the purchased course list.