### PR TITLE
feat: Add Content Artifacts bottom sheet for downloading resources

### DIFF
--- a/course/src/main/java/in/testpress/course/fragments/BaseContentDetailFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/BaseContentDetailFragment.kt
@@ -28,6 +28,9 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import `in`.testpress.course.ui.ContentActivity.*
+import android.view.Menu
+import android.view.MenuInflater
+import android.util.Log
 
 abstract class BaseContentDetailFragment : Fragment(), BookmarkListener, ContentActivity.OnBackPressedListener,
     EmptyViewListener {
@@ -48,6 +51,7 @@ abstract class BaseContentDetailFragment : Fragment(), BookmarkListener, Content
     open lateinit var viewModel: ContentViewModel
     private var hideBottomNavigation: Boolean = false
     private var forceReloadContent: Boolean = false
+    private var optionsMenu: Menu? = null
 
     override val bookmarkId: Long?
         get() = if (!::content.isInitialized) null else content.bookmarkId
@@ -80,6 +84,10 @@ abstract class BaseContentDetailFragment : Fragment(), BookmarkListener, Content
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        if (item.itemId == R.id.view_resources) {
+            openResourcesBottomSheet()
+            return true
+        }
         val intent = Intent()
         intent.putExtra(TestpressSdk.ACTION_PRESSED_HOME, true)
 
@@ -91,6 +99,25 @@ abstract class BaseContentDetailFragment : Fragment(), BookmarkListener, Content
         return false
     }
 
