### PR TITLE
feat: Make WebView zoom controls configurable via intent extras

### DIFF
--- a/core/src/main/java/in/testpress/fragments/WebViewFragment.kt
+++ b/core/src/main/java/in/testpress/fragments/WebViewFragment.kt
@@ -116,10 +116,10 @@ class WebViewFragment : Fragment(), EmptyViewListener {
         webView.settings.loadWithOverviewMode = true
         // Allow use of Local Storage
         webView.settings.domStorageEnabled = true
-        webView.settings.builtInZoomControls = true
+        webView.settings.builtInZoomControls = allowZoomControl
         webView.settings.displayZoomControls = false
         webView.settings.cacheMode = cacheMode
-        webView.settings.setSupportZoom(true)
+        webView.settings.setSupportZoom(allowZoomControl)
         webView.webViewClient = CustomWebViewClient(this)
         webView.webChromeClient = CustomWebChromeClient(this)
         webView.settings.userAgentString += CUSTOM_USER_AGENT

--- a/core/src/main/java/in/testpress/fragments/WebViewFragment.kt
+++ b/core/src/main/java/in/testpress/fragments/WebViewFragment.kt
@@ -116,10 +116,10 @@ class WebViewFragment : Fragment(), EmptyViewListener {
         webView.settings.loadWithOverviewMode = true
         // Allow use of Local Storage
         webView.settings.domStorageEnabled = true
-        // Disable pinch to zoom without the zoom buttons
-        webView.settings.builtInZoomControls = false
+        webView.settings.builtInZoomControls = true
+        webView.settings.displayZoomControls = false
         webView.settings.cacheMode = cacheMode
-        webView.settings.setSupportZoom(allowZoomControl)
+        webView.settings.setSupportZoom(true)
         webView.webViewClient = CustomWebViewClient(this)
         webView.webChromeClient = CustomWebChromeClient(this)
         webView.settings.userAgentString += CUSTOM_USER_AGENT

--- a/core/src/main/java/in/testpress/ui/AbstractWebViewActivity.kt
+++ b/core/src/main/java/in/testpress/ui/AbstractWebViewActivity.kt
@@ -17,6 +17,7 @@ abstract class AbstractWebViewActivity: BaseToolBarActivity(), WebViewFragment.L
     private var isAuthenticationRequired: Boolean = true
     private var allowNonInstituteUrl: Boolean = false
     private var allowValidationErrors: Boolean = false
+    private var allowZoomControls: Boolean = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -41,6 +42,7 @@ abstract class AbstractWebViewActivity: BaseToolBarActivity(), WebViewFragment.L
         isAuthenticationRequired = intent.getBooleanExtra(IS_AUTHENTICATION_REQUIRED,true)
         allowNonInstituteUrl = intent.getBooleanExtra(ALLOW_NON_INSTITUTE_URL_IN_WEB_VIEW, false)
         allowValidationErrors = intent.getBooleanExtra(ALLOW_VALIDATION_ERRORS, false)
+        allowZoomControls = intent.getBooleanExtra(WebViewFragment.ALLOW_ZOOM_CONTROLS, false)
     }
 
     open fun initializeWebViewFragment() {
@@ -57,6 +59,7 @@ abstract class AbstractWebViewActivity: BaseToolBarActivity(), WebViewFragment.L
             this.putString(WebViewFragment.URL_TO_OPEN, urlPath)
             this.putBoolean(WebViewFragment.IS_AUTHENTICATION_REQUIRED, isAuthenticationRequired)
             this.putBoolean(WebViewFragment.ALLOW_NON_INSTITUTE_URL_IN_WEB_VIEW, allowNonInstituteUrl)
+            this.putBoolean(WebViewFragment.ALLOW_ZOOM_CONTROLS, allowZoomControls)
             this.putBoolean(ALLOW_VALIDATION_ERRORS, allowValidationErrors)
         }
     }
@@ -83,6 +86,27 @@ abstract class AbstractWebViewActivity: BaseToolBarActivity(), WebViewFragment.L
                 putExtra(URL_TO_OPEN, urlPath)
                 putExtra(IS_AUTHENTICATION_REQUIRED, isAuthenticationRequired)
                 putExtra(ALLOW_NON_INSTITUTE_URL_IN_WEB_VIEW, allowNonInstituteUrl)
+            }
+        }
+
+        fun createIntent(
+            currentContext: Context,
+            title: String,
+            urlPath: String,
+            isAuthenticationRequired: Boolean,
+            allowNonInstituteUrl: Boolean = false,
+            allowZoomControls: Boolean = false,
+            activityToOpen: Class<out AbstractWebViewActivity>
+        ): Intent {
+            return createIntent(
+                currentContext,
+                title,
+                urlPath,
+                isAuthenticationRequired,
+                allowNonInstituteUrl,
+                activityToOpen
+            ).apply {
+                putExtra(WebViewFragment.ALLOW_ZOOM_CONTROLS, allowZoomControls)
             }
         }
     }

--- a/core/src/main/java/in/testpress/util/webview/WebView.kt
+++ b/core/src/main/java/in/testpress/util/webview/WebView.kt
@@ -27,10 +27,9 @@ open class WebView @JvmOverloads constructor(
             domStorageEnabled = true
             useWideViewPort = false
             loadWithOverviewMode = true
-            builtInZoomControls = true
-            displayZoomControls = false
+            builtInZoomControls = false
             cacheMode = WebSettings.LOAD_CACHE_ELSE_NETWORK
-            setSupportZoom(true)
+            setSupportZoom(false)
             userAgentString += " TestpressAndroidApp/WebView"
         }
         

--- a/core/src/main/java/in/testpress/util/webview/WebView.kt
+++ b/core/src/main/java/in/testpress/util/webview/WebView.kt
@@ -27,9 +27,10 @@ open class WebView @JvmOverloads constructor(
             domStorageEnabled = true
             useWideViewPort = false
             loadWithOverviewMode = true
-            builtInZoomControls = false
+            builtInZoomControls = true
+            displayZoomControls = false
             cacheMode = WebSettings.LOAD_CACHE_ELSE_NETWORK
-            setSupportZoom(false)
+            setSupportZoom(true)
             userAgentString += " TestpressAndroidApp/WebView"
         }
         


### PR DESCRIPTION
- The `WebViewFragment` now uses the `allowZoomControl` parameter to enable or disable zoom controls dynamically.
- `AbstractWebViewActivity` has been updated to accept `allowZoomControls` as an intent extra and pass it down to the `WebViewFragment`.