### PR TITLE
fix: Prevent initialization crash in OfflineAttachmentViewModel

### DIFF
--- a/course/src/main/java/in/testpress/course/services/NewOfflineAttachmentDownloadManager.kt
+++ b/course/src/main/java/in/testpress/course/services/NewOfflineAttachmentDownloadManager.kt
@@ -6,6 +6,7 @@ import android.util.Log
 import android.widget.Toast
 import `in`.testpress.course.domain.DomainAttachmentContent
 import `in`.testpress.course.repository.OfflineAttachmentsRepository
+import `in`.testpress.database.TestpressDatabase
 import `in`.testpress.database.entities.OfflineAttachment
 import `in`.testpress.database.entities.OfflineAttachmentDownloadStatus
 import `in`.testpress.util.getFileExtensionFromUrl
@@ -418,9 +419,19 @@ class NewOfflineAttachmentDownloadManager private constructor(private val reposi
             }
         }
 
+        fun getInstance(context: Context): NewOfflineAttachmentDownloadManager {
+            return INSTANCE ?: synchronized(this) {
+                INSTANCE ?: NewOfflineAttachmentDownloadManager(
+                    OfflineAttachmentsRepository(
+                        TestpressDatabase.invoke(context.applicationContext).offlineAttachmentDao()
+                    )
+                ).also { INSTANCE = it }
+            }
+        }
+
         fun getInstance(): NewOfflineAttachmentDownloadManager {
             return INSTANCE ?: throw IllegalStateException(
-                "NewOfflineAttachmentDownloadManager is not initialized. Call init() in your Application class."
+                "NewOfflineAttachmentDownloadManager is not initialized. Call init() in your Application class or use getInstance(context)."
             )
         }
     }

--- a/course/src/main/java/in/testpress/course/viewmodels/OfflineAttachmentViewModel.kt
+++ b/course/src/main/java/in/testpress/course/viewmodels/OfflineAttachmentViewModel.kt
@@ -32,19 +32,19 @@ class OfflineAttachmentViewModel(application: Application) : AndroidViewModel(ap
         context: Context,
         attachment: DomainAttachmentContent
     ) {
-        NewOfflineAttachmentDownloadManager.getInstance(context).enqueueDownload(context, attachment)
+        NewOfflineAttachmentDownloadManager.getInstance(getApplication()).enqueueDownload(context, attachment)
     }
 
     fun cancel(context: Context, offlineAttachment: OfflineAttachment) {
-        NewOfflineAttachmentDownloadManager.getInstance(context).cancelDownload(context, offlineAttachment)
+        NewOfflineAttachmentDownloadManager.getInstance(getApplication()).cancelDownload(context, offlineAttachment)
     }
 
     fun delete(context: Context, offlineAttachment: OfflineAttachment) {
-        NewOfflineAttachmentDownloadManager.getInstance(context).deleteDownload(context, offlineAttachment)
+        NewOfflineAttachmentDownloadManager.getInstance(getApplication()).deleteDownload(context, offlineAttachment)
     }
 
     fun openFile(context: Context, offlineAttachment: OfflineAttachment) {
-        NewOfflineAttachmentDownloadManager.getInstance(context).openFile(context, offlineAttachment)
+        NewOfflineAttachmentDownloadManager.getInstance(getApplication()).openFile(context, offlineAttachment)
     }
 
     fun deleteById(id: Long) {

--- a/course/src/main/java/in/testpress/course/viewmodels/OfflineAttachmentViewModel.kt
+++ b/course/src/main/java/in/testpress/course/viewmodels/OfflineAttachmentViewModel.kt
@@ -32,19 +32,19 @@ class OfflineAttachmentViewModel(application: Application) : AndroidViewModel(ap
         context: Context,
         attachment: DomainAttachmentContent
     ) {
-        NewOfflineAttachmentDownloadManager.getInstance().enqueueDownload(context, attachment)
+        NewOfflineAttachmentDownloadManager.getInstance(context).enqueueDownload(context, attachment)
     }
 
     fun cancel(context: Context, offlineAttachment: OfflineAttachment) {
-        NewOfflineAttachmentDownloadManager.getInstance().cancelDownload(context, offlineAttachment)
+        NewOfflineAttachmentDownloadManager.getInstance(context).cancelDownload(context, offlineAttachment)
     }
 
     fun delete(context: Context, offlineAttachment: OfflineAttachment) {
-        NewOfflineAttachmentDownloadManager.getInstance().deleteDownload(context, offlineAttachment)
+        NewOfflineAttachmentDownloadManager.getInstance(context).deleteDownload(context, offlineAttachment)
     }
 
     fun openFile(context: Context, offlineAttachment: OfflineAttachment) {
-        NewOfflineAttachmentDownloadManager.getInstance().openFile(context, offlineAttachment)
+        NewOfflineAttachmentDownloadManager.getInstance(context).openFile(context, offlineAttachment)
     }
 
     fun deleteById(id: Long) {


### PR DESCRIPTION
- OfflineAttachmentViewModel calls NewOfflineAttachmentDownloadManager.getInstance() which throws an IllegalStateException if the download manager is not initialized
- This occurs because the download manager was not initialized in the application class or when it is invoked early
- Fixed by introducing a context-based NewOfflineAttachmentDownloadManager.getInstance(context) method that lazy-initializes the instance using the application context database, and refactoring ViewModel calls to use it