### PR TITLE
refactor: Migrate deprecated onBackPressed to OnBackPressedDispatcher

### DIFF
--- a/core/src/main/java/in/testpress/ui/AbstractWebViewActivity.kt
+++ b/core/src/main/java/in/testpress/ui/AbstractWebViewActivity.kt
@@ -6,6 +6,7 @@ import `in`.testpress.fragments.WebViewFragment
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import androidx.activity.OnBackPressedCallback
 
 abstract class AbstractWebViewActivity: BaseToolBarActivity(), WebViewFragment.Listener {
 
@@ -19,21 +20,26 @@ abstract class AbstractWebViewActivity: BaseToolBarActivity(), WebViewFragment.L
     private var allowValidationErrors: Boolean = false
     private var allowZoomControls: Boolean = false
 
+    private val webViewBackPressedCallback = object : OnBackPressedCallback(true) {
+        override fun handleOnBackPressed() {
+            if (webViewFragment.canGoBack()) {
+                webViewFragment.goBack()
+            } else {
+                isEnabled = false
+                onBackPressedDispatcher.onBackPressed()
+                isEnabled = true
+            }
+        }
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        onBackPressedDispatcher.addCallback(this, webViewBackPressedCallback)
         _layout = BaseTestpressWebviewContainerLayoutBinding.inflate(layoutInflater)
         setContentView(layout.root)
         parseArguments()
         setActionBarTitle(title)
         initializeWebViewFragment()
-    }
-
-    override fun onBackPressed() {
-        if (webViewFragment.canGoBack()) {
-            webViewFragment.goBack()
-        } else {
-            super.onBackPressed()
-        }
     }
 
     private fun parseArguments() {

--- a/core/src/main/java/in/testpress/ui/AbstractWebViewActivity.kt
+++ b/core/src/main/java/in/testpress/ui/AbstractWebViewActivity.kt
@@ -7,6 +7,7 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.OnBackPressedCallback
+import `in`.testpress.util.extension.passThrough
 
 abstract class AbstractWebViewActivity: BaseToolBarActivity(), WebViewFragment.Listener {
 
@@ -25,9 +26,7 @@ abstract class AbstractWebViewActivity: BaseToolBarActivity(), WebViewFragment.L
             if (webViewFragment.canGoBack()) {
                 webViewFragment.goBack()
             } else {
-                isEnabled = false
-                onBackPressedDispatcher.onBackPressed()
-                isEnabled = true
+                passThrough(onBackPressedDispatcher)
             }
         }
     }

--- a/core/src/main/java/in/testpress/ui/BaseToolBarActivity.kt
+++ b/core/src/main/java/in/testpress/ui/BaseToolBarActivity.kt
@@ -12,6 +12,7 @@ import android.view.MenuItem
 import android.view.View
 import android.view.WindowManager
 import android.widget.ImageView
+import androidx.activity.OnBackPressedCallback
 import androidx.annotation.StringRes
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
@@ -31,6 +32,27 @@ open class BaseToolBarActivity: AppCompatActivity() {
     private var session: TestpressSession? = null
     protected lateinit var logo: ImageView
     protected lateinit var toolbar: Toolbar
+
+    protected val toolBarBackPressedCallback = object : OnBackPressedCallback(true) {
+        override fun handleOnBackPressed() {
+            if (callingActivity != null) {
+                setResult(RESULT_CANCELED, Intent().putExtra(TestpressSdk.ACTION_PRESSED_HOME, false))
+            }
+            try {
+                isEnabled = false
+                onBackPressedDispatcher.onBackPressed()
+            } catch (e: IllegalStateException) {
+                supportFinishAfterTransition()
+            } finally {
+                isEnabled = true
+            }
+        }
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        onBackPressedDispatcher.addCallback(this, toolBarBackPressedCallback)
+    }
 
     override fun setContentView(layoutResId: Int) {
         super.setContentView(layoutResId)
@@ -88,10 +110,17 @@ open class BaseToolBarActivity: AppCompatActivity() {
              * [.startActivity] instead of [.startActivityForResult]
              */
             if (callingActivity == null) {
-                onBackPressed()
+                onBackPressedDispatcher.onBackPressed()
             } else {
                 setResult(RESULT_CANCELED, Intent().putExtras(getDataToSetResult()))
-                super.onBackPressed()
+                try {
+                    toolBarBackPressedCallback.isEnabled = false
+                    onBackPressedDispatcher.onBackPressed()
+                } catch (e: IllegalStateException) {
+                    supportFinishAfterTransition()
+                } finally {
+                    toolBarBackPressedCallback.isEnabled = true
+                }
             }
             return true
         }
@@ -104,21 +133,6 @@ open class BaseToolBarActivity: AppCompatActivity() {
 
     open fun getRetrofitCalls(): Array<RetrofitCall<*>> {
         return arrayOf()
-    }
-
-    override fun onBackPressed() {
-        /**
-         * Set result with home button pressed flag false if activity is started by
-         * [.startActivityForResult]
-         */
-        if (callingActivity != null) {
-            setResult(RESULT_CANCELED, Intent().putExtra(TestpressSdk.ACTION_PRESSED_HOME, false))
-        }
-        try {
-            super.onBackPressed()
-        } catch (e: IllegalStateException) {
-            supportFinishAfterTransition()
-        }
     }
 
     override fun onResume() {

--- a/core/src/main/java/in/testpress/ui/BaseToolBarActivity.kt
+++ b/core/src/main/java/in/testpress/ui/BaseToolBarActivity.kt
@@ -16,6 +16,7 @@ import androidx.activity.OnBackPressedCallback
 import androidx.annotation.StringRes
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
+import `in`.testpress.util.extension.passThrough
 
 /**
  * Base activity used to support the toolbar & handle backpress.
@@ -39,12 +40,9 @@ open class BaseToolBarActivity: AppCompatActivity() {
                 setResult(RESULT_CANCELED, Intent().putExtra(TestpressSdk.ACTION_PRESSED_HOME, false))
             }
             try {
-                isEnabled = false
-                onBackPressedDispatcher.onBackPressed()
+                passThrough(onBackPressedDispatcher)
             } catch (e: IllegalStateException) {
                 supportFinishAfterTransition()
-            } finally {
-                isEnabled = true
             }
         }
     }
@@ -114,12 +112,9 @@ open class BaseToolBarActivity: AppCompatActivity() {
             } else {
                 setResult(RESULT_CANCELED, Intent().putExtras(getDataToSetResult()))
                 try {
-                    toolBarBackPressedCallback.isEnabled = false
-                    onBackPressedDispatcher.onBackPressed()
+                    toolBarBackPressedCallback.passThrough(onBackPressedDispatcher)
                 } catch (e: IllegalStateException) {
                     supportFinishAfterTransition()
-                } finally {
-                    toolBarBackPressedCallback.isEnabled = true
                 }
             }
             return true

--- a/core/src/main/java/in/testpress/util/extension/OnBackPressedCallback.kt
+++ b/core/src/main/java/in/testpress/util/extension/OnBackPressedCallback.kt
@@ -1,0 +1,13 @@
+package `in`.testpress.util.extension
+
+import androidx.activity.OnBackPressedCallback
+import androidx.activity.OnBackPressedDispatcher
+
+fun OnBackPressedCallback.passThrough(dispatcher: OnBackPressedDispatcher) {
+    try {
+        isEnabled = false
+        dispatcher.onBackPressed()
+    } finally {
+        isEnabled = true
+    }
+}

--- a/course/src/main/java/in/testpress/course/ui/ContentActivity.java
+++ b/course/src/main/java/in/testpress/course/ui/ContentActivity.java
@@ -5,6 +5,7 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.view.MenuItem;
 
+import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 
@@ -57,9 +58,24 @@ public class ContentActivity extends BaseToolBarActivity implements ContentFragm
         return intent;
     }
 
+    private final OnBackPressedCallback fragmentBackPressedCallback = new OnBackPressedCallback(true) {
+        @Override
+        public void handleOnBackPressed() {
+            backPressedHandled = false;
+            delegateBackPressToFragments();
+            
+            if (!backPressedHandled) {
+                setEnabled(false);
+                getOnBackPressedDispatcher().onBackPressed();
+                setEnabled(true);
+            }
+        }
+    };
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        getOnBackPressedDispatcher().addCallback(this, fragmentBackPressedCallback);
         setContentView(R.layout.content_detail_activity);
         Bundle bundle = getIntent().getExtras();
         ContentLoadingFragment fragment = new ContentLoadingFragment();
@@ -71,29 +87,13 @@ public class ContentActivity extends BaseToolBarActivity implements ContentFragm
     @Override
     public boolean onOptionsItemSelected(final MenuItem item) {
         if(item.getItemId() == android.R.id.home) {
-            backPressedHandled = false;
-            delegateBackPressToFragments();
-            if (getCallingActivity() != null) {
-                return false;
-            } else if (!backPressedHandled) {
-                super.onBackPressed();
-            }
+            getOnBackPressedDispatcher().onBackPressed();
             return true;
         }
         return super.onOptionsItemSelected(item);
     }
 
     private boolean backPressedHandled = false;
-    
-    @Override
-    public void onBackPressed() {
-        backPressedHandled = false;
-        delegateBackPressToFragments();
-        
-        if (!backPressedHandled) {
-            super.onBackPressed();
-        }
-    }
 
     private void delegateBackPressToFragments() {
         for (Fragment fragment : getSupportFragmentManager().getFragments()) {

--- a/course/src/main/java/in/testpress/course/ui/ContentActivity.java
+++ b/course/src/main/java/in/testpress/course/ui/ContentActivity.java
@@ -65,9 +65,12 @@ public class ContentActivity extends BaseToolBarActivity implements ContentFragm
             delegateBackPressToFragments();
             
             if (!backPressedHandled) {
-                setEnabled(false);
-                getOnBackPressedDispatcher().onBackPressed();
-                setEnabled(true);
+                try {
+                    setEnabled(false);
+                    getOnBackPressedDispatcher().onBackPressed();
+                } finally {
+                    setEnabled(true);
+                }
             }
         }
     };
@@ -87,6 +90,11 @@ public class ContentActivity extends BaseToolBarActivity implements ContentFragm
     @Override
     public boolean onOptionsItemSelected(final MenuItem item) {
         if(item.getItemId() == android.R.id.home) {
+            if (getCallingActivity() != null) {
+                backPressedHandled = false;
+                delegateBackPressToFragments();
+                return false;
+            }
             getOnBackPressedDispatcher().onBackPressed();
             return true;
         }

--- a/course/src/main/java/in/testpress/course/ui/CustomTestGenerationActivity.kt
+++ b/course/src/main/java/in/testpress/course/ui/CustomTestGenerationActivity.kt
@@ -14,9 +14,9 @@ import `in`.testpress.util.BaseJavaScriptInterface
 import `in`.testpress.util.extension.toast
 import android.content.Intent
 import android.os.Bundle
-import androidx.activity.OnBackPressedCallback
 import android.webkit.JavascriptInterface
 import android.widget.Toolbar
+import androidx.activity.OnBackPressedCallback
 import androidx.core.view.isVisible
 import `in`.testpress.exam.network.NetworkAttempt
 import `in`.testpress.exam.network.asGreenDaoModel
@@ -31,9 +31,7 @@ class CustomTestGenerationActivity: AbstractWebViewActivity() {
             if (testFragment != null) {
                 testFragment.showEndExamAlert()
             } else {
-                isEnabled = false
-                onBackPressedDispatcher.onBackPressed()
-                isEnabled = true
+                this@CustomTestGenerationActivity.finish()
             }
         }
     }
@@ -110,8 +108,6 @@ class CustomTestGenerationActivity: AbstractWebViewActivity() {
         supportFragmentManager.beginTransaction()
             .replace(R.id.fragment_container, testFragment).commitAllowingStateLoss()
     }
-
-
 
 }
 

--- a/course/src/main/java/in/testpress/course/ui/CustomTestGenerationActivity.kt
+++ b/course/src/main/java/in/testpress/course/ui/CustomTestGenerationActivity.kt
@@ -14,6 +14,7 @@ import `in`.testpress.util.BaseJavaScriptInterface
 import `in`.testpress.util.extension.toast
 import android.content.Intent
 import android.os.Bundle
+import androidx.activity.OnBackPressedCallback
 import android.webkit.JavascriptInterface
 import android.widget.Toolbar
 import androidx.core.view.isVisible
@@ -22,6 +23,25 @@ import `in`.testpress.exam.network.asGreenDaoModel
 
 
 class CustomTestGenerationActivity: AbstractWebViewActivity() {
+
+    private val customTestBackPressedCallback = object : OnBackPressedCallback(true) {
+        override fun handleOnBackPressed() {
+            val testFragment: TestFragment? =
+                (supportFragmentManager.findFragmentById(R.id.fragment_container) as? TestFragment?)
+            if (testFragment != null) {
+                testFragment.showEndExamAlert()
+            } else {
+                isEnabled = false
+                onBackPressedDispatcher.onBackPressed()
+                isEnabled = true
+            }
+        }
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        onBackPressedDispatcher.addCallback(this, customTestBackPressedCallback)
+    }
 
     override fun onWebViewInitializationSuccess() {
         webViewFragment.addJavascriptInterface(JavaScriptInterface(this),"AndroidInterface")
@@ -91,15 +111,7 @@ class CustomTestGenerationActivity: AbstractWebViewActivity() {
             .replace(R.id.fragment_container, testFragment).commitAllowingStateLoss()
     }
 
-    override fun onBackPressed() {
-        val testFragment: TestFragment? =
-            (supportFragmentManager.findFragmentById(R.id.fragment_container) as? TestFragment?)
-        if (testFragment != null) {
-            testFragment.showEndExamAlert()
-        } else {
-            this.finish()
-        }
-    }
+
 
 }
 


### PR DESCRIPTION
- Replace the deprecated `onBackPressed()` method with `OnBackPressedDispatcher` and `OnBackPressedCallback`
- Update `BaseToolBarActivity`, `ContentActivity`, and `CustomTestGenerationActivity` to register back pressed callbacks in `onCreate`
- Maintain existing back navigation logic, including result setting and fragment delegation, within the new callback structure
- Ensure compatibility with predictive back gestures in modern Android versions