### PR TITLE
feat: Display relative and absolute validity in product details

### DIFF
--- a/store/src/main/java/in/testpress/store/ui/ProductDetailFragment.kt
+++ b/store/src/main/java/in/testpress/store/ui/ProductDetailFragment.kt
@@ -23,9 +23,11 @@ import androidx.fragment.app.FragmentActivity
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import `in`.testpress.core.TestpressException
 import `in`.testpress.database.entities.DomainProduct
+import `in`.testpress.database.entities.PriceEntity
 import `in`.testpress.enums.Status
 import `in`.testpress.fragments.EmptyViewFragment
 import `in`.testpress.fragments.EmptyViewListener
+import `in`.testpress.store.R
 import `in`.testpress.store.TestpressStore
 import `in`.testpress.store.data.model.NetworkProductOffersResponse
 import `in`.testpress.store.data.model.mapping.asProduct
@@ -34,6 +36,7 @@ import `in`.testpress.store.databinding.TestpressProductDetailsFragmentBinding
 import `in`.testpress.store.models.Order
 import `in`.testpress.store.ui.viewmodel.ProductViewModel
 import `in`.testpress.store.util.generateRandom10CharString
+import `in`.testpress.util.DateUtils
 import `in`.testpress.util.StringUtils
 import `in`.testpress.util.ImageUtils
 import `in`.testpress.util.UILImageGetter
@@ -245,6 +248,8 @@ class ProductDetailFragment : Fragment(), EmptyViewListener {
                     notesListContainer.isVisible = false
                 }
 
