### PR TITLE
feat: Add Uyirmei to floating window allowed institutes

### DIFF
--- a/core/src/main/java/in/testpress/models/InstituteSettings.java
+++ b/core/src/main/java/in/testpress/models/InstituteSettings.java
@@ -505,11 +505,10 @@ public class InstituteSettings {
         return this;
     }
 
-    public boolean isBrilliantPalaELearn() {
-        return getDomainUrl().toLowerCase().contains("brilliantpala");
-    }
-
-    public boolean isMetier() {
-        return getDomainUrl().toLowerCase().contains("metier");
+    public boolean isFloatingWindowAllowedInstitute() {
+        String domain = getDomainUrl().toLowerCase();
+        return domain.contains("brilliantpala") || 
+               domain.contains("metier") || 
+               domain.contains("uyirmeitnpsctamilacademy");
     }
 }

--- a/core/src/main/java/in/testpress/models/InstituteSettings.java
+++ b/core/src/main/java/in/testpress/models/InstituteSettings.java
@@ -506,9 +506,25 @@ public class InstituteSettings {
     }
 
     public boolean isFloatingWindowAllowedInstitute() {
-        String domain = getDomainUrl().toLowerCase();
-        return domain.contains("brilliantpala") || 
-               domain.contains("metier") || 
+        String domainUrl = getDomainUrl();
+        if (domainUrl == null) return false;
+        String domain = domainUrl.toLowerCase();
+        return domain.contains("brilliantpala") ||
+               domain.contains("metier") ||
                domain.contains("uyirmeitnpsctamilacademy");
+    }
+
+    /** @deprecated Use {@link #isFloatingWindowAllowedInstitute()} instead */
+    @Deprecated
+    public boolean isBrilliantPalaELearn() {
+        String domainUrl = getDomainUrl();
+        return domainUrl != null && domainUrl.toLowerCase().contains("brilliantpala");
+    }
+
+    /** @deprecated Use {@link #isFloatingWindowAllowedInstitute()} instead */
+    @Deprecated
+    public boolean isMetier() {
+        String domainUrl = getDomainUrl();
+        return domainUrl != null && domainUrl.toLowerCase().contains("metier");
     }
 }

--- a/exam/src/main/java/in/testpress/exam/ui/TestActivity.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestActivity.java
@@ -141,7 +141,8 @@ public class TestActivity extends BaseToolBarActivity  {
         UIUtils.setIndeterminateDrawable(this, findViewById(R.id.progress_bar), 4);
         apiClient = new TestpressExamApiClient(this);
         TestpressSession session = TestpressSdk.getTestpressSession(this);
-        isFloatingWindowAllowedInstitute = session != null && session.getInstituteSettings().isFloatingWindowAllowedInstitute();
+        InstituteSettings settings = session != null ? session.getInstituteSettings() : null;
+        isFloatingWindowAllowedInstitute = settings != null && settings.isFloatingWindowAllowedInstitute();
         final Intent intent = getIntent();
         Bundle data = intent.getExtras();
         assert data != null;

--- a/exam/src/main/java/in/testpress/exam/ui/TestActivity.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestActivity.java
@@ -111,8 +111,7 @@ public class TestActivity extends BaseToolBarActivity  {
     private ExamViewModel examViewModel;
     private boolean reflectionCompleted = false;
     private static final int REFLECTION_REQUEST_CODE = 1001;
-    private boolean isBrilliantPala;
-    private boolean isMetier;
+    private boolean isFloatingWindowAllowedInstitute;
 
     @Override
     protected void onCreate(final Bundle savedInstanceState) {
@@ -142,8 +141,7 @@ public class TestActivity extends BaseToolBarActivity  {
         UIUtils.setIndeterminateDrawable(this, findViewById(R.id.progress_bar), 4);
         apiClient = new TestpressExamApiClient(this);
         TestpressSession session = TestpressSdk.getTestpressSession(this);
-        isBrilliantPala = session != null && session.getInstituteSettings().isBrilliantPalaELearn();
-        isMetier = session != null && session.getInstituteSettings().isMetier();
+        isFloatingWindowAllowedInstitute = session != null && session.getInstituteSettings().isFloatingWindowAllowedInstitute();
         final Intent intent = getIntent();
         Bundle data = intent.getExtras();
         assert data != null;
@@ -193,7 +191,7 @@ public class TestActivity extends BaseToolBarActivity  {
 
     @Override
     public boolean dispatchTouchEvent(MotionEvent ev) {
-        if (isKioskModeRequired() || (!isBrilliantPala && !isMetier)) {
+        if (isKioskModeRequired() || !isFloatingWindowAllowedInstitute) {
             if (isOverlayDetected(ev)) return true;
         }
         if (blockInputIfUnpinned(ev)) return true;


### PR DESCRIPTION
- Consolidate individual boolean checks for BrilliantPala and Metier into a single `isFloatingWindowAllowedInstitute` method
- Add `uyirmeitnpsctamilacademy` to the list of allowed domains
- This ensures users from the Uyirmei institute can use legitimate floating apps (like calculators) during exams when window monitoring is disabled