### PR TITLE
feat: Introduce custom in-app offline attachment download manager

### DIFF
--- a/core/src/main/java/in/testpress/util/FileUtils.kt
+++ b/core/src/main/java/in/testpress/util/FileUtils.kt
@@ -215,7 +215,7 @@ fun getMimeTypeFromUri(context: Context, filePath: String?, contentUri: String?)
             // For file paths
             !filePath.isNullOrBlank() -> {
                 val file = File(Uri.parse(filePath).path ?: return "*/*")
-                val extension = MimeTypeMap.getFileExtensionFromUrl(file.name)
+                val extension = file.name.substringAfterLast('.', "")
                 MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension.lowercase()) ?: "*/*"
             }
 

--- a/course/src/main/java/in/testpress/course/domain/NewOfflineAttachmentDownload.kt
+++ b/course/src/main/java/in/testpress/course/domain/NewOfflineAttachmentDownload.kt
@@ -1,0 +1,15 @@
+package `in`.testpress.course.domain
+
+enum class NewOfflineAttachmentDownloadFailureReason {
+    FAILURE_REASON_NONE,
+    FAILURE_REASON_NETWORK,
+    FAILURE_REASON_IO,
+    FAILURE_REASON_HTTP,
+    FAILURE_REASON_UNKNOWN
+}
+
+interface NewOfflineAttachmentDownloadListener {
+    fun onDownloadProgress(id: Long, bytesDownloaded: Long, contentLength: Long, percent: Float)
+    fun onDownloadCompleted(id: Long, filePath: String)
+    fun onDownloadFailed(id: Long, failureReason: NewOfflineAttachmentDownloadFailureReason, exception: Exception?)
+}

--- a/course/src/main/java/in/testpress/course/helpers/OfflineAttachmentSyncManager.kt
+++ b/course/src/main/java/in/testpress/course/helpers/OfflineAttachmentSyncManager.kt
@@ -33,7 +33,7 @@ class OfflineAttachmentSyncManager(
     private suspend fun checkAndUpdateAttachmentStatus(attachment: OfflineAttachment) {
         val resolver = context.contentResolver
         try {
-            val fileExists = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            val fileExists = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && !attachment.contentUri.isNullOrBlank()) {
                 val uri = attachment.contentUri?.let(Uri::parse)
                 uri != null && runCatching {
                     resolver.openAssetFileDescriptor(uri, "r")?.use { true } ?: false

--- a/course/src/main/java/in/testpress/course/repository/OfflineAttachmentsRepository.kt
+++ b/course/src/main/java/in/testpress/course/repository/OfflineAttachmentsRepository.kt
@@ -24,6 +24,7 @@ class OfflineAttachmentsRepository(private val dao: OfflineAttachmentsDao) {
     suspend fun updateFilePathWithDownloadId(downloadId: Long, path: String) = dao.updateFilePathWithDownloadId(downloadId, path)
 
     suspend fun getByDownloadId(downloadId: Long) = dao.getByDownloadId(downloadId)
+    suspend fun getById(id: Long): OfflineAttachment? = dao.getById(id)
     fun getAttachment(id: Long) = dao.getAttachment(id)
 
     suspend fun getAllWithStatus(status: OfflineAttachmentDownloadStatus) =

--- a/course/src/main/java/in/testpress/course/services/NewOfflineAttachmentDownloadManager.kt
+++ b/course/src/main/java/in/testpress/course/services/NewOfflineAttachmentDownloadManager.kt
@@ -24,6 +24,8 @@ import java.net.SocketTimeoutException
 import java.net.URL
 import `in`.testpress.course.domain.NewOfflineAttachmentDownloadFailureReason
 import `in`.testpress.course.domain.NewOfflineAttachmentDownloadListener
+import java.util.Collections
+import java.util.WeakHashMap
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.atomic.AtomicBoolean
@@ -178,7 +180,7 @@ class NewOfflineAttachmentDownloadManager private constructor(private val reposi
     private val pendingQueue = LinkedBlockingQueue<DomainAttachmentContent>()
     private val activeJobs = ConcurrentHashMap<Long, Job>()
     private val activeDownloaders = ConcurrentHashMap<Long, NewOfflineAttachmentDownloader>()
-    private val listeners = Collections.synchronizedSet(
+    private val listeners: MutableSet<NewOfflineAttachmentDownloadListener> = Collections.synchronizedSet(
         Collections.newSetFromMap(WeakHashMap<NewOfflineAttachmentDownloadListener, Boolean>())
     )
 

--- a/course/src/main/java/in/testpress/course/services/NewOfflineAttachmentDownloadManager.kt
+++ b/course/src/main/java/in/testpress/course/services/NewOfflineAttachmentDownloadManager.kt
@@ -72,7 +72,25 @@ class NewOfflineAttachmentDownloader(
 
             connection?.connect()
 
-            val responseCode = connection?.responseCode ?: -1
+            var responseCode = connection?.responseCode ?: -1
+
+            // Handle 416 Range Not Satisfiable: stale or oversized partial file. Clear it and start from scratch.
+            if (responseCode == 416) {
+                connection?.disconnect()
+                if (file.exists()) {
+                    file.delete()
+                }
+                existingLength = 0L
+
+                connection = url.openConnection() as HttpURLConnection
+                connection?.connectTimeout = connectTimeout
+                connection?.readTimeout = readTimeout
+                connection?.instanceFollowRedirects = true
+                connection?.connect()
+
+                responseCode = connection?.responseCode ?: -1
+            }
+
             val isResume = responseCode == HttpURLConnection.HTTP_PARTIAL
 
             // If range response is not 206 (Partial Content), rewrite file from scratch
@@ -155,22 +173,21 @@ class NewOfflineAttachmentDownloadManager private constructor(private val reposi
     private val progressScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
     private val dbMutex = Mutex()
 
+    @Volatile
     private var maxParallelDownloads = 3
     private val pendingQueue = LinkedBlockingQueue<DomainAttachmentContent>()
     private val activeJobs = ConcurrentHashMap<Long, Job>()
     private val activeDownloaders = ConcurrentHashMap<Long, NewOfflineAttachmentDownloader>()
-    private val listeners = mutableListOf<NewOfflineAttachmentDownloadListener>()
+    private val listeners = Collections.synchronizedSet(
+        Collections.newSetFromMap(WeakHashMap<NewOfflineAttachmentDownloadListener, Boolean>())
+    )
 
     fun addListener(listener: NewOfflineAttachmentDownloadListener) {
-        synchronized(listeners) {
-            listeners.add(listener)
-        }
+        listeners.add(listener)
     }
 
     fun removeListener(listener: NewOfflineAttachmentDownloadListener) {
-        synchronized(listeners) {
-            listeners.remove(listener)
-        }
+        listeners.remove(listener)
     }
 
     fun setMaxParallelDownloads(max: Int) {
@@ -181,6 +198,12 @@ class NewOfflineAttachmentDownloadManager private constructor(private val reposi
     fun enqueueDownload(context: Context, domainAttachmentContent: DomainAttachmentContent) {
         if (domainAttachmentContent.attachmentUrl == null) {
             Toast.makeText(context, "Attachment URL cannot be null", Toast.LENGTH_SHORT).show()
+            return
+        }
+
+        // De-duplication check: if task is already running or queued, ignore the duplicate request
+        if (activeJobs.containsKey(domainAttachmentContent.id) ||
+            pendingQueue.any { it.id == domainAttachmentContent.id }) {
             return
         }
 
@@ -223,99 +246,111 @@ class NewOfflineAttachmentDownloadManager private constructor(private val reposi
     }
 
     private suspend fun runDownloadTask(content: DomainAttachmentContent) {
-        val attachment = dbMutex.withLock { repository.getById(content.id) } ?: return
-        val url = content.attachmentUrl ?: return
-        val filePath = Uri.parse(attachment.path).path ?: return
+        try {
+            val attachment = dbMutex.withLock { repository.getById(content.id) } ?: return
+            val url = content.attachmentUrl ?: return
+            val filePath = Uri.parse(attachment.path).path ?: return
 
-        var attempt = 1
-        val maxRetries = 5
-        var succeeded = false
-        var lastException: Exception? = null
-        var failureReason = NewOfflineAttachmentDownloadFailureReason.FAILURE_REASON_NONE
+            var attempt = 1
+            val maxRetries = 5
+            var succeeded = false
+            var lastException: Exception? = null
+            var failureReason = NewOfflineAttachmentDownloadFailureReason.FAILURE_REASON_NONE
 
-        val downloader = NewOfflineAttachmentDownloader(Uri.parse(url), filePath)
-        activeDownloaders[content.id] = downloader
+            val downloader = NewOfflineAttachmentDownloader(Uri.parse(url), filePath)
+            activeDownloaders[content.id] = downloader
 
-        // Update DB status to DOWNLOADING before start
-        dbMutex.withLock {
-            val record = repository.getById(content.id)
-            record?.let {
-                repository.update(it.copy(status = OfflineAttachmentDownloadStatus.DOWNLOADING))
+            // Update DB status to DOWNLOADING before start
+            dbMutex.withLock {
+                val record = repository.getById(content.id)
+                record?.let {
+                    repository.update(it.copy(status = OfflineAttachmentDownloadStatus.DOWNLOADING))
+                }
             }
-        }
 
-        while (attempt <= maxRetries && !succeeded) {
-            try {
-                downloader.download(object : NewOfflineAttachmentDownloader.ProgressListener {
-                    override fun onProgress(contentLength: Long, bytesDownloaded: Long, percentDownloaded: Float) {
-                        val progressPercent = if (percentDownloaded >= 0) percentDownloaded.toInt() else 0
-                        progressScope.launch {
-                            dbMutex.withLock {
-                                val record = repository.getById(content.id)
-                                record?.let {
-                                    if (it.status != OfflineAttachmentDownloadStatus.COMPLETED &&
-                                        it.status != OfflineAttachmentDownloadStatus.FAILED) {
-                                        repository.update(it.copy(progress = progressPercent))
+            var lastUpdatedPercent = -1
+
+            while (attempt <= maxRetries && !succeeded) {
+                try {
+                    downloader.download(object : NewOfflineAttachmentDownloader.ProgressListener {
+                        override fun onProgress(contentLength: Long, bytesDownloaded: Long, percentDownloaded: Float) {
+                            val progressPercent = if (percentDownloaded >= 0) percentDownloaded.toInt() else 0
+                            
+                            // Only update database when the rounded percentage changes to throttle I/O roundtrips
+                            if (progressPercent != lastUpdatedPercent) {
+                                lastUpdatedPercent = progressPercent
+                                progressScope.launch {
+                                    dbMutex.withLock {
+                                        val record = repository.getById(content.id)
+                                        record?.let {
+                                            if (it.status != OfflineAttachmentDownloadStatus.COMPLETED &&
+                                                it.status != OfflineAttachmentDownloadStatus.FAILED) {
+                                                repository.update(it.copy(progress = progressPercent))
+                                            }
+                                        }
                                     }
                                 }
                             }
+
+                            // Dispatch progress to UI listeners immediately for smooth updates
                             synchronized(listeners) {
                                 listeners.forEach {
                                     it.onDownloadProgress(content.id, bytesDownloaded, contentLength, percentDownloaded)
                                 }
                             }
                         }
+                    })
+                    succeeded = true
+                } catch (e: Exception) {
+                    lastException = e
+                    failureReason = when (e) {
+                        is SocketTimeoutException -> NewOfflineAttachmentDownloadFailureReason.FAILURE_REASON_NETWORK
+                        is HttpDownloadException -> NewOfflineAttachmentDownloadFailureReason.FAILURE_REASON_HTTP
+                        is IOException -> NewOfflineAttachmentDownloadFailureReason.FAILURE_REASON_IO
+                        else -> NewOfflineAttachmentDownloadFailureReason.FAILURE_REASON_UNKNOWN
                     }
-                })
-                succeeded = true
-            } catch (e: Exception) {
-                lastException = e
-                failureReason = when (e) {
-                    is SocketTimeoutException -> NewOfflineAttachmentDownloadFailureReason.FAILURE_REASON_NETWORK
-                    is HttpDownloadException -> NewOfflineAttachmentDownloadFailureReason.FAILURE_REASON_HTTP
-                    is IOException -> NewOfflineAttachmentDownloadFailureReason.FAILURE_REASON_IO
-                    else -> NewOfflineAttachmentDownloadFailureReason.FAILURE_REASON_UNKNOWN
-                }
 
-                Log.w("NewOfflineAttachmentDownloadManager", "Download ID=${content.id} failed on attempt $attempt: ${e.message}")
+                    Log.w("NewOfflineAttachmentDownloadManager", "Download ID=${content.id} failed on attempt $attempt: ${e.message}")
 
-                if (attempt < maxRetries) {
-                    val backoffMs = Math.min(1000L * attempt, 30000L)
-                    delay(backoffMs)
-                    attempt++
-                } else {
-                    break
+                    if (attempt < maxRetries) {
+                        val backoffMs = Math.min(1000L * attempt, 30000L)
+                        delay(backoffMs)
+                        attempt++
+                    } else {
+                        break
+                    }
                 }
             }
-        }
 
-        activeDownloaders.remove(content.id)
-        dbMutex.withLock {
-            activeJobs.remove(content.id)
-        }
-
-        progressScope.launch {
-            dbMutex.withLock {
-                val record = repository.getById(content.id)
-                record?.let {
-                    if (succeeded) {
-                        repository.update(it.copy(
-                            status = OfflineAttachmentDownloadStatus.COMPLETED,
-                            progress = 100
-                        ))
-                        synchronized(listeners) {
-                            listeners.forEach { l -> l.onDownloadCompleted(content.id, filePath) }
-                        }
-                    } else {
-                        repository.update(it.copy(
-                            status = OfflineAttachmentDownloadStatus.FAILED,
-                            progress = 0
-                        ))
-                        synchronized(listeners) {
-                            listeners.forEach { l -> l.onDownloadFailed(content.id, failureReason, lastException) }
+            progressScope.launch {
+                dbMutex.withLock {
+                    val record = repository.getById(content.id)
+                    record?.let {
+                        if (succeeded) {
+                            repository.update(it.copy(
+                                status = OfflineAttachmentDownloadStatus.COMPLETED,
+                                progress = 100
+                            ))
+                            synchronized(listeners) {
+                                listeners.forEach { l -> l.onDownloadCompleted(content.id, filePath) }
+                            }
+                        } else {
+                            repository.update(it.copy(
+                                status = OfflineAttachmentDownloadStatus.FAILED,
+                                progress = 0
+                            ))
+                            synchronized(listeners) {
+                                listeners.forEach { l -> l.onDownloadFailed(content.id, failureReason, lastException) }
+                            }
                         }
                     }
                 }
+                processQueue()
+            }
+        } finally {
+            activeDownloaders.remove(content.id)
+            dbMutex.withLock {
+                activeJobs.remove(content.id)
             }
             processQueue()
         }

--- a/course/src/main/java/in/testpress/course/services/NewOfflineAttachmentDownloadManager.kt
+++ b/course/src/main/java/in/testpress/course/services/NewOfflineAttachmentDownloadManager.kt
@@ -1,0 +1,390 @@
+package `in`.testpress.course.services
+
+import android.content.Context
+import android.net.Uri
+import android.util.Log
+import android.widget.Toast
+import `in`.testpress.course.domain.DomainAttachmentContent
+import `in`.testpress.course.repository.OfflineAttachmentsRepository
+import `in`.testpress.database.entities.OfflineAttachment
+import `in`.testpress.database.entities.OfflineAttachmentDownloadStatus
+import `in`.testpress.util.getFileExtensionFromUrl
+import `in`.testpress.util.getMimeTypeFromUri
+import `in`.testpress.util.openFile
+import `in`.testpress.util.sanitizeFileName
+import kotlinx.coroutines.*
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import java.io.File
+import java.io.FileOutputStream
+import java.io.IOException
+import java.io.InputStream
+import java.net.HttpURLConnection
+import java.net.SocketTimeoutException
+import java.net.URL
+import `in`.testpress.course.domain.NewOfflineAttachmentDownloadFailureReason
+import `in`.testpress.course.domain.NewOfflineAttachmentDownloadListener
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.atomic.AtomicBoolean
+
+class HttpDownloadException(val responseCode: Int, message: String) : IOException(message)
+
+
+class NewOfflineAttachmentDownloader(
+    private val uri: Uri,
+    private val outputFilePath: String,
+    private val connectTimeout: Int = 30000,
+    private val readTimeout: Int = 30000
+) {
+    private val isActive = AtomicBoolean(true)
+    private var connection: HttpURLConnection? = null
+    private var inputStream: InputStream? = null
+    private var outputStream: FileOutputStream? = null
+
+    interface ProgressListener {
+        fun onProgress(contentLength: Long, bytesDownloaded: Long, percentDownloaded: Float)
+    }
+
+    fun download(progressListener: ProgressListener?) {
+        try {
+            val file = File(outputFilePath)
+            val parent = file.parentFile
+            if (parent != null && !parent.exists()) {
+                parent.mkdirs()
+            }
+
+            var existingLength = 0L
+            if (file.exists()) {
+                existingLength = file.length()
+            }
+
+            val url = URL(uri.toString())
+            connection = url.openConnection() as HttpURLConnection
+            connection?.connectTimeout = connectTimeout
+            connection?.readTimeout = readTimeout
+            connection?.instanceFollowRedirects = true
+
+            // Set Range header for resume if file already exists
+            if (existingLength > 0) {
+                connection?.setRequestProperty("Range", "bytes=$existingLength-")
+            }
+
+            connection?.connect()
+
+            val responseCode = connection?.responseCode ?: -1
+            val isResume = responseCode == HttpURLConnection.HTTP_PARTIAL
+
+            // If range response is not 206 (Partial Content), rewrite file from scratch
+            if (existingLength > 0 && !isResume) {
+                existingLength = 0L
+            }
+
+            if (responseCode >= 400) {
+                throw HttpDownloadException(responseCode, "Server returned HTTP response code: $responseCode")
+            }
+
+            inputStream = connection?.inputStream ?: throw IOException("Could not open input stream")
+            outputStream = FileOutputStream(file, isResume)
+
+            var bytesDownloaded = existingLength
+            val responseContentLength = connection?.contentLengthLong ?: -1L
+            val totalContentLength = if (responseContentLength > 0) {
+                if (isResume) responseContentLength + existingLength else responseContentLength
+            } else {
+                -1L
+            }
+
+            val buffer = ByteArray(8192)
+            var bytesReadThisChunk: Int
+
+            while (isActive.get()) {
+                bytesReadThisChunk = inputStream?.read(buffer) ?: -1
+                if (bytesReadThisChunk == -1) break
+
+                outputStream?.write(buffer, 0, bytesReadThisChunk)
+                bytesDownloaded += bytesReadThisChunk
+
+                val percent = if (totalContentLength > 0) {
+                    (bytesDownloaded * 100f) / totalContentLength
+                } else {
+                    -1f
+                }
+                progressListener?.onProgress(totalContentLength, bytesDownloaded, percent)
+            }
+
+            outputStream?.flush()
+
+            if (!isActive.get()) {
+                throw IOException("Download cancelled by user")
+            }
+
+            // Verify content length matches bytes downloaded
+            if (totalContentLength > 0 && bytesDownloaded != totalContentLength) {
+                throw IOException("Incomplete download: read $bytesDownloaded of $totalContentLength bytes")
+            }
+
+        } finally {
+            cleanup()
+        }
+    }
+
+    fun cancel() {
+        isActive.set(false)
+        cleanup()
+    }
+
+    private fun cleanup() {
+        try {
+            inputStream?.close()
+        } catch (ignored: Exception) {}
+        try {
+            outputStream?.close()
+        } catch (ignored: Exception) {}
+        try {
+            connection?.disconnect()
+        } catch (ignored: Exception) {}
+        inputStream = null
+        outputStream = null
+        connection = null
+    }
+}
+
+class NewOfflineAttachmentDownloadManager private constructor(private val repository: OfflineAttachmentsRepository) {
+
+    private val progressScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+    private val dbMutex = Mutex()
+
+    private var maxParallelDownloads = 3
+    private val pendingQueue = LinkedBlockingQueue<DomainAttachmentContent>()
+    private val activeJobs = ConcurrentHashMap<Long, Job>()
+    private val activeDownloaders = ConcurrentHashMap<Long, NewOfflineAttachmentDownloader>()
+    private val listeners = mutableListOf<NewOfflineAttachmentDownloadListener>()
+
+    fun addListener(listener: NewOfflineAttachmentDownloadListener) {
+        synchronized(listeners) {
+            listeners.add(listener)
+        }
+    }
+
+    fun removeListener(listener: NewOfflineAttachmentDownloadListener) {
+        synchronized(listeners) {
+            listeners.remove(listener)
+        }
+    }
+
+    fun setMaxParallelDownloads(max: Int) {
+        maxParallelDownloads = max
+        processQueue()
+    }
+
+    fun enqueueDownload(context: Context, domainAttachmentContent: DomainAttachmentContent) {
+        if (domainAttachmentContent.attachmentUrl == null) {
+            Toast.makeText(context, "Attachment URL cannot be null", Toast.LENGTH_SHORT).show()
+            return
+        }
+
+        val fileName = "${domainAttachmentContent.title}${getFileExtensionFromUrl(domainAttachmentContent.attachmentUrl)}".sanitizeFileName()
+        val directory = File(context.filesDir, "offline_attachments")
+        val destFile = File(directory, fileName)
+
+        val offlineAttachment = OfflineAttachment(
+            id = domainAttachmentContent.id,
+            title = domainAttachmentContent.title ?: "Attachment ${domainAttachmentContent.id}",
+            url = domainAttachmentContent.attachmentUrl,
+            path = Uri.fromFile(destFile).toString(),
+            contentUri = null,
+            downloadId = 0L, // placeholder
+            status = OfflineAttachmentDownloadStatus.QUEUED,
+            progress = 0
+        )
+
+        progressScope.launch {
+            dbMutex.withLock {
+                repository.insert(offlineAttachment)
+            }
+            pendingQueue.add(domainAttachmentContent)
+            processQueue()
+        }
+    }
+
+    private fun processQueue() {
+        progressScope.launch {
+            dbMutex.withLock {
+                while (activeJobs.size < maxParallelDownloads && pendingQueue.isNotEmpty()) {
+                    val content = pendingQueue.poll() ?: break
+                    val job = launch {
+                        runDownloadTask(content)
+                    }
+                    activeJobs[content.id] = job
+                }
+            }
+        }
+    }
+
+    private suspend fun runDownloadTask(content: DomainAttachmentContent) {
+        val attachment = dbMutex.withLock { repository.getById(content.id) } ?: return
+        val url = content.attachmentUrl ?: return
+        val filePath = Uri.parse(attachment.path).path ?: return
+
+        var attempt = 1
+        val maxRetries = 5
+        var succeeded = false
+        var lastException: Exception? = null
+        var failureReason = NewOfflineAttachmentDownloadFailureReason.FAILURE_REASON_NONE
+
+        val downloader = NewOfflineAttachmentDownloader(Uri.parse(url), filePath)
+        activeDownloaders[content.id] = downloader
+
+        // Update DB status to DOWNLOADING before start
+        dbMutex.withLock {
+            val record = repository.getById(content.id)
+            record?.let {
+                repository.update(it.copy(status = OfflineAttachmentDownloadStatus.DOWNLOADING))
+            }
+        }
+
+        while (attempt <= maxRetries && !succeeded) {
+            try {
+                downloader.download(object : NewOfflineAttachmentDownloader.ProgressListener {
+                    override fun onProgress(contentLength: Long, bytesDownloaded: Long, percentDownloaded: Float) {
+                        val progressPercent = if (percentDownloaded >= 0) percentDownloaded.toInt() else 0
+                        progressScope.launch {
+                            dbMutex.withLock {
+                                val record = repository.getById(content.id)
+                                record?.let {
+                                    if (it.status != OfflineAttachmentDownloadStatus.COMPLETED &&
+                                        it.status != OfflineAttachmentDownloadStatus.FAILED) {
+                                        repository.update(it.copy(progress = progressPercent))
+                                    }
+                                }
+                            }
+                            synchronized(listeners) {
+                                listeners.forEach {
+                                    it.onDownloadProgress(content.id, bytesDownloaded, contentLength, percentDownloaded)
+                                }
+                            }
+                        }
+                    }
+                })
+                succeeded = true
+            } catch (e: Exception) {
+                lastException = e
+                failureReason = when (e) {
+                    is SocketTimeoutException -> NewOfflineAttachmentDownloadFailureReason.FAILURE_REASON_NETWORK
+                    is HttpDownloadException -> NewOfflineAttachmentDownloadFailureReason.FAILURE_REASON_HTTP
+                    is IOException -> NewOfflineAttachmentDownloadFailureReason.FAILURE_REASON_IO
+                    else -> NewOfflineAttachmentDownloadFailureReason.FAILURE_REASON_UNKNOWN
+                }
+
+                Log.w("NewOfflineAttachmentDownloadManager", "Download ID=${content.id} failed on attempt $attempt: ${e.message}")
+
+                if (attempt < maxRetries) {
+                    val backoffMs = Math.min(1000L * attempt, 30000L)
+                    delay(backoffMs)
+                    attempt++
+                } else {
+                    break
+                }
+            }
+        }
+
+        activeDownloaders.remove(content.id)
+        dbMutex.withLock {
+            activeJobs.remove(content.id)
+        }
+
+        progressScope.launch {
+            dbMutex.withLock {
+                val record = repository.getById(content.id)
+                record?.let {
+                    if (succeeded) {
+                        repository.update(it.copy(
+                            status = OfflineAttachmentDownloadStatus.COMPLETED,
+                            progress = 100
+                        ))
+                        synchronized(listeners) {
+                            listeners.forEach { l -> l.onDownloadCompleted(content.id, filePath) }
+                        }
+                    } else {
+                        repository.update(it.copy(
+                            status = OfflineAttachmentDownloadStatus.FAILED,
+                            progress = 0
+                        ))
+                        synchronized(listeners) {
+                            listeners.forEach { l -> l.onDownloadFailed(content.id, failureReason, lastException) }
+                        }
+                    }
+                }
+            }
+            processQueue()
+        }
+    }
+
+    fun cancelDownload(context: Context, offlineAttachment: OfflineAttachment) {
+        val downloader = activeDownloaders[offlineAttachment.id]
+        downloader?.cancel()
+
+        val job = activeJobs[offlineAttachment.id]
+        job?.cancel()
+
+        progressScope.launch {
+            dbMutex.withLock {
+                repository.delete(offlineAttachment.id)
+            }
+            val file = Uri.parse(offlineAttachment.path).path?.let { File(it) }
+            if (file != null && file.exists()) {
+                file.delete()
+            }
+            processQueue()
+        }
+    }
+
+    fun deleteDownload(context: Context, offlineAttachment: OfflineAttachment) {
+        cancelDownload(context, offlineAttachment)
+    }
+
+    fun openFile(context: Context, offlineAttachment: OfflineAttachment) {
+        val filePathUri = offlineAttachment.path
+        val contentUri = offlineAttachment.contentUri
+        val mimeType = getMimeTypeFromUri(context, filePathUri, contentUri)
+        openFile(context, filePathUri, contentUri, mimeType)
+    }
+
+    fun restartDownloadProgressTracking(context: Context) {
+        progressScope.launch {
+            val downloadingAttachments = repository.getAllWithStatus(OfflineAttachmentDownloadStatus.DOWNLOADING)
+            val queuedAttachments = repository.getAllWithStatus(OfflineAttachmentDownloadStatus.QUEUED)
+
+            val attachmentsToTrack = downloadingAttachments + queuedAttachments
+            attachmentsToTrack.forEach { attachment ->
+                val domainAttachmentContent = DomainAttachmentContent(
+                    id = attachment.id,
+                    title = attachment.title,
+                    attachmentUrl = attachment.url,
+                    allowDownload = true
+                )
+                enqueueDownload(context, domainAttachmentContent)
+            }
+        }
+    }
+
+    companion object {
+        @Volatile
+        private var INSTANCE: NewOfflineAttachmentDownloadManager? = null
+
+        fun init(repository: OfflineAttachmentsRepository) {
+            synchronized(this) {
+                if (INSTANCE == null) {
+                    INSTANCE = NewOfflineAttachmentDownloadManager(repository)
+                }
+            }
+        }
+
+        fun getInstance(): NewOfflineAttachmentDownloadManager {
+            return INSTANCE ?: throw IllegalStateException(
+                "NewOfflineAttachmentDownloadManager is not initialized. Call init() in your Application class."
+            )
+        }
+    }
+}

--- a/course/src/main/java/in/testpress/course/viewmodels/OfflineAttachmentViewModel.kt
+++ b/course/src/main/java/in/testpress/course/viewmodels/OfflineAttachmentViewModel.kt
@@ -9,7 +9,7 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import `in`.testpress.course.domain.DomainAttachmentContent
 import `in`.testpress.course.repository.OfflineAttachmentsRepository
-import `in`.testpress.course.services.OfflineAttachmentDownloadManager
+import `in`.testpress.course.services.NewOfflineAttachmentDownloadManager
 import `in`.testpress.database.TestpressDatabase
 import `in`.testpress.database.entities.OfflineAttachment
 import kotlinx.coroutines.flow.SharingStarted
@@ -32,19 +32,19 @@ class OfflineAttachmentViewModel(application: Application) : AndroidViewModel(ap
         context: Context,
         attachment: DomainAttachmentContent
     ) {
-        OfflineAttachmentDownloadManager.getInstance().enqueueDownload(context, attachment)
+        NewOfflineAttachmentDownloadManager.getInstance().enqueueDownload(context, attachment)
     }
 
     fun cancel(context: Context, offlineAttachment: OfflineAttachment) {
-        OfflineAttachmentDownloadManager.getInstance().cancelDownload(context, offlineAttachment)
+        NewOfflineAttachmentDownloadManager.getInstance().cancelDownload(context, offlineAttachment)
     }
 
     fun delete(context: Context, offlineAttachment: OfflineAttachment) {
-        OfflineAttachmentDownloadManager.getInstance().deleteDownload(context, offlineAttachment)
+        NewOfflineAttachmentDownloadManager.getInstance().deleteDownload(context, offlineAttachment)
     }
 
     fun openFile(context: Context, offlineAttachment: OfflineAttachment) {
-        OfflineAttachmentDownloadManager.getInstance().openFile(context, offlineAttachment)
+        NewOfflineAttachmentDownloadManager.getInstance().openFile(context, offlineAttachment)
     }
 
     fun deleteById(id: Long) {

--- a/samples/src/main/java/in/testpress/samples/MainActivity.java
+++ b/samples/src/main/java/in/testpress/samples/MainActivity.java
@@ -7,7 +7,7 @@ import android.view.View;
 
 import in.testpress.core.TestpressSdk;
 import in.testpress.course.repository.OfflineAttachmentsRepository;
-import in.testpress.course.services.OfflineAttachmentDownloadManager;
+import in.testpress.course.services.NewOfflineAttachmentDownloadManager;
 import in.testpress.database.TestpressDatabase;
 import in.testpress.database.dao.OfflineAttachmentsDao;
 import in.testpress.exam.TestpressExam;
@@ -68,8 +68,8 @@ public class MainActivity extends BaseToolBarActivity {
     private void initOfflineAttachmentDownloadManager() {
         OfflineAttachmentsDao offlineAttachmentDao = TestpressDatabase.Companion.invoke(this).offlineAttachmentDao();
         OfflineAttachmentsRepository offlineAttachmentsRepository =new OfflineAttachmentsRepository(offlineAttachmentDao);
-        OfflineAttachmentDownloadManager.Companion.init(offlineAttachmentsRepository);
-        OfflineAttachmentDownloadManager.Companion.getInstance().restartDownloadProgressTracking(this);
+        NewOfflineAttachmentDownloadManager.Companion.init(offlineAttachmentsRepository);
+        NewOfflineAttachmentDownloadManager.Companion.getInstance().restartDownloadProgressTracking(this);
     }
 
     private void showAnalytics() {


### PR DESCRIPTION
Replaces the dependency on the Android system DownloadManager with a custom, coroutine-based in-app downloader NewOfflineAttachmentDownloadManager. 
This change aligns attachment downloads with ExoPlayer's self-managed design.

**Improvements and differences from the old approach:**
- **Self-Managed Queueing:**  Performs downloads in-app rather than delegating them to the OS,  preventing downloads from being halted by system power-saving modes or background execution
  limits.
- **Resume Support:**  Implements HTTP Range headers to support resuming partially downloaded files instead of restarting them from scratch.
- **Concurrency Control:**  Restricts concurrent downloads using an internal queue with customizable parallel limits (defaulting to 3), preventing excessive bandwidth consumption.
- **Private Storage:**  Saves files directly into the app-private files directory to prevent external tampering or accidental user deletion, unlike the public Downloads folder used previously.
- **Automatic Retries:**  Retries failed downloads up to 5 times using backoff delays to handle transient network issues.
- **Detailed Failure Tracking:**  Categorizes failures into network, HTTP, IO, or unknown reasons for better debugging and user feedback.
- **Thread-Safe Database Syncing:**  Integrates Mutex locks with repository updates to prevent database concurrency issues.