### PR TITLE
fix: Use exam-level attempts count for retake decisions

### DIFF
--- a/course/src/main/java/in/testpress/course/domain/DomainContent.kt
+++ b/course/src/main/java/in/testpress/course/domain/DomainContent.kt
@@ -93,15 +93,19 @@ data class DomainContent(
         return null
     }
 
+    fun getAttemptsCount(): Int {
+        return exam?.attemptsCount ?: attemptsCount ?: 0
+    }
+
     fun hasAttempted(): Boolean {
-        return (attemptsCount ?: 0) > 0
+        return getAttemptsCount() > 0
     }
 
     fun hasNotAttempted() = !hasAttempted()
 
     private fun canRetakeExam(): Boolean {
         if (exam?.allowRetake == true) {
-            return (attemptsCount!! <= exam!!.maxRetakes!!) || (exam!!.maxRetakes == -1)
+            return (getAttemptsCount() <= (exam!!.maxRetakes ?: 0)) || (exam!!.maxRetakes == -1)
         }
 
         return false

--- a/course/src/main/java/in/testpress/course/domain/DomainContent.kt
+++ b/course/src/main/java/in/testpress/course/domain/DomainContent.kt
@@ -105,7 +105,7 @@ data class DomainContent(
 
     private fun canRetakeExam(): Boolean {
         if (exam?.allowRetake == true) {
-            return (getAttemptsCount() <= (exam!!.maxRetakes ?: 0)) || (exam!!.maxRetakes == -1)
+            return (getAttemptsCount() <= (exam?.maxRetakes ?: 0)) || (exam?.maxRetakes == -1)
         }
 
         return false

--- a/course/src/main/java/in/testpress/course/fragments/BaseExamWidgetFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/BaseExamWidgetFragment.kt
@@ -197,7 +197,7 @@ open class BaseExamWidgetFragment : Fragment() {
 
     private fun canDownloadExam(): Boolean {
         return if (content.exam?.allowRetake == true) {
-            val totalAttemptTaken = content.attemptsCount!! + content.exam?.pausedAttemptsCount!!
+            val totalAttemptTaken = content.getAttemptsCount() + (content.exam?.pausedAttemptsCount ?: 0)
             (totalAttemptTaken <= content.exam!!.maxRetakes!!) || (content.exam!!.maxRetakes == -1)
         } else {
             return content.hasNotAttempted() && (content.exam?.pausedAttemptsCount!! == 0)
@@ -206,7 +206,7 @@ open class BaseExamWidgetFragment : Fragment() {
 
     private fun canAttemptOfflineExam(): Boolean {
         return if (content.exam?.allowRetake == true) {
-            val totalAttemptTaken = content.attemptsCount!! + content.exam?.pausedAttemptsCount!!
+            val totalAttemptTaken = content.getAttemptsCount() + (content.exam?.pausedAttemptsCount ?: 0)
             (totalAttemptTaken <= content.exam!!.maxRetakes!!) || (content.exam!!.maxRetakes == -1)
         } else {
             return content.hasNotAttempted() && (content.exam?.pausedAttemptsCount!! == 0)
@@ -309,7 +309,7 @@ open class BaseExamWidgetFragment : Fragment() {
     private fun updateAttemptsCountToDownloadedOfflineExam() {
         offlineExamViewModel.updateAttemptsCount(
             content.examId!!,
-            content.attemptsCount!!.toLong(),
+            content.getAttemptsCount().toLong(),
             content.exam?.pausedAttemptsCount!!.toLong()
         )
     }

--- a/course/src/main/java/in/testpress/course/fragments/ExamContentFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/ExamContentFragment.kt
@@ -82,7 +82,7 @@ interface ExamRefreshListener {
 class ExamWidgetFactory {
     companion object {
         fun getWidget(content: DomainContent): Fragment {
-            val attemptsCount = content.exam?.attemptsCount ?: content.attemptsCount ?: 0
+            val attemptsCount = content.getAttemptsCount()
             if (attemptsCount > 0){
                 return AttemptsListFragment()
             }

--- a/course/src/main/java/in/testpress/course/fragments/ExamContentFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/ExamContentFragment.kt
@@ -82,7 +82,8 @@ interface ExamRefreshListener {
 class ExamWidgetFactory {
     companion object {
         fun getWidget(content: DomainContent): Fragment {
-            if (content.attemptsCount!! > 0){
+            val attemptsCount = content.exam?.attemptsCount ?: content.attemptsCount ?: 0
+            if (attemptsCount > 0){
                 return AttemptsListFragment()
             }
             return ExamStartScreenFragment()

--- a/course/src/main/java/in/testpress/course/fragments/QuizContentFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/QuizContentFragment.kt
@@ -64,7 +64,7 @@ class QuizContentFragment: BaseContentDetailFragment(), ExamRefreshListener {
 class QuizWidgetFactory {
     companion object {
         fun getWidget(content: DomainContent, context: Context): Fragment? {
-            if ((content.exam?.attemptsCount ?: content.attemptsCount ?: 0) > 0 && InternetConnectivityChecker.isConnected(context)){
+            if (content.getAttemptsCount() > 0 && InternetConnectivityChecker.isConnected(context)){
                 return QuizAttemptsList()
             }
             return null

--- a/course/src/main/java/in/testpress/course/fragments/QuizContentFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/QuizContentFragment.kt
@@ -64,7 +64,7 @@ class QuizContentFragment: BaseContentDetailFragment(), ExamRefreshListener {
 class QuizWidgetFactory {
     companion object {
         fun getWidget(content: DomainContent, context: Context): Fragment? {
-            if (content.attemptsCount!! > 0 && InternetConnectivityChecker.isConnected(context)){
+            if ((content.exam?.attemptsCount ?: content.attemptsCount ?: 0) > 0 && InternetConnectivityChecker.isConnected(context)){
                 return QuizAttemptsList()
             }
             return null


### PR DESCRIPTION
**Issue:**
After completing an exam inside a course, some users were shown the start/retake screen instead of the attempt history or scoring page, even when allow_retake was disabled and they had already attempted the exam once.

**Cause:**
The API response contains two different attempts_count values:
- Top-level content.attempts_count (from ChapterContentParticipant
  table, updated asynchronously via Celery — can be stale at 0)
- Nested exam.attempts_count (direct COUNT on UserExam table —
  always fresh)

The Android app was using the content-level attempts_count, which returned 0 for users whose async participant count update hadn't completed yet. This made hasNotAttempted() return true, incorrectly allowing the retake flow.

**Fix:**
Changed all retake decision points to read exam.attemptsCount as the authoritative source, falling back to content.attemptsCount only when exam data is unavailable:

- DomainContent.getAttemptsCount() — new helper that prefers exam-level count
- ExamWidgetFactory.getWidget() — routes to AttemptsListFragment when exam-level count > 0
- QuizWidgetFactory.getWidget() — same fix for quizzes
- canDownloadExam(), canAttemptOfflineExam() — use exam-level count for retake limit calculation

The exam-level count is always accurate because it queries the UserExam table directly on every API request, with no caching or async update delays.