+    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
+        super.onCreateOptionsMenu(menu, inflater)
+        optionsMenu = menu
+        inflater.inflate(R.menu.content_artifacts_menu, menu)
+    }
+
+    override fun onPrepareOptionsMenu(menu: Menu) {
+        super.onPrepareOptionsMenu(menu)
+        optionsMenu = menu
+        val hasArtifacts = isContentInitialized() && content.hasArtifacts == true
+        menu.findItem(R.id.view_resources)?.isVisible = hasArtifacts
+    }
+
+    private fun openResourcesBottomSheet() {
+        if (!isContentInitialized()) return
+        val bottomSheet = ContentArtifactsBottomSheet.newInstance(contentId)
+        bottomSheet.show(childFragmentManager, ContentArtifactsBottomSheet.TAG)
+    }
+
 
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     fun loadContentAndInitializeBoomarkFragment() {
@@ -99,6 +126,7 @@ abstract class BaseContentDetailFragment : Fragment(), BookmarkListener, Content
                 Status.SUCCESS -> {
                     content = resource.data!!
                     display()
+                    activity?.invalidateOptionsMenu()
 
                     if (isBookmarkEnabled && !::bookmarkFragment.isInitialized) {
                         initializeBookmarkFragment()

--- a/course/src/main/java/in/testpress/course/fragments/BaseContentDetailFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/BaseContentDetailFragment.kt
@@ -30,7 +30,7 @@ import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import `in`.testpress.course.ui.ContentActivity.*
 import android.view.Menu
 import android.view.MenuInflater
-import android.util.Log
+
 
 abstract class BaseContentDetailFragment : Fragment(), BookmarkListener, ContentActivity.OnBackPressedListener,
     EmptyViewListener {
@@ -51,7 +51,6 @@ abstract class BaseContentDetailFragment : Fragment(), BookmarkListener, Content
     open lateinit var viewModel: ContentViewModel
     private var hideBottomNavigation: Boolean = false
     private var forceReloadContent: Boolean = false
-    private var optionsMenu: Menu? = null
 
     override val bookmarkId: Long?
         get() = if (!::content.isInitialized) null else content.bookmarkId
@@ -101,13 +100,11 @@ abstract class BaseContentDetailFragment : Fragment(), BookmarkListener, Content
 
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
         super.onCreateOptionsMenu(menu, inflater)
-        optionsMenu = menu
         inflater.inflate(R.menu.content_artifacts_menu, menu)
     }
 
     override fun onPrepareOptionsMenu(menu: Menu) {
         super.onPrepareOptionsMenu(menu)
-        optionsMenu = menu
         val hasArtifacts = isContentInitialized() && content.hasArtifacts == true
         menu.findItem(R.id.view_resources)?.isVisible = hasArtifacts
     }

--- a/course/src/main/java/in/testpress/course/fragments/ContentArtifactsBottomSheet.kt
+++ b/course/src/main/java/in/testpress/course/fragments/ContentArtifactsBottomSheet.kt
@@ -1,0 +1,184 @@
+package `in`.testpress.course.fragments
+
+import `in`.testpress.course.R
+import `in`.testpress.course.databinding.FragmentContentArtifactsBottomSheetBinding
+import `in`.testpress.course.domain.DomainContentArtifact
+import `in`.testpress.course.ui.ContentArtifactsAdapter
+import `in`.testpress.course.viewmodels.ContentArtifactsViewModel
+import `in`.testpress.course.repository.ContentArtifactsRepository
+import `in`.testpress.enums.Status
+import android.app.DownloadManager
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import android.os.Environment
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Toast
+import androidx.core.view.isVisible
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.recyclerview.widget.DividerItemDecoration
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+
+
+class ContentArtifactsBottomSheet : BottomSheetDialogFragment() {
+
+    private var _binding: FragmentContentArtifactsBottomSheetBinding? = null
+    private val binding get() = _binding!!
+
+    private lateinit var viewModel: ContentArtifactsViewModel
+    private lateinit var adapter: ContentArtifactsAdapter
+
+    private var contentId: Long = -1L
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentContentArtifactsBottomSheetBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        contentId = arguments?.getLong(ARG_CONTENT_ID, -1L) ?: -1L
+
+        setupRecyclerView()
+        setupViewModel()
+        loadArtifacts()
+    }
+
+    private fun setupRecyclerView() {
+        adapter = ContentArtifactsAdapter { artifact -> onArtifactClicked(artifact) }
+        binding.rvArtifacts.apply {
+            layoutManager = LinearLayoutManager(requireContext())
+            adapter = this@ContentArtifactsBottomSheet.adapter
+        }
+    }
+
+    private fun setupViewModel() {
+        viewModel = ViewModelProvider(this, object : ViewModelProvider.Factory {
+            @Suppress("UNCHECKED_CAST")
+            override fun <T : ViewModel> create(modelClass: Class<T>): T {
+                return ContentArtifactsViewModel(ContentArtifactsRepository(requireContext())) as T
+            }
+        })[ContentArtifactsViewModel::class.java]
+    }
+
+    private fun loadArtifacts() {
+        if (contentId == -1L) {
+            dismiss()
+            return
+        }
+
+        binding.btnRetry.setOnClickListener { loadArtifacts() }
+
+        viewModel.loadArtifacts(contentId).observe(viewLifecycleOwner) { resource ->
+            when (resource.status) {
+                Status.LOADING -> showLoading()
+                Status.SUCCESS -> {
+                    val artifacts = resource.data.orEmpty()
+                    if (artifacts.isEmpty()) {
+                        showEmptyState()
+                    } else {
+                        showArtifacts(artifacts)
+                    }
+                }
+                Status.ERROR -> showError()
+            }
+        }
+    }
+
+    private fun showLoading() {
+        binding.progressBarArtifacts.isVisible = true
+        binding.rvArtifacts.isVisible = false
+        binding.tvNoArtifacts.isVisible = false
+        binding.layoutError.isVisible = false
+    }
+
+    private fun showArtifacts(artifacts: List<DomainContentArtifact>) {
+        binding.progressBarArtifacts.isVisible = false
+        binding.rvArtifacts.isVisible = true
+        binding.tvNoArtifacts.isVisible = false
+        binding.layoutError.isVisible = false
+        adapter.submitList(artifacts)
+    }
+
+    private fun showEmptyState() {
+        binding.progressBarArtifacts.isVisible = false
+        binding.rvArtifacts.isVisible = false
+        binding.tvNoArtifacts.isVisible = true
+        binding.layoutError.isVisible = false
+    }
+
+    private fun showError() {
+        binding.progressBarArtifacts.isVisible = false
+        binding.rvArtifacts.isVisible = false
+        binding.tvNoArtifacts.isVisible = false
+        binding.layoutError.isVisible = true
+    }
+
+    private fun onArtifactClicked(artifact: DomainContentArtifact) {
+        if (artifact.isAccessible && artifact.url != null) {
+            downloadArtifact(artifact)
+        } else {
+            Toast.makeText(
+                requireContext(),
+                R.string.testpress_resource_locked_message,
+                Toast.LENGTH_LONG
+            ).show()
+        }
+    }
+
+    private fun downloadArtifact(artifact: DomainContentArtifact) {
+        val url = artifact.url ?: return
+        try {
+            val uri = Uri.parse(url)
+            val fileName = "${artifact.name}.${uri.lastPathSegment?.substringAfterLast('.') ?: "file"}"
+            val request = DownloadManager.Request(uri).apply {
+                setTitle(artifact.name)
+                setDescription(getString(R.string.testpress_download))
+                setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED)
+                setDestinationInExternalPublicDir(Environment.DIRECTORY_DOWNLOADS, fileName)
+                setMimeType("application/octet-stream")
+            }
+            val downloadManager =
+                requireContext().getSystemService(Context.DOWNLOAD_SERVICE) as DownloadManager
+            downloadManager.enqueue(request)
+            Toast.makeText(
+                requireContext(),
+                getString(R.string.testpress_download) + " started",
+                Toast.LENGTH_SHORT
+            ).show()
+        } catch (e: Exception) {
+            // Fallback: open in browser
+            val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
+            if (intent.resolveActivity(requireContext().packageManager) != null) {
+                startActivity(intent)
+            }
+        }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
+    companion object {
+        const val TAG = "ContentArtifactsBottomSheet"
+        private const val ARG_CONTENT_ID = "arg_content_id"
+
+        fun newInstance(contentId: Long): ContentArtifactsBottomSheet {
+            return ContentArtifactsBottomSheet().apply {
+                arguments = Bundle().apply {
+                    putLong(ARG_CONTENT_ID, contentId)
+                }
+            }
+        }
+    }
+}

--- a/course/src/main/java/in/testpress/course/fragments/ContentArtifactsBottomSheet.kt
+++ b/course/src/main/java/in/testpress/course/fragments/ContentArtifactsBottomSheet.kt
@@ -65,7 +65,7 @@ class ContentArtifactsBottomSheet : BottomSheetDialogFragment() {
         viewModel = ViewModelProvider(this, object : ViewModelProvider.Factory {
             @Suppress("UNCHECKED_CAST")
             override fun <T : ViewModel> create(modelClass: Class<T>): T {
-                return ContentArtifactsViewModel(ContentArtifactsRepository(requireContext())) as T
+                return ContentArtifactsViewModel(ContentArtifactsRepository(requireContext().applicationContext)) as T
             }
         })[ContentArtifactsViewModel::class.java]
     }
@@ -124,7 +124,7 @@ class ContentArtifactsBottomSheet : BottomSheetDialogFragment() {
     }
 
     private fun onArtifactClicked(artifact: DomainContentArtifact) {
-        if (artifact.isAccessible && artifact.url != null) {
+        if (artifact.isAccessible) {
             downloadArtifact(artifact)
         } else {
             Toast.makeText(
@@ -139,7 +139,12 @@ class ContentArtifactsBottomSheet : BottomSheetDialogFragment() {
         val url = artifact.url ?: return
         try {
             val uri = Uri.parse(url)
-            val fileName = "${artifact.name}.${uri.lastPathSegment?.substringAfterLast('.') ?: "file"}"
+            val extension = uri.lastPathSegment?.substringAfterLast('.') ?: "file"
+            val fileName = if (artifact.name.endsWith(".$extension", ignoreCase = true)) {
+                artifact.name
+            } else {
+                "${artifact.name}.$extension"
+            }
             val request = DownloadManager.Request(uri).apply {
                 setTitle(artifact.name)
                 setDescription(getString(R.string.testpress_download))
@@ -152,14 +157,20 @@ class ContentArtifactsBottomSheet : BottomSheetDialogFragment() {
             downloadManager.enqueue(request)
             Toast.makeText(
                 requireContext(),
-                getString(R.string.testpress_download) + " started",
+                getString(R.string.testpress_download_started, getString(R.string.testpress_download)),
                 Toast.LENGTH_SHORT
             ).show()
         } catch (e: Exception) {
             // Fallback: open in browser
-            val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
-            if (intent.resolveActivity(requireContext().packageManager) != null) {
+            try {
+                val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
                 startActivity(intent)
+            } catch (anfe: android.content.ActivityNotFoundException) {
+                Toast.makeText(
+                    requireContext(),
+                    "No app found to open this link",
+                    Toast.LENGTH_SHORT
+                ).show()
             }
         }
     }

--- a/course/src/main/java/in/testpress/course/network/CourseService.kt
+++ b/course/src/main/java/in/testpress/course/network/CourseService.kt
@@ -144,6 +144,11 @@ interface CourseService {
         @Path(value = "content_id", encoded = true) contentId: Long,
         @Path(value = "id", encoded = true) highlightId: Long
     ): RetrofitCall<Void>
+
+    @GET("/api/v3/contents/{content_id}/artifacts/")
+    fun getArtifacts(
+        @Path(value = "content_id", encoded = true) contentId: Long
+    ): RetrofitCall<NetworkContentArtifactsResponse>
 }
 
 
@@ -267,5 +272,9 @@ class CourseNetwork(context: Context) : TestpressApiClient(context, TestpressSdk
 
     fun deleteHighlight(contentId: Long, highlightId: Long): RetrofitCall<Void> {
         return getCourseService().deleteHighlight(contentId, highlightId)
+    }
+
+    fun getArtifacts(contentId: Long): RetrofitCall<NetworkContentArtifactsResponse> {
+        return getCourseService().getArtifacts(contentId)
     }
 }

--- a/course/src/main/java/in/testpress/course/repository/ContentArtifactsRepository.kt
+++ b/course/src/main/java/in/testpress/course/repository/ContentArtifactsRepository.kt
@@ -6,6 +6,7 @@ import `in`.testpress.course.domain.DomainContentArtifact
 import `in`.testpress.course.network.CourseNetwork
 import `in`.testpress.course.network.NetworkContentArtifact
 import `in`.testpress.network.Resource
+import `in`.testpress.course.network.asDomainModels
 import android.content.Context
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
@@ -22,7 +23,7 @@ class ContentArtifactsRepository(private val context: Context) {
         courseNetwork.getArtifacts(contentId).enqueue(
             object : TestpressCallback<`in`.testpress.course.network.NetworkContentArtifactsResponse>() {
                 override fun onSuccess(response: `in`.testpress.course.network.NetworkContentArtifactsResponse) {
-                    val artifacts = response.results.map { it.toDomain() }
+                    val artifacts = response.results.asDomainModels()
                     result.postValue(Resource.success(artifacts))
                 }
 
@@ -34,11 +35,4 @@ class ContentArtifactsRepository(private val context: Context) {
 
         return result
     }
-
-    private fun NetworkContentArtifact.toDomain() = DomainContentArtifact(
-        id = id,
-        name = name,
-        url = url,
-        accessibleWithoutAttempt = accessibleWithoutAttempt
-    )
 }

--- a/course/src/main/java/in/testpress/course/repository/ContentArtifactsRepository.kt
+++ b/course/src/main/java/in/testpress/course/repository/ContentArtifactsRepository.kt
@@ -1,0 +1,44 @@
+package `in`.testpress.course.repository
+
+import `in`.testpress.core.TestpressCallback
+import `in`.testpress.core.TestpressException
+import `in`.testpress.course.domain.DomainContentArtifact
+import `in`.testpress.course.network.CourseNetwork
+import `in`.testpress.course.network.NetworkContentArtifact
+import `in`.testpress.network.Resource
+import android.content.Context
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+
+
+class ContentArtifactsRepository(private val context: Context) {
+
+    private val courseNetwork = CourseNetwork(context)
+
+    fun loadArtifacts(contentId: Long): LiveData<Resource<List<DomainContentArtifact>>> {
+        val result = MutableLiveData<Resource<List<DomainContentArtifact>>>()
+        result.value = Resource.loading(null)
+
+        courseNetwork.getArtifacts(contentId).enqueue(
+            object : TestpressCallback<`in`.testpress.course.network.NetworkContentArtifactsResponse>() {
+                override fun onSuccess(response: `in`.testpress.course.network.NetworkContentArtifactsResponse) {
+                    val artifacts = response.results.map { it.toDomain() }
+                    result.postValue(Resource.success(artifacts))
+                }
+
+                override fun onException(exception: TestpressException) {
+                    result.postValue(Resource.error(exception, null))
+                }
+            }
+        )
+
+        return result
+    }
+
+    private fun NetworkContentArtifact.toDomain() = DomainContentArtifact(
+        id = id,
+        name = name,
+        url = url,
+        accessibleWithoutAttempt = accessibleWithoutAttempt
+    )
+}

--- a/course/src/main/java/in/testpress/course/ui/ContentArtifactsAdapter.kt
+++ b/course/src/main/java/in/testpress/course/ui/ContentArtifactsAdapter.kt
@@ -1,0 +1,61 @@
+package `in`.testpress.course.ui
+
+import `in`.testpress.course.R
+import `in`.testpress.course.databinding.ItemContentArtifactBinding
+import `in`.testpress.course.domain.DomainContentArtifact
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.core.view.isVisible
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+
+
+class ContentArtifactsAdapter(
+    private val onArtifactClick: (DomainContentArtifact) -> Unit
+) : ListAdapter<DomainContentArtifact, ContentArtifactsAdapter.ArtifactViewHolder>(DIFF_CALLBACK) {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ArtifactViewHolder {
+        val binding = ItemContentArtifactBinding.inflate(
+            LayoutInflater.from(parent.context), parent, false
+        )
+        return ArtifactViewHolder(binding)
+    }
+
+    override fun onBindViewHolder(holder: ArtifactViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+
+    inner class ArtifactViewHolder(
+        private val binding: ItemContentArtifactBinding
+    ) : RecyclerView.ViewHolder(binding.root) {
+
+        fun bind(artifact: DomainContentArtifact) {
+            binding.tvArtifactName.text = artifact.name
+
+            if (artifact.isAccessible) {
+                binding.ivArtifactDownload.isVisible = true
+                binding.ivArtifactLocked.isVisible = false
+                binding.artifactItemRoot.isEnabled = true
+                binding.artifactItemRoot.setOnClickListener { onArtifactClick(artifact) }
+            } else {
+                binding.ivArtifactDownload.isVisible = false
+                binding.ivArtifactLocked.isVisible = true
+                binding.artifactItemRoot.isEnabled = false
+                binding.artifactItemRoot.setOnClickListener {
+                    onArtifactClick(artifact) // still notify so Fragment can show a toast
+                }
+            }
+        }
+    }
+
+    companion object {
+        private val DIFF_CALLBACK = object : DiffUtil.ItemCallback<DomainContentArtifact>() {
+            override fun areItemsTheSame(old: DomainContentArtifact, new: DomainContentArtifact) =
+                old.id == new.id
+
+            override fun areContentsTheSame(old: DomainContentArtifact, new: DomainContentArtifact) =
+                old == new
+        }
+    }
+}

--- a/course/src/main/java/in/testpress/course/ui/ContentArtifactsAdapter.kt
+++ b/course/src/main/java/in/testpress/course/ui/ContentArtifactsAdapter.kt
@@ -36,12 +36,12 @@ class ContentArtifactsAdapter(
             if (artifact.isAccessible) {
                 binding.ivArtifactDownload.isVisible = true
                 binding.ivArtifactLocked.isVisible = false
-                binding.artifactItemRoot.isEnabled = true
+                binding.artifactItemRoot.alpha = 1.0f
                 binding.artifactItemRoot.setOnClickListener { onArtifactClick(artifact) }
             } else {
                 binding.ivArtifactDownload.isVisible = false
                 binding.ivArtifactLocked.isVisible = true
-                binding.artifactItemRoot.isEnabled = false
+                binding.artifactItemRoot.alpha = 0.5f
                 binding.artifactItemRoot.setOnClickListener {
                     onArtifactClick(artifact) // still notify so Fragment can show a toast
                 }

--- a/course/src/main/java/in/testpress/course/viewmodels/ContentArtifactsViewModel.kt
+++ b/course/src/main/java/in/testpress/course/viewmodels/ContentArtifactsViewModel.kt
@@ -1,0 +1,16 @@
+package `in`.testpress.course.viewmodels
+
+import `in`.testpress.course.domain.DomainContentArtifact
+import `in`.testpress.course.repository.ContentArtifactsRepository
+import `in`.testpress.network.Resource
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.ViewModel
+
+class ContentArtifactsViewModel(
+    private val repository: ContentArtifactsRepository
+) : ViewModel() {
+
+    fun loadArtifacts(contentId: Long): LiveData<Resource<List<DomainContentArtifact>>> {
+        return repository.loadArtifacts(contentId)
+    }
+}

--- a/course/src/main/res/drawable/drag_handle_shape.xml
+++ b/course/src/main/res/drawable/drag_handle_shape.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="#CCCCCC" />
+    <corners android:radius="4dp" />
+</shape>

--- a/course/src/main/res/drawable/ic_file_text.xml
+++ b/course/src/main/res/drawable/ic_file_text.xml
@@ -1,0 +1,36 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:strokeColor="#FF000000"
+        android:strokeWidth="2"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:pathData="M6 22a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h8a2.4 2.4 0 0 1 1.704.706l3.588 3.588A2.4 2.4 0 0 1 20 8v12a2 2 0 0 1-2 2z"/>
+    <path
+        android:strokeColor="#FF000000"
+        android:strokeWidth="2"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:pathData="M14 2v5a1 1 0 0 0 1 1h5"/>
+    <path
+        android:strokeColor="#FF000000"
+        android:strokeWidth="2"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:pathData="M10 9H8"/>
+    <path
+        android:strokeColor="#FF000000"
+        android:strokeWidth="2"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:pathData="M16 13H8"/>
+    <path
+        android:strokeColor="#FF000000"
+        android:strokeWidth="2"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:pathData="M16 17H8"/>
+</vector>

--- a/course/src/main/res/layout/fragment_content_artifacts_bottom_sheet.xml
+++ b/course/src/main/res/layout/fragment_content_artifacts_bottom_sheet.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior">
+
+    <!-- Drag handle -->
+    <View
+        android:layout_width="40dp"
+        android:layout_height="4dp"
+        android:layout_gravity="center_horizontal"
+        android:layout_marginTop="8dp"
+        android:layout_marginBottom="4dp"
+        android:background="@drawable/drag_handle_shape" />
+
+    <!-- Header -->
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:paddingHorizontal="20dp"
+        android:paddingTop="16dp"
+        android:paddingBottom="12dp">
+
+        <TextView
+            android:id="@+id/tv_artifacts_title"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/testpress_resources"
+            android:textAppearance="?attr/textAppearanceHeadline5"
+            android:textColor="#222222"
+            android:textStyle="bold" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:text="@string/testpress_resources_subheading"
+            android:textAppearance="?attr/textAppearanceBody2"
+            android:textColor="#666666" />
+    </LinearLayout>
+
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:background="@color/testpress_gray_light" />
+
+    <!-- Loading indicator -->
+    <ProgressBar
+        android:id="@+id/progress_bar_artifacts"
+        style="?android:attr/progressBarStyle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:layout_margin="32dp"
+        android:visibility="gone" />
+
+    <!-- Artifact list -->
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/rv_artifacts"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:maxHeight="400dp"
+        android:nestedScrollingEnabled="false"
+        android:paddingBottom="16dp"
+        android:visibility="gone" />
+
+    <!-- Empty state -->
+    <TextView
+        android:id="@+id/tv_no_artifacts"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:padding="32dp"
+        android:text="@string/testpress_no_resources_available"
+        android:textAppearance="?attr/textAppearanceBody1"
+        android:textColor="@color/testpress_text_gray"
+        android:visibility="gone" />
+
+    <!-- Error state -->
+    <LinearLayout
+        android:id="@+id/layout_error"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:orientation="vertical"
+        android:padding="24dp"
+        android:visibility="gone">
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:text="@string/testpress_failed_to_load_resources"
+            android:textAppearance="?attr/textAppearanceBody1" />
+
+        <Button
+            android:id="@+id/btn_retry"
+            style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:text="@string/testpress_retry" />
+
+    </LinearLayout>
+
+</LinearLayout>

--- a/course/src/main/res/layout/item_content_artifact.xml
+++ b/course/src/main/res/layout/item_content_artifact.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/artifact_item_root"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="?attr/selectableItemBackground"
+    android:clickable="true"
+    android:focusable="true"
+    android:gravity="center_vertical"
+    android:minHeight="56dp"
+    android:orientation="horizontal"
+    android:paddingHorizontal="16dp"
+    android:paddingVertical="12dp">
+
+    <!-- File description/document icon on the left -->
+    <ImageView
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        android:importantForAccessibility="no"
+        android:src="@drawable/ic_file_text"
+        app:tint="@color/testpress_text_gray" />
+
+    <!-- Artifact name in the center -->
+    <TextView
+        android:id="@+id/tv_artifact_name"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="12dp"
+        android:layout_weight="1"
+        android:fontFamily="sans-serif-medium"
+        android:textColor="#333333"
+        android:textSize="16sp"
+        tools:text="Study Material - Chapter 1.pdf" />
+
+    <!-- Action icon (Download or Lock) on the right -->
+    <FrameLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content">
+
+        <ImageView
+            android:id="@+id/iv_artifact_download"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:contentDescription="@string/testpress_download"
+            android:src="@drawable/ic_download_outline"
+            android:visibility="gone"
+            app:tint="@color/testpress_black" />
+
+        <ImageView
+            android:id="@+id/iv_artifact_locked"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:contentDescription="@string/testpress_locked"
+            android:src="@drawable/ic_lock"
+            android:visibility="gone"
+            app:tint="@color/testpress_text_gray_light" />
+    </FrameLayout>
+
+</LinearLayout>

--- a/course/src/main/res/menu/content_artifacts_menu.xml
+++ b/course/src/main/res/menu/content_artifacts_menu.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:id="@+id/view_resources"
+        android:icon="@drawable/baseline_attach_file_24"
+        android:title="@string/testpress_view_resources"
+        android:visible="true"
+        app:iconTint="@android:color/white"
+        app:showAsAction="always" />
+
+</menu>

--- a/course/src/main/res/values/strings.xml
+++ b/course/src/main/res/values/strings.xml
@@ -133,4 +133,14 @@
     <string name="question_button_check">Check</string>
     <string name="question_button_continue">Continue</string>
     <string name="question_correct_answer">Correct answer is: %1$s</string>
+
+    <string name="testpress_view_resources">Resources</string>
+    <string name="testpress_resources">Resources</string>
+    <string name="testpress_no_resources_available">No resources available for this content.</string>
+    <string name="testpress_failed_to_load_resources">Failed to load resources. Please try again.</string>
+    <string name="testpress_download">Download</string>
+    <string name="testpress_locked">Locked — complete exam to access</string>
+    <string name="testpress_retry">Retry</string>
+    <string name="testpress_resource_locked_message">Complete the exam first to access this resource.</string>
+    <string name="testpress_resources_subheading">Download files and study material for this content</string>
 </resources>

--- a/course/src/main/res/values/strings.xml
+++ b/course/src/main/res/values/strings.xml
@@ -139,6 +139,7 @@
     <string name="testpress_no_resources_available">No resources available for this content.</string>
     <string name="testpress_failed_to_load_resources">Failed to load resources. Please try again.</string>
     <string name="testpress_download">Download</string>
+    <string name="testpress_download_started">%1$s started</string>
     <string name="testpress_locked">Locked — complete exam to access</string>
     <string name="testpress_retry">Retry</string>
     <string name="testpress_resource_locked_message">Complete the exam first to access this resource.</string>


### PR DESCRIPTION
Add a new bottom sheet to display and download content artifacts (resources) associated with a course content. 
- Added `ContentArtifactsRepository` and `ContentArtifactsViewModel` for fetching artifacts
- Created `ContentArtifactsBottomSheet` and adapter to display the list of resources
- Updated `BaseContentDetailFragment` to include a "Resources" menu item which opens the bottom sheet
- Added domain models and network models for content artifacts
- Added necessary layouts and string resources