+                renderValidity()
+
                 buyButton.apply {
                     text = product.buyNowText
                     setOnClickListener {
@@ -315,6 +320,36 @@ class ProductDetailFragment : Fragment(), EmptyViewListener {
                 isVisible = true
             }
         }
+    }
+
+    private fun renderValidity() {
+        val prices = domainProduct?.prices ?: return
+        val price = prices.firstOrNull() ?: return
+        if (price.purchaseValidityType == null) return
+
+        val validityText = getValidityInfo(price) ?: return
+        binding.detailLayout.validityContainer.isVisible = true
+        binding.detailLayout.validityText.text = validityText
+    }
+
+    private fun getValidityInfo(price: PriceEntity): String? {
+        return when (price.purchaseValidityType) {
+            1 -> getRelativeValidityText(price)
+            2 -> getAbsoluteValidityText(price)
+            else -> null
+        }
+    }
+
+    private fun getRelativeValidityText(price: PriceEntity): String? {
+        val days = price.validity?.toIntOrNull() ?: return null
+        return context?.resources?.getQuantityString(R.plurals.valid_for_days, days, days)
+    }
+
+    private fun getAbsoluteValidityText(price: PriceEntity): String? {
+        val date = price.absoluteExpiryDate ?: return null
+        val formatted = DateUtils.formatDateToReadable(date)
+        if (formatted.isEmpty() || formatted == date) return null
+        return getString(R.string.valid_till, formatted)
     }
 
     private fun showErrorState(exception: TestpressException?) {

--- a/store/src/main/java/in/testpress/store/ui/ProductDetailsActivity.java
+++ b/store/src/main/java/in/testpress/store/ui/ProductDetailsActivity.java
@@ -35,6 +35,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 
+import in.testpress.store.models.PricesItem;
 import in.testpress.core.TestpressCallback;
 import in.testpress.core.TestpressException;
 import in.testpress.core.TestpressSdk;
@@ -52,6 +53,7 @@ import in.testpress.store.models.UserInstallmentPlan;
 import in.testpress.store.network.StoreApiClient;
 import in.testpress.store.util.UtilKt;
 import in.testpress.ui.BaseToolBarActivity;
+import in.testpress.util.DateUtils;
 import in.testpress.util.EventsTrackerFacade;
 import in.testpress.util.ImageUtils;
 import in.testpress.util.UILImageGetter;
@@ -292,6 +294,8 @@ public class ProductDetailsActivity extends BaseToolBarActivity {
             appliedDiscountNameText.setVisibility(View.GONE);
         }
 
+        renderValidity(product);
+
         // Update product description
         if(product.getDescription().isEmpty()) {
             descriptionContainer.setVisibility(View.GONE);
@@ -454,6 +458,48 @@ public class ProductDetailsActivity extends BaseToolBarActivity {
         sheet.setPlanSelectedListener(selectedPlan ->
                 openDetailSheet(selectedPlan, true));
         sheet.show(getSupportFragmentManager(), "installment_plan_list");
+    }
+
+    private void renderValidity(Product product) {
+        TextView validityText = (TextView) findViewById(R.id.validity_text);
+        View validityContainer = findViewById(R.id.validity_container);
+        if (validityText == null || validityContainer == null) return;
+
+        List<PricesItem> prices = product.getPrices();
+        if (prices == null || prices.isEmpty()) return;
+        PricesItem price = prices.get(0);
+        if (price.getPurchaseValidityType() == null) return;
+
+        String validityInfo = getValidityInfo(price);
+        if (validityInfo != null) {
+            validityText.setText(validityInfo);
+            validityContainer.setVisibility(View.VISIBLE);
+        }
+    }
+
+    private String getValidityInfo(PricesItem price) {
+        Integer purchaseValidityType = price.getPurchaseValidityType();
+        if (purchaseValidityType == null) {
+            return null;
+        }
+        if (purchaseValidityType == 1) {
+            Integer days = price.getValidity();
+            if (days != null) {
+                return getResources().getQuantityString(R.plurals.valid_for_days, days, days);
+            }
+        } else if (purchaseValidityType == 2) {
+            String date = price.getAbsoluteExpiryDate();
+            if (date != null && !date.isEmpty()) {
+                return formatAbsoluteDate(date);
+            }
+        }
+        return null;
+    }
+
+    private String formatAbsoluteDate(String date) {
+        String formatted = DateUtils.formatDateToReadable(date);
+        if (formatted.isEmpty() || formatted.equals(date)) return null;
+        return getString(R.string.valid_till, formatted);
     }
 
     private void openDetailSheet(InstallmentPlan plan, boolean showBack) {

--- a/store/src/main/res/layout/testpress_product_details_content_scrolling.xml
+++ b/store/src/main/res/layout/testpress_product_details_content_scrolling.xml
@@ -76,6 +76,35 @@
         <RelativeLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:id="@+id/validity_container"
+            android:padding="@dimen/testpress_horizontal_margin"
+            android:visibility="gone">
+
+            <ImageView
+                android:id="@+id/validity_icon"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_centerVertical="true"
+                android:layout_marginEnd="@dimen/testpress_horizontal_margin"
+                android:layout_marginRight="@dimen/testpress_horizontal_margin"
+                android:src="@drawable/ic_event_black_18dp" />
+
+            <TextView
+                android:id="@+id/validity_text"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="@dimen/testpress_horizontal_margin"
+                android:layout_marginStart="@dimen/testpress_horizontal_margin"
+                android:layout_toEndOf="@id/validity_icon"
+                android:layout_toRightOf="@id/validity_icon"
+                android:textAppearance="@style/TextAppearance.AppCompat.Small"
+                android:textColor="#212121" />
+
+        </RelativeLayout>
+
+        <RelativeLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
             android:id="@+id/total_notes_container"
             android:padding="@dimen/testpress_horizontal_margin">
 

--- a/store/src/main/res/values/strings.xml
+++ b/store/src/main/res/values/strings.xml
@@ -79,4 +79,11 @@
     <string name="installment_due_on">due on %1$s</string>
     <string name="testpress_amount_with_symbol">₹%1$s</string>
 
+    <plurals name="valid_for_days">
+        <item quantity="one">Valid for %d day</item>
+        <item quantity="other">Valid for %d days</item>
+    </plurals>
+
+    <string name="valid_till">Valid till %1$s</string>
+
 </resources>


### PR DESCRIPTION
Display the purchase validity for a product on the product detail screen. Render validity information based on the purchaseValidityType of the product's price. Display relative validity (e.g., Valid for 30 days) or absolute validity (e.g., Valid till Dec 31, 2025).