### PR TITLE
feat: Add webview support for BPSC exam templates

### DIFF
--- a/core/src/main/java/in/testpress/fragments/WebViewFragment.kt
+++ b/core/src/main/java/in/testpress/fragments/WebViewFragment.kt
@@ -29,7 +29,7 @@ class WebViewFragment : Fragment(), EmptyViewListener {
     private val layout: WebviewFragmentBinding get() = _layout!!
     lateinit var webView: android.webkit.WebView
     var instituteSettings: InstituteSettings? = null
-    private var listener : Listener? = null
+    var listener : Listener? = null
     var imagePath: String? = null
     var filePathCallback: ValueCallback<Array<Uri>?>? = null
     private lateinit var emptyViewFragment: EmptyViewFragment
@@ -195,10 +195,6 @@ class WebViewFragment : Fragment(), EmptyViewListener {
         retryLoad()
     }
 
-    fun setListener(listener: Listener){
-        this.listener = listener
-    }
-
     @SuppressLint("JavascriptInterface")
     fun addJavascriptInterface(javascriptInterface: BaseJavaScriptInterface, name: String){
         webView.addJavascriptInterface(javascriptInterface,name)
@@ -226,6 +222,7 @@ class WebViewFragment : Fragment(), EmptyViewListener {
 
     interface Listener {
         fun onWebViewInitializationSuccess()
+        fun shouldOverrideUrlLoading(url: String?): Boolean = false
     }
 
     companion object {

--- a/core/src/main/java/in/testpress/ui/AbstractWebViewActivity.kt
+++ b/core/src/main/java/in/testpress/ui/AbstractWebViewActivity.kt
@@ -46,7 +46,7 @@ abstract class AbstractWebViewActivity: BaseToolBarActivity(), WebViewFragment.L
     open fun initializeWebViewFragment() {
         webViewFragment = WebViewFragment()
         webViewFragment.arguments = getWebViewArguments()
-        webViewFragment.setListener(this)
+        webViewFragment.listener = this
         supportFragmentManager.beginTransaction()
             .replace(R.id.fragment_container, webViewFragment)
             .commit()
@@ -92,4 +92,12 @@ class WebViewWithSSOActivity:AbstractWebViewActivity(){
 
     override fun onWebViewInitializationSuccess() {}
 
+    override fun shouldOverrideUrlLoading(url: String?): Boolean {
+        if (url?.contains("/review/") == true && (url.contains("/attempts/") || url.contains("/exams/"))) {
+            setResult(android.app.Activity.RESULT_OK)
+            finish()
+            return true
+        }
+        return false
+    }
 }

--- a/core/src/main/java/in/testpress/util/webview/CustomWebViewClient.kt
+++ b/core/src/main/java/in/testpress/util/webview/CustomWebViewClient.kt
@@ -14,6 +14,9 @@ class CustomWebViewClient(val fragment: WebViewFragment) : AndroidWebViewClient(
 
     override fun shouldOverrideUrlLoading(view: AndroidWebView?, request: WebResourceRequest?): Boolean {
         val url = request?.url.toString()
+        if (fragment.listener?.shouldOverrideUrlLoading(url) == true) {
+            return true
+        }
         return when {
             isPDFUrl(url) -> {
                 fragment.openUrlInBrowser(url)
@@ -43,6 +46,11 @@ class CustomWebViewClient(val fragment: WebViewFragment) : AndroidWebViewClient(
     private fun hasHttpScheme(url: String): Boolean {
         return url.startsWith("http://", ignoreCase = true) ||
                url.startsWith("https://", ignoreCase = true)
+    }
+
+    override fun doUpdateVisitedHistory(view: AndroidWebView?, url: String?, isReload: Boolean) {
+        super.doUpdateVisitedHistory(view, url, isReload)
+        fragment.listener?.shouldOverrideUrlLoading(url)
     }
 
     override fun onPageStarted(view: AndroidWebView?, url: String?, favicon: Bitmap?) {

--- a/exam/src/main/java/in/testpress/exam/ui/MindsetInsightsActivity.kt
+++ b/exam/src/main/java/in/testpress/exam/ui/MindsetInsightsActivity.kt
@@ -30,7 +30,7 @@ class MindsetInsightsActivity : AbstractWebViewActivity() {
             putBoolean(WebViewFragment.IS_AUTHENTICATION_REQUIRED, true)
             putInt(WebViewFragment.CACHE_MODE, WebSettings.LOAD_NO_CACHE)
         }
-        webViewFragment.setListener(this)
+        webViewFragment.listener = this
         supportFragmentManager.beginTransaction()
             .replace(R.id.fragment_container, webViewFragment)
             .commitAllowingStateLoss()

--- a/exam/src/main/java/in/testpress/exam/ui/TestActivity.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestActivity.java
@@ -57,6 +57,8 @@ import in.testpress.ui.BaseToolBarActivity;
 import in.testpress.util.Assert;
 import in.testpress.util.FormatDate;
 import in.testpress.util.UIUtils;
+import in.testpress.models.SSOUrl;
+import in.testpress.ui.WebViewWithSSOActivity;
 import in.testpress.util.ViewUtils;
 import in.testpress.v2_4.models.ApiResponse;
 
@@ -81,6 +83,7 @@ public class TestActivity extends BaseToolBarActivity  {
     public static final String PARAM_IS_PARTIAL_QUESTIONS = "isPartialQuestions";
     public static final String PARAM_ACTION = "action";
     public static final String PARAM_VALUE_ACTION_END = "end";
+    private static final int BPSC_WEBVIEW_REQUEST_CODE = 1002;
     private TestpressExamApiClient apiClient;
     Exam exam;
     Attempt attempt;
@@ -593,26 +596,32 @@ public class TestActivity extends BaseToolBarActivity  {
         progressBar.setVisibility(View.VISIBLE);
         fragmentContainer.setVisibility(View.GONE);
         apiClient.getSSOURL()
-            .enqueue(new in.testpress.core.TestpressCallback<in.testpress.models.SSOUrl>() {
+            .enqueue(new TestpressCallback<SSOUrl>() {
                 @Override
-                public void onSuccess(in.testpress.models.SSOUrl result) {
+                public void onSuccess(SSOUrl result) {
                     progressBar.setVisibility(View.GONE);
-                    String baseUrl = in.testpress.core.TestpressSdk.getTestpressSession(TestActivity.this).getInstituteSettings().getBaseUrl();
+                    TestpressSession session = TestpressSdk.getTestpressSession(TestActivity.this);
+                    if (session == null || result == null || result.getSsoUrl() == null) {
+                        ViewUtils.toast(TestActivity.this, "Failed to authenticate. Please try again.");
+                        finish();
+                        return;
+                    }
+                    String baseUrl = session.getInstituteSettings().getBaseUrl();
                     String fullUrl = baseUrl + result.getSsoUrl() + "&next=" + urlPath;
-                    startActivityForResult(in.testpress.ui.WebViewWithSSOActivity.Companion.createIntent(
+                    startActivityForResult(WebViewWithSSOActivity.Companion.createIntent(
                             TestActivity.this,
                             exam.getTitle(),
                             fullUrl,
                             true,
                             false,
-                            in.testpress.ui.WebViewWithSSOActivity.class
-                    ), 1002);
+                            WebViewWithSSOActivity.class
+                    ), BPSC_WEBVIEW_REQUEST_CODE);
                 }
 
                 @Override
-                public void onException(in.testpress.core.TestpressException exception) {
+                public void onException(TestpressException exception) {
                     progressBar.setVisibility(View.GONE);
-                    in.testpress.util.ViewUtils.toast(TestActivity.this, "Failed to authenticate. Please try again.");
+                    ViewUtils.toast(TestActivity.this, "Failed to authenticate. Please try again.");
                     finish();
                 }
             });
@@ -830,10 +839,13 @@ public class TestActivity extends BaseToolBarActivity  {
 
     private String getBpscExamUrlPath(boolean resumeExam) {
         if (resumeExam) {
-            if (courseContent != null) {
+            if (courseContent != null && courseAttempt != null) {
                 return "/exams/chapter_content/" + courseContent.getId() + "/" + courseAttempt.getId() + "/";
             }
-            return "/exams/run/" + exam.getSlug() + "/start/" + attempt.getId() + "/";
+            if (exam != null && attempt != null) {
+                return "/exams/run/" + exam.getSlug() + "/start/" + attempt.getId() + "/";
+            }
+            return "";
         }
         if (courseContent != null) {
             if (isPartialQuestions) {
@@ -841,7 +853,7 @@ public class TestActivity extends BaseToolBarActivity  {
             }
             return "/exams/chapter_content/" + courseContent.getId() + "/";
         }
-        return "/exams/run/" + exam.getSlug() + "/start/";
+        return exam != null ? "/exams/run/" + exam.getSlug() + "/start/" : "";
     }
 
     private void createContentAttempt() {
@@ -884,7 +896,7 @@ public class TestActivity extends BaseToolBarActivity  {
             }
             return;
         }
-        if (requestCode == 1002) {
+        if (requestCode == BPSC_WEBVIEW_REQUEST_CODE) {
             setResult(Activity.RESULT_OK);
             finish();
             return;

--- a/exam/src/main/java/in/testpress/exam/ui/TestActivity.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestActivity.java
@@ -588,6 +588,36 @@ public class TestActivity extends BaseToolBarActivity  {
         }
     }
 
+
+    private void fetchSSOAndLaunchWebView(final String urlPath) {
+        progressBar.setVisibility(View.VISIBLE);
+        fragmentContainer.setVisibility(View.GONE);
+        apiClient.getSSOURL()
+            .enqueue(new in.testpress.core.TestpressCallback<in.testpress.models.SSOUrl>() {
+                @Override
+                public void onSuccess(in.testpress.models.SSOUrl result) {
+                    progressBar.setVisibility(View.GONE);
+                    String baseUrl = in.testpress.core.TestpressSdk.getTestpressSession(TestActivity.this).getInstituteSettings().getBaseUrl();
+                    String fullUrl = baseUrl + result.getSsoUrl() + "&next=" + urlPath;
+                    startActivityForResult(in.testpress.ui.WebViewWithSSOActivity.Companion.createIntent(
+                            TestActivity.this,
+                            exam.getTitle(),
+                            fullUrl,
+                            true,
+                            false,
+                            in.testpress.ui.WebViewWithSSOActivity.class
+                    ), 1002);
+                }
+
+                @Override
+                public void onException(in.testpress.core.TestpressException exception) {
+                    progressBar.setVisibility(View.GONE);
+                    in.testpress.util.ViewUtils.toast(TestActivity.this, "Failed to authenticate. Please try again.");
+                    finish();
+                }
+            });
+    }
+
     @SuppressLint("SetTextI18n")
     void displayStartExamScreen() {
         TextView examTitle = findViewById(R.id.exam_title);
@@ -775,6 +805,13 @@ public class TestActivity extends BaseToolBarActivity  {
             startLockTask();
             return;
         }
+
+        if (isBpscTemplate()) {
+            String urlPath = getBpscExamUrlPath(resumeExam);
+            fetchSSOAndLaunchWebView(urlPath);
+            return;
+        }
+
         if (resumeExam){
             examViewModel.startAttempt(attempt.getStartUrlFrag());
         } else {
@@ -785,6 +822,26 @@ public class TestActivity extends BaseToolBarActivity  {
             }
         }
         examDetailsContainer.setVisibility(View.GONE);
+    }
+
+    private boolean isBpscTemplate() {
+        return exam != null && exam.getTemplateType() != null && exam.getTemplateType() == 22;
+    }
+
+    private String getBpscExamUrlPath(boolean resumeExam) {
+        if (resumeExam) {
+            if (courseContent != null) {
+                return "/exams/chapter_content/" + courseContent.getId() + "/" + courseAttempt.getId() + "/";
+            }
+            return "/exams/run/" + exam.getSlug() + "/start/" + attempt.getId() + "/";
+        }
+        if (courseContent != null) {
+            if (isPartialQuestions) {
+                return "/exams/chapter_content/" + courseContent.getId() + "/retake/incorrect/";
+            }
+            return "/exams/chapter_content/" + courseContent.getId() + "/";
+        }
+        return "/exams/run/" + exam.getSlug() + "/start/";
     }
 
     private void createContentAttempt() {
@@ -825,6 +882,11 @@ public class TestActivity extends BaseToolBarActivity  {
                 reflectionCompleted = true;
                 showWarningAlertOrStartExam();
             }
+            return;
+        }
+        if (requestCode == 1002) {
+            setResult(Activity.RESULT_OK);
+            finish();
             return;
         }
         if ((requestCode == CarouselFragment.TEST_TAKEN_REQUEST_CODE) && (Activity.RESULT_OK == resultCode)) {


### PR DESCRIPTION
- BPSC template exams (templateType 22) require a web interface rather than the native exam screen
- Added logic to identify BPSC templates and fetch an SSO URL before launching the exam
- The exam is now launched using WebViewWithSSOActivity with the generated URL
- Handled the activity result to properly finish the TestActivity when returning from the webview