### PR TITLE
build: Update compile and target SDK versions to 36

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,9 +34,9 @@ task clean(type: Delete) {
 }
 
 ext {
-    compileSdkVersion = 35
+    compileSdkVersion = 36
     minSdkVersion = 26
-    targetSdkVersion = 35
+    targetSdkVersion = 36
     minSdkVersionForUITest = 26
     buildToolsVersion = '30.0.3'
 


### PR DESCRIPTION
- The project previously used SDK version 35 for compilation and targeting
- This is updated to version 36 to stay current with the latest Android SDK features and requirements
- Updated both `compileSdkVersion` and `targetSdkVersion` in the root `build.gradle` file