### PR TITLE
build: Upgrade Kotlin to 2.2.20 and Room to 2.8.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@
 
 buildscript {
     ext.kotlin_version = '2.2.20'
-    ext.kotlin_coroutine_version = '1.3.3'
+    ext.kotlin_coroutine_version = '1.8.1'
     repositories {
         google()
         jcenter()
@@ -20,6 +20,8 @@ buildscript {
 
 allprojects {
     configurations.all {
+        // Exclude legacy Kotlin android extensions to prevent duplicate class packaging conflicts 
+        // with the modern kotlin-parcelize-runtime library pulled in by newer dependencies.
         exclude group: 'org.jetbrains.kotlin', module: 'kotlin-android-extensions-runtime'
     }
     repositories {
@@ -91,9 +93,9 @@ ext {
     firebaseAnalytics = "com.google.firebase:firebase-analytics:17.4.0"
     jsoup = "org.jsoup:jsoup:1.13.1"
     sentrySDK = "io.sentry:sentry-android:8.0.0"
-    kotlinStdlibJdk7 = "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.0"
-    kotlinxCoroutinesCore = "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.3"
-    kotlinxCoroutinesAndroid = "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.3"
+    kotlinStdlibJdk7 = "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    kotlinxCoroutinesCore = "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlin_coroutine_version"
+    kotlinxCoroutinesAndroid = "org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlin_coroutine_version"
     flexboxLayout = "com.google.android.flexbox:flexbox:3.0.0"
     jwtdecode = "com.auth0.android:jwtdecode:2.0.2"
 
@@ -111,7 +113,7 @@ ext {
     androidCoreTesting = "androidx.arch.core:core-testing:2.1.0"
     androidRoomTesting = "android.arch.persistence.room:testing:1.1.1"
     fragmentTestingExtensions = "androidx.fragment:fragment-testing:1.4.1"
-    kotlinxCoroutinesTest = "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.3.3"
+    kotlinxCoroutinesTest = "org.jetbrains.kotlinx:kotlinx-coroutines-test:$kotlin_coroutine_version"
     androidXTestLibrary = "androidx.test:rules:1.1.0"
     junit = 'junit:junit:4.12'
     mockito = 'org.mockito:mockito-core:2.23.4'

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.8.0'
+    ext.kotlin_version = '2.2.20'
     ext.kotlin_coroutine_version = '1.3.3'
     repositories {
         google()
@@ -11,6 +11,7 @@ buildscript {
         classpath 'com.android.tools.build:gradle:8.5.1'
         classpath 'com.google.gms:google-services:4.3.10'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath "org.jetbrains.kotlin:compose-compiler-gradle-plugin:$kotlin_version"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }
@@ -18,7 +19,9 @@ buildscript {
 }
 
 allprojects {
-
+    configurations.all {
+        exclude group: 'org.jetbrains.kotlin', module: 'kotlin-android-extensions-runtime'
+    }
     repositories {
         google()
         jcenter()
@@ -52,10 +55,10 @@ ext {
     androidArchRuntime = "androidx.arch.core:core-runtime:2.1.0"
     coreKotlinExtensions = "androidx.core:core-ktx:1.7.0"
     androidMultiDexLibrary = "androidx.multidex:multidex:2.0.1"
-    roomRuntime = "androidx.room:room-runtime:2.4.3"
-    roomKotlinExtensions = "androidx.room:room-ktx:2.4.3"
-    roomPaging = "androidx.room:room-paging:2.4.3"
-    roomCompiler = "androidx.room:room-compiler:2.4.3"
+    roomRuntime = "androidx.room:room-runtime:2.8.4"
+    roomKotlinExtensions = "androidx.room:room-ktx:2.8.4"
+    roomPaging = "androidx.room:room-paging:2.8.4"
+    roomCompiler = "androidx.room:room-compiler:2.8.4"
     viewPager2 = "androidx.viewpager2:viewpager2:1.0.0"
     securityCrypto = "androidx.security:security-crypto:1.0.0"
 

--- a/course/build.gradle
+++ b/course/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
+apply plugin: 'org.jetbrains.kotlin.plugin.compose'
 
 android {
     compileSdkVersion rootProject.compileSdkVersion
@@ -34,9 +35,6 @@ android {
     buildFeatures {
         viewBinding true
         compose true
-    }
-    composeOptions {
-        kotlinCompilerExtensionVersion '1.4.1'
     }
     namespace 'in.testpress.course'
     testNamespace 'in.testpress.course.androidTest'


### PR DESCRIPTION
- Upgraded Kotlin compiler version from 1.8.0 to 2.2.20 to meet the dependency requirements of the new Zoom Meeting SDK v7.x libraries
- Added compose-compiler-gradle-plugin to the buildscript classpath to support Jetpack Compose UI compilation in the course module under Kotlin 2.x
- Excluded the legacy kotlin-android-extensions-runtime dependency globally to resolve duplicate class conflicts with the modern kotlin-parcelize-runtime library
- Upgraded the Room database dependencies from 2.4.3 to 2.8.4 to support parsing Kotlin 2.2.x class metadata during KAPT annotation processing