### PR TITLE
feat: Bypass overlay detection for metier practice exams

### DIFF
--- a/core/src/main/java/in/testpress/models/InstituteSettings.java
+++ b/core/src/main/java/in/testpress/models/InstituteSettings.java
@@ -508,4 +508,8 @@ public class InstituteSettings {
     public boolean isBrilliantPalaELearn() {
         return getDomainUrl().toLowerCase().contains("brilliantpala");
     }
+
+    public boolean isMetier() {
+        return getDomainUrl().toLowerCase().contains("metier");
+    }
 }

--- a/exam/src/main/java/in/testpress/exam/ui/TestActivity.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestActivity.java
@@ -109,6 +109,7 @@ public class TestActivity extends BaseToolBarActivity  {
     private boolean reflectionCompleted = false;
     private static final int REFLECTION_REQUEST_CODE = 1001;
     private boolean isBrilliantPala;
+    private boolean isMetier;
 
     @Override
     protected void onCreate(final Bundle savedInstanceState) {
@@ -139,6 +140,7 @@ public class TestActivity extends BaseToolBarActivity  {
         apiClient = new TestpressExamApiClient(this);
         TestpressSession session = TestpressSdk.getTestpressSession(this);
         isBrilliantPala = session != null && session.getInstituteSettings().isBrilliantPalaELearn();
+        isMetier = session != null && session.getInstituteSettings().isMetier();
         final Intent intent = getIntent();
         Bundle data = intent.getExtras();
         assert data != null;
@@ -188,7 +190,7 @@ public class TestActivity extends BaseToolBarActivity  {
 
     @Override
     public boolean dispatchTouchEvent(MotionEvent ev) {
-        if (isKioskModeRequired() || !isBrilliantPala) {
+        if (isKioskModeRequired() || (!isBrilliantPala && !isMetier)) {
             if (isOverlayDetected(ev)) return true;
         }
         if (blockInputIfUnpinned(ev)) return true;


### PR DESCRIPTION

Students at metier require the use of floating windows during unmonitored practice exams.
The SDK previously blocked all overlays in TestActivity regardless of the exam settings.
Added ismetier() helper to InstituteSettings and updated TestActivity to bypass overlay detection if monitoring is disabled and the institute is metier