### PR TITLE
fix: Enable Fermion live stream recording playback and fullscreen

### DIFF
--- a/course/src/main/java/in/testpress/course/fragments/FermionLiveStreamFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/FermionLiveStreamFragment.kt
@@ -11,6 +11,7 @@ import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.fragment.app.Fragment
 import `in`.testpress.course.R
+import `in`.testpress.util.webview.BaseWebChromeClient
 
 class FermionLiveStreamFragment : Fragment() {
 
@@ -56,8 +57,9 @@ class FermionLiveStreamFragment : Fragment() {
         settings.mediaPlaybackRequiresUserGesture = false
     }
 
-    private fun buildChromeClient() = object : WebChromeClient() {
-        override fun onPermissionRequest(request: PermissionRequest) {
+    private fun buildChromeClient() = object : BaseWebChromeClient(this) {
+        override fun onPermissionRequest(request: PermissionRequest?) {
+            if (request == null) return
             val expectedHost = streamUrl?.let { android.net.Uri.parse(it).host }
             val requestHost = request.origin.host
 

--- a/course/src/main/java/in/testpress/course/fragments/FermionLiveStreamFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/FermionLiveStreamFragment.kt
@@ -18,6 +18,7 @@ class FermionLiveStreamFragment : Fragment() {
     private var initialLoadComplete = false
     private var streamUrl: String? = null
     private var webView: WebView? = null
+    private var chromeClient: BaseWebChromeClient? = null
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -39,9 +40,10 @@ class FermionLiveStreamFragment : Fragment() {
 
     private fun setupWebView() {
         val container = requireView() as ViewGroup
+        chromeClient = buildChromeClient()
         webView = WebView(requireContext()).apply {
             configureSettings()
-            webChromeClient = buildChromeClient()
+            webChromeClient = chromeClient
             webViewClient = buildWebViewClient()
             streamUrl?.let { loadUrl(it) }
         }
@@ -114,6 +116,8 @@ class FermionLiveStreamFragment : Fragment() {
 
     override fun onDestroyView() {
         super.onDestroyView()
+        chromeClient?.cleanup()
+        chromeClient = null
         webView?.destroy()
         webView = null
     }

--- a/course/src/main/java/in/testpress/course/fragments/LiveStreamFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/LiveStreamFragment.kt
@@ -67,12 +67,19 @@ class LiveStreamFragment : BaseContentDetailFragment(), LiveStreamCallbackListen
 
     override fun display() {
         view?.findViewById<View>(R.id.loading_screen)?.visibility = View.GONE
-        when (content.liveStream?.status) {
+        val liveStream = content.liveStream
+        when (liveStream?.status) {
             "Running" -> {
                 displayPlayerViewWithChat()
             }
             "Not Started" -> displayNotStartedNotice()
-            "Completed" -> displayEndedNotice()
+            "Completed" -> {
+                if (isFermionProvider() && liveStream.showRecordedVideo == true) {
+                    showFermionRecording()
+                } else {
+                    displayEndedNotice()
+                }
+            }
         }
     }
 
@@ -156,6 +163,15 @@ class LiveStreamFragment : BaseContentDetailFragment(), LiveStreamCallbackListen
     private fun showFermionPlayer() {
         setupFermionPlayer()
         setupChatWebView()
+        viewModel.createContentAttempt(contentId)
+        swipeRefresh.isEnabled = false
+        hideBottomNavigationBar()
+    }
+
+    private fun showFermionRecording() {
+        setupFermionPlayer()
+        view?.findViewById<View>(R.id.chat_view_fragment)?.visibility = View.GONE
+        
         viewModel.createContentAttempt(contentId)
         swipeRefresh.isEnabled = false
         hideBottomNavigationBar()

--- a/course/src/main/java/in/testpress/course/fragments/LiveStreamFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/LiveStreamFragment.kt
@@ -75,7 +75,7 @@ class LiveStreamFragment : BaseContentDetailFragment(), LiveStreamCallbackListen
             "Not Started" -> displayNotStartedNotice()
             "Completed" -> {
                 if (isFermionProvider() && liveStream.showRecordedVideo == true) {
-                    showFermionRecording()
+                    showFermionPlayer(showChat = false)
                 } else {
                     displayEndedNotice()
                 }
@@ -160,18 +160,13 @@ class LiveStreamFragment : BaseContentDetailFragment(), LiveStreamCallbackListen
         }
     }
 
-    private fun showFermionPlayer() {
+    private fun showFermionPlayer(showChat: Boolean = true) {
         setupFermionPlayer()
-        setupChatWebView()
-        viewModel.createContentAttempt(contentId)
-        swipeRefresh.isEnabled = false
-        hideBottomNavigationBar()
-    }
-
-    private fun showFermionRecording() {
-        setupFermionPlayer()
-        view?.findViewById<View>(R.id.chat_view_fragment)?.visibility = View.GONE
-        
+        if (showChat) {
+            setupChatWebView()
+        } else {
+            view?.findViewById<View>(R.id.chat_view_fragment)?.visibility = View.GONE
+        }
         viewModel.createContentAttempt(contentId)
         swipeRefresh.isEnabled = false
         hideBottomNavigationBar()


### PR DESCRIPTION
- Completed Fermion streams were displaying a static "ended" notice because unlike standard streams that return a separate video object for recordings, Fermion streams provide the recording via the same live stream URL
- Fixed by bypassing the ended notice to load the Fermion player when showRecordedVideo is true, and hiding the chat container for recordings
- The fullscreen button inside the Fermion player was unresponsive because Android's default WebChromeClient does not natively support HTML5 fullscreen video playback
- Changed FermionLiveStreamFragment to extend BaseWebChromeClient instead of WebChromeClient, which implements onShowCustomView and onHideCustomView to properly handle HTML5 fullscreen requests