### PR TITLE
fix: Prevent infinite loading when viewing custom module solutions

### DIFF
--- a/exam/src/main/java/in/testpress/exam/ui/ReviewQuestionsActivity.java
+++ b/exam/src/main/java/in/testpress/exam/ui/ReviewQuestionsActivity.java
@@ -532,7 +532,7 @@ public class ReviewQuestionsActivity extends BaseToolBarActivity  {
             }
         }
         if (uniqueLanguages.size() < languageCodes.size()) {
-            if (!languagesFetched) {
+            if (!languagesFetched && exam != null) {
                 fetchLanguages();
                 return;
             }


### PR DESCRIPTION
- Opening solutions from a Custom Module test report resulted in an infinite loading spinner
- Custom module tests do not have an Exam instance (exam is null). 
- When language codes were checked, displayReviewItems() called fetchLanguages() and returned early.
- Because exam was null, fetchLanguages() returned immediately without rendering review items or hiding the progress bar
- Fixed by ensuring fetchLanguages() is only called when exam is not null in displayReviewItems()