### PR TITLE
fix: Resolve NPE on exam start and hide empty attempt headers

### DIFF
--- a/course/src/main/java/in/testpress/course/fragments/BaseExamWidgetFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/BaseExamWidgetFragment.kt
@@ -412,7 +412,7 @@ open class BaseExamWidgetFragment : Fragment() {
         if (exam.templateType in listOf(IELTS_TEMPLATE, CTET_TEMPLATE)) {
             startButton.setOnClickListener {startExamInWebview(content)}
         } else if (contentAttempts.isEmpty()) {
-            MultiLanguagesUtil.supportMultiLanguage(requireActivity(), exam.asGreenDaoModel(), startButton) {
+            MultiLanguagesUtil.supportMultiLanguage(requireActivity(), requireView(), exam.asGreenDaoModel(), startButton) {
                 if (shouldShowPreExamReflection(exam)) {
                     openPreExamReflection(exam)
                 } else {
@@ -502,7 +502,7 @@ open class BaseExamWidgetFragment : Fragment() {
         if (exam.templateType in listOf(IELTS_TEMPLATE, CTET_TEMPLATE) || exam.hasAudioQuestions == true) {
             startButton.setOnClickListener { startExamInWebview(content) }
         } else if (contentAttempts.isEmpty()) {
-            MultiLanguagesUtil.supportMultiLanguage(activity, exam.asGreenDaoModel(), startButton) {
+            MultiLanguagesUtil.supportMultiLanguage(requireActivity(), requireView(), exam.asGreenDaoModel(), startButton) {
                 resumeExamBasedOnAttemptType(exam, true, pausedAttempt)
             }
         } else {

--- a/course/src/main/java/in/testpress/course/fragments/BaseExamWidgetFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/BaseExamWidgetFragment.kt
@@ -412,7 +412,9 @@ open class BaseExamWidgetFragment : Fragment() {
         if (exam.templateType in listOf(IELTS_TEMPLATE, CTET_TEMPLATE)) {
             startButton.setOnClickListener {startExamInWebview(content)}
         } else if (contentAttempts.isEmpty()) {
-            MultiLanguagesUtil.supportMultiLanguage(requireActivity(), requireView(), exam.asGreenDaoModel(), startButton) {
+            val act = activity ?: return
+            val v = view ?: return
+            MultiLanguagesUtil.supportMultiLanguage(act, v, exam.asGreenDaoModel(), startButton) {
                 if (shouldShowPreExamReflection(exam)) {
                     openPreExamReflection(exam)
                 } else {
@@ -502,7 +504,9 @@ open class BaseExamWidgetFragment : Fragment() {
         if (exam.templateType in listOf(IELTS_TEMPLATE, CTET_TEMPLATE) || exam.hasAudioQuestions == true) {
             startButton.setOnClickListener { startExamInWebview(content) }
         } else if (contentAttempts.isEmpty()) {
-            MultiLanguagesUtil.supportMultiLanguage(requireActivity(), requireView(), exam.asGreenDaoModel(), startButton) {
+            val act = activity ?: return
+            val v = view ?: return
+            MultiLanguagesUtil.supportMultiLanguage(act, v, exam.asGreenDaoModel(), startButton) {
                 resumeExamBasedOnAttemptType(exam, true, pausedAttempt)
             }
         } else {

--- a/course/src/main/java/in/testpress/course/ui/ContentAttemptListAdapter.java
+++ b/course/src/main/java/in/testpress/course/ui/ContentAttemptListAdapter.java
@@ -105,6 +105,9 @@ public class ContentAttemptListAdapter extends RecyclerView.Adapter<RecyclerView
 
     @Override
     public int getItemCount() {
+        if (mAttempts.isEmpty()) {
+            return 0;
+        }
         return mAttempts.size() + 1;
     }
 

--- a/exam/src/main/java/in/testpress/exam/ui/AttemptListAdapter.java
+++ b/exam/src/main/java/in/testpress/exam/ui/AttemptListAdapter.java
@@ -99,6 +99,9 @@ class AttemptListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder>  
 
     @Override
     public int getItemCount() {
+        if (mAttempts.isEmpty()) {
+            return 0;
+        }
         return mAttempts.size() + 1;
     }
 

--- a/exam/src/main/java/in/testpress/exam/ui/AttemptsActivity.java
+++ b/exam/src/main/java/in/testpress/exam/ui/AttemptsActivity.java
@@ -183,7 +183,7 @@ public class AttemptsActivity extends BaseToolBarActivity
             descriptionContent.setText(exam.getDescription());
         }
         if (canAttemptExam()) {
-            MultiLanguagesUtil.supportMultiLanguage(this, exam, startButton,
+            MultiLanguagesUtil.supportMultiLanguage(this, findViewById(android.R.id.content), exam, startButton,
                     new MultiLanguagesUtil.LanguageSelectionListener() {
                         @Override
                         public void onLanguageSelected() {

--- a/exam/src/main/java/in/testpress/exam/ui/TestActivity.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestActivity.java
@@ -654,7 +654,7 @@ public class TestActivity extends BaseToolBarActivity  {
         examTitle.setText(exam.getTitle());
         numberOfQuestions.setText(exam.getNumberOfQuestions().toString());
         if (attempt == null) {
-            MultiLanguagesUtil.supportMultiLanguage(this, exam, startButton,
+            MultiLanguagesUtil.supportMultiLanguage(this, findViewById(android.R.id.content), exam, startButton,
                     new MultiLanguagesUtil.LanguageSelectionListener() {
                         @Override
                         public void onLanguageSelected() {
@@ -662,7 +662,7 @@ public class TestActivity extends BaseToolBarActivity  {
                         }});
             examDuration.setText(exam.getDuration());
         } else {
-            MultiLanguagesUtil.supportMultiLanguage(this, exam, resumeButton,
+            MultiLanguagesUtil.supportMultiLanguage(this, findViewById(android.R.id.content), exam, resumeButton,
                     new MultiLanguagesUtil.LanguageSelectionListener() {
                         @Override
                         public void onLanguageSelected() {

--- a/exam/src/main/java/in/testpress/exam/util/MultiLanguagesUtil.java
+++ b/exam/src/main/java/in/testpress/exam/util/MultiLanguagesUtil.java
@@ -19,10 +19,19 @@ import in.testpress.ui.ExploreSpinnerAdapter;
 
 public class MultiLanguagesUtil {
 
-    public static void supportMultiLanguage(final Activity activity, final Exam exam, Button startButton,
+    public static void supportMultiLanguage(final Activity activity, View rootView, final Exam exam, Button startButton,
                                             final LanguageSelectionListener listener) {
 
-        View languageLayout = activity.findViewById(R.id.language_layout);
+        View languageLayout = rootView.findViewById(R.id.language_layout);
+        if (languageLayout == null) {
+            startButton.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    listener.onLanguageSelected();
+                }
+            });
+            return;
+        }
         final ArrayList<Language> languages = new ArrayList<>(exam.getRawLanguages());
         if (languages.size() > 1) {
             final ExploreSpinnerAdapter languageSpinnerAdapter =
@@ -32,7 +41,7 @@ public class MultiLanguagesUtil {
             for (Language language : languages) {
                 languageSpinnerAdapter.addItem(language.getCode(), language.getTitle(), true, 0);
             }
-            final Spinner languageSpinner = (Spinner) activity.findViewById(R.id.language_spinner);
+            final Spinner languageSpinner = (Spinner) rootView.findViewById(R.id.language_spinner);
             languageSpinner.setAdapter(languageSpinnerAdapter);
             languageSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
                 @Override

--- a/exam/src/main/java/in/testpress/exam/util/MultiLanguagesUtil.java
+++ b/exam/src/main/java/in/testpress/exam/util/MultiLanguagesUtil.java
@@ -2,6 +2,7 @@ package in.testpress.exam.util;
 
 import android.app.Activity;
 import android.content.DialogInterface;
+import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
 import android.view.View;
 import android.widget.AdapterView;
@@ -19,10 +20,10 @@ import in.testpress.ui.ExploreSpinnerAdapter;
 
 public class MultiLanguagesUtil {
 
-    public static void supportMultiLanguage(final Activity activity, View rootView, final Exam exam, Button startButton,
+    public static void supportMultiLanguage(final Activity activity, @NonNull View rootView, final Exam exam, Button startButton,
                                             final LanguageSelectionListener listener) {
 
-        View languageLayout = rootView.findViewById(R.id.language_layout);
+        View languageLayout = rootView != null ? rootView.findViewById(R.id.language_layout) : null;
         if (languageLayout == null) {
             startButton.setOnClickListener(new View.OnClickListener() {
                 @Override
@@ -42,6 +43,15 @@ public class MultiLanguagesUtil {
                 languageSpinnerAdapter.addItem(language.getCode(), language.getTitle(), true, 0);
             }
             final Spinner languageSpinner = (Spinner) rootView.findViewById(R.id.language_spinner);
+            if (languageSpinner == null) {
+                startButton.setOnClickListener(new View.OnClickListener() {
+                    @Override
+                    public void onClick(View v) {
+                        listener.onLanguageSelected();
+                    }
+                });
+                return;
+            }
             languageSpinner.setAdapter(languageSpinnerAdapter);
             languageSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
                 @Override


### PR DESCRIPTION
Issue: 
- `MultiLanguagesUtil` crashed on fresh exams because it couldn't find the layout view before the Fragment attached to the Activity.
- Empty attempt table headers were showing when there was no data.

**Fix:**
- Changed `MultiLanguagesUtil.supportMultiLanguage()` to explicitly require a `View rootView` instead of relying on the Activity.
- Added a null-safety check for the language layout.
- Updated `AttemptListAdapter` and `ContentAttemptListAdapter` to return 0 when the attempts list is empty, hiding the empty headers.