### PR TITLE
fix: Resolve Zoom SDK crashes, ANR issues, and lifecycle bugs

### DIFF
--- a/course/src/main/java/in/testpress/course/domain/zoom/callbacks/MeetingChatCallback.kt
+++ b/course/src/main/java/in/testpress/course/domain/zoom/callbacks/MeetingChatCallback.kt
@@ -25,7 +25,11 @@ object MeetingChatCallback : BaseCallback<MeetingChatCallback.ChatEvent?>() {
         }
     }
 
-    init {
-        ZoomSDK.getInstance().inMeetingService.addListener(chatListener)
+    fun register() {
+        ZoomSDK.getInstance().inMeetingService?.addListener(chatListener)
+    }
+
+    fun unregister() {
+        ZoomSDK.getInstance().inMeetingService?.removeListener(chatListener)
     }
 }

--- a/course/src/main/java/in/testpress/course/domain/zoom/callbacks/MeetingChatCallback.kt
+++ b/course/src/main/java/in/testpress/course/domain/zoom/callbacks/MeetingChatCallback.kt
@@ -25,11 +25,18 @@ object MeetingChatCallback : BaseCallback<MeetingChatCallback.ChatEvent?>() {
         }
     }
 
+    @Volatile private var isRegistered = false
+
     fun register() {
+        if (isRegistered) return
         ZoomSDK.getInstance().inMeetingService?.addListener(chatListener)
+        isRegistered = true
     }
 
     fun unregister() {
+        if (!isRegistered) return
         ZoomSDK.getInstance().inMeetingService?.removeListener(chatListener)
+        isRegistered = false
     }
 }
+

--- a/course/src/main/java/in/testpress/course/domain/zoom/callbacks/MeetingCommonCallback.kt
+++ b/course/src/main/java/in/testpress/course/domain/zoom/callbacks/MeetingCommonCallback.kt
@@ -72,8 +72,13 @@ object MeetingCommonCallback : BaseCallback<MeetingCommonCallback.CommonEvent?>(
 
     }
 
-    init {
-        ZoomSDK.getInstance().inMeetingService.addListener(commonListener)
-        ZoomSDK.getInstance().meetingService.addListener(serviceListener)
+    fun register() {
+        ZoomSDK.getInstance().inMeetingService?.addListener(commonListener)
+        ZoomSDK.getInstance().meetingService?.addListener(serviceListener)
+    }
+
+    fun unregister() {
+        ZoomSDK.getInstance().inMeetingService?.removeListener(commonListener)
+        ZoomSDK.getInstance().meetingService?.removeListener(serviceListener)
     }
 }

--- a/course/src/main/java/in/testpress/course/domain/zoom/callbacks/MeetingCommonCallback.kt
+++ b/course/src/main/java/in/testpress/course/domain/zoom/callbacks/MeetingCommonCallback.kt
@@ -72,13 +72,19 @@ object MeetingCommonCallback : BaseCallback<MeetingCommonCallback.CommonEvent?>(
 
     }
 
+    @Volatile private var isRegistered = false
+
     fun register() {
+        if (isRegistered) return
         ZoomSDK.getInstance().inMeetingService?.addListener(commonListener)
         ZoomSDK.getInstance().meetingService?.addListener(serviceListener)
+        isRegistered = true
     }
 
     fun unregister() {
+        if (!isRegistered) return
         ZoomSDK.getInstance().inMeetingService?.removeListener(commonListener)
         ZoomSDK.getInstance().meetingService?.removeListener(serviceListener)
+        isRegistered = false
     }
 }

--- a/course/src/main/java/in/testpress/course/domain/zoom/callbacks/MeetingShareCallback.kt
+++ b/course/src/main/java/in/testpress/course/domain/zoom/callbacks/MeetingShareCallback.kt
@@ -24,7 +24,11 @@ object MeetingShareCallback : BaseCallback<MeetingShareCallback.ShareEvent?>() {
         override fun onShareSettingTypeChanged(p0: ShareSettingType?) {}
     }
 
-    init {
-        ZoomSDK.getInstance().inMeetingService.inMeetingShareController.addListener(shareListener)
-    }
-}
+    fun register() {
+        ZoomSDK.getInstance().inMeetingService?.inMeetingShareController?.addListener(shareListener)
+     }
+ 
+     fun unregister() {
+        ZoomSDK.getInstance().inMeetingService?.inMeetingShareController?.removeListener(shareListener)
+     }
+ }

--- a/course/src/main/java/in/testpress/course/domain/zoom/callbacks/MeetingShareCallback.kt
+++ b/course/src/main/java/in/testpress/course/domain/zoom/callbacks/MeetingShareCallback.kt
@@ -24,11 +24,18 @@ object MeetingShareCallback : BaseCallback<MeetingShareCallback.ShareEvent?>() {
         override fun onShareSettingTypeChanged(p0: ShareSettingType?) {}
     }
 
+    @Volatile private var isRegistered = false
+
     fun register() {
+        if (isRegistered) return
         ZoomSDK.getInstance().inMeetingService?.inMeetingShareController?.addListener(shareListener)
-     }
- 
-     fun unregister() {
+        isRegistered = true
+    }
+
+    fun unregister() {
+        if (!isRegistered) return
         ZoomSDK.getInstance().inMeetingService?.inMeetingShareController?.removeListener(shareListener)
-     }
- }
+        isRegistered = false
+    }
+}
+

--- a/course/src/main/java/in/testpress/course/domain/zoom/callbacks/MeetingUserCallback.kt
+++ b/course/src/main/java/in/testpress/course/domain/zoom/callbacks/MeetingUserCallback.kt
@@ -48,7 +48,11 @@ object MeetingUserCallback: BaseCallback<MeetingUserCallback.UserEvent?>() {
         }
     }
 
-    init{
-        ZoomSDK.getInstance().inMeetingService.addListener(userListener)
+    fun register() {
+        ZoomSDK.getInstance().inMeetingService?.addListener(userListener)
+    }
+
+    fun unregister() {
+        ZoomSDK.getInstance().inMeetingService?.removeListener(userListener)
     }
 }

--- a/course/src/main/java/in/testpress/course/domain/zoom/callbacks/MeetingUserCallback.kt
+++ b/course/src/main/java/in/testpress/course/domain/zoom/callbacks/MeetingUserCallback.kt
@@ -14,7 +14,7 @@ object MeetingUserCallback: BaseCallback<MeetingUserCallback.UserEvent?>() {
 
     private var userListener = object: SimpleInMeetingListener() {
         override fun onMeetingUserJoin(list: List<Long>) {
-            if (ZoomSDK.getInstance().meetingService.meetingStatus == us.zoom.sdk.MeetingStatus.MEETING_STATUS_INMEETING) {
+            if (ZoomSDK.getInstance().meetingService?.meetingStatus == us.zoom.sdk.MeetingStatus.MEETING_STATUS_INMEETING) {
                 for (event in callbacks) {
                     event?.onMeetingUserJoin(list)
                 }
@@ -22,7 +22,7 @@ object MeetingUserCallback: BaseCallback<MeetingUserCallback.UserEvent?>() {
         }
 
         override fun onMeetingUserLeave(list: List<Long>) {
-            if (ZoomSDK.getInstance().meetingService.meetingStatus == us.zoom.sdk.MeetingStatus.MEETING_STATUS_INMEETING) {
+            if (ZoomSDK.getInstance().meetingService?.meetingStatus == us.zoom.sdk.MeetingStatus.MEETING_STATUS_INMEETING) {
                 for (event in callbacks) {
                     event?.onMeetingUserLeave(list)
                 }
@@ -48,11 +48,17 @@ object MeetingUserCallback: BaseCallback<MeetingUserCallback.UserEvent?>() {
         }
     }
 
+    @Volatile private var isRegistered = false
+
     fun register() {
+        if (isRegistered) return
         ZoomSDK.getInstance().inMeetingService?.addListener(userListener)
+        isRegistered = true
     }
 
     fun unregister() {
+        if (!isRegistered) return
         ZoomSDK.getInstance().inMeetingService?.removeListener(userListener)
+        isRegistered = false
     }
 }

--- a/course/src/main/java/in/testpress/course/fragments/VideoConferenceFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/VideoConferenceFragment.kt
@@ -138,8 +138,9 @@ class VideoConferenceFragment : BaseContentDetailFragment() {
     }
 
     private fun loadProfileAndInitializeConference(videoConference: DomainVideoConferenceContent?) {
-        TestpressUserDetails.getInstance().load(requireContext(),object : TestpressCallback<ProfileDetails>(){
+        TestpressUserDetails.getInstance().load(requireContext(), object : TestpressCallback<ProfileDetails>() {
             override fun onSuccess(result: ProfileDetails?) {
+                if (!isAdded) return
                 profileDetails = result
                 profileDetails?.let {
                     initVideoConferenceHandler(videoConference, it)
@@ -147,16 +148,21 @@ class VideoConferenceFragment : BaseContentDetailFragment() {
             }
 
             override fun onException(exception: TestpressException) {
+                if (!isAdded) return
                 emptyViewFragment.displayError(exception)
             }
         })
     }
 
     private fun initVideoConferenceHandler(
-        videoConference: DomainVideoConferenceContent?, 
+        videoConference: DomainVideoConferenceContent?,
         profileDetails: ProfileDetails,
         onInitComplete: (() -> Unit)? = null
     ) {
+        if (!isAdded) {
+            onInitComplete?.invoke()
+            return
+        }
         try {
             videoConferenceHandler = VideoConferenceHandler(requireContext(), videoConference ?: throw NullPointerException("videoConference is null during initialization"), profileDetails)
             videoConferenceHandler?.init(object : VideoConferenceInitializeListener {
@@ -185,7 +191,7 @@ class VideoConferenceFragment : BaseContentDetailFragment() {
                 hideLoadingAndEnableStartButton()
             }
             Sentry.captureException(e) { scope ->
-                scope.setTag("user_name", profileDetails.username?:"")
+                scope.setTag("user_name", profileDetails.username ?: "")
                 scope.setContexts(
                     "Video Conference Error",
                     object : HashMap<String?, Any?>() {
@@ -196,6 +202,10 @@ class VideoConferenceFragment : BaseContentDetailFragment() {
                     }
                 )
             }
+            onInitComplete?.invoke()
+        } catch (e: IllegalStateException) {
+            // Fragment detached from activity mid-initialization (e.g. user navigated away)
+            Sentry.captureException(e)
             onInitComplete?.invoke()
         }
     }

--- a/course/src/main/java/in/testpress/course/ui/ChatFragment.kt
+++ b/course/src/main/java/in/testpress/course/ui/ChatFragment.kt
@@ -19,8 +19,8 @@ class ChatFragment : Fragment(), MeetingChatCallback.ChatEvent{
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        inMeetingChatController = ZoomSDK.getInstance().inMeetingService.inMeetingChatController
-        currentUserId = ZoomSDK.getInstance().inMeetingService.myUserID
+        inMeetingChatController = ZoomSDK.getInstance().inMeetingService?.inMeetingChatController ?: run { return }
+        currentUserId = ZoomSDK.getInstance().inMeetingService?.myUserID ?: 0
         MeetingChatCallback.addListener(this)
     }
 
@@ -44,7 +44,7 @@ class ChatFragment : Fragment(), MeetingChatCallback.ChatEvent{
     private fun sendMessage(){
         val inputBox = binding.inputBox
         val recyclerView = binding.recyclerChat
-        val chatController = ZoomSDK.getInstance().inMeetingService.inMeetingChatController
+        val chatController = ZoomSDK.getInstance().inMeetingService?.inMeetingChatController
 
         if (inputBox.text?.isNotBlank() == true && chatController != null) {
             val chatMessage = ChatMessageBuilder()

--- a/course/src/main/java/in/testpress/course/ui/CustomMeetingActivity.kt
+++ b/course/src/main/java/in/testpress/course/ui/CustomMeetingActivity.kt
@@ -67,8 +67,6 @@ class CustomMeetingActivity : FragmentActivity(), MeetingUserCallback.UserEvent,
     }
 
     private fun registerCallbackListener() {
-        MeetingCommonCallback.register()
-        MeetingUserCallback.register()
         MeetingCommonCallback.addListener(this)
         MeetingUserCallback.addListener(this)
     }
@@ -154,6 +152,7 @@ class CustomMeetingActivity : FragmentActivity(), MeetingUserCallback.UserEvent,
 
     override fun onMeetingUserJoin(list: List<Long?>?) {
         audioController.connectAudioWithVoIP()
+        audioController.setLoudSpeakerStatus(true)
         audioController.muteMyAudio(true)
     }
 

--- a/course/src/main/java/in/testpress/course/ui/CustomMeetingActivity.kt
+++ b/course/src/main/java/in/testpress/course/ui/CustomMeetingActivity.kt
@@ -67,6 +67,8 @@ class CustomMeetingActivity : FragmentActivity(), MeetingUserCallback.UserEvent,
     }
 
     private fun registerCallbackListener() {
+        MeetingCommonCallback.register()
+        MeetingUserCallback.register()
         MeetingCommonCallback.addListener(this)
         MeetingUserCallback.addListener(this)
     }

--- a/course/src/main/java/in/testpress/course/ui/MeetingScreenFragment.kt
+++ b/course/src/main/java/in/testpress/course/ui/MeetingScreenFragment.kt
@@ -28,8 +28,6 @@ class MeetingScreenFragment : Fragment(), MeetingShareCallback.ShareEvent, Meeti
     }
 
     private fun registerCallback() {
-        MeetingShareCallback.register()
-        MeetingUserCallback.register()
         MeetingShareCallback.addListener(this)
         MeetingUserCallback.addListener(this)
     }

--- a/course/src/main/java/in/testpress/course/ui/MeetingScreenFragment.kt
+++ b/course/src/main/java/in/testpress/course/ui/MeetingScreenFragment.kt
@@ -28,6 +28,8 @@ class MeetingScreenFragment : Fragment(), MeetingShareCallback.ShareEvent, Meeti
     }
 
     private fun registerCallback() {
+        MeetingShareCallback.register()
+        MeetingUserCallback.register()
         MeetingShareCallback.addListener(this)
         MeetingUserCallback.addListener(this)
     }

--- a/course/src/main/java/in/testpress/course/util/ZoomMeetHandler.kt
+++ b/course/src/main/java/in/testpress/course/util/ZoomMeetHandler.kt
@@ -53,6 +53,8 @@ class ZoomMeetHandler(
             TestpressSdk.getTestpressSession(context)!!.instituteSettings
         useCustomMeetingUi = instituteSettings.isCustomMeetingUIEnabled
         zoomSDK.meetingSettingsHelper.isCustomizedMeetingUIEnabled = useCustomMeetingUi
+        zoomSDK.meetingSettingsHelper.setAutoConnectVoIPWhenJoinMeeting(true)
+        zoomSDK.meetingSettingsHelper.setMuteMyMicrophoneWhenJoinMeeting(true)
     }
 
     private fun configureMeetingUi() {

--- a/course/src/main/java/in/testpress/course/util/ZoomMeetHandler.kt
+++ b/course/src/main/java/in/testpress/course/util/ZoomMeetHandler.kt
@@ -4,6 +4,9 @@ import `in`.testpress.core.TestpressSdk
 import `in`.testpress.core.TestpressSdk.COURSE_CONTENT_DETAIL_REQUEST_CODE
 import `in`.testpress.course.domain.DomainVideoConferenceContent
 import `in`.testpress.course.domain.zoom.callbacks.MeetingCommonCallback
+import `in`.testpress.course.domain.zoom.callbacks.MeetingUserCallback
+import `in`.testpress.course.domain.zoom.callbacks.MeetingShareCallback
+import `in`.testpress.course.domain.zoom.callbacks.MeetingChatCallback
 import `in`.testpress.course.ui.CustomMeetingActivity
 import `in`.testpress.course.ui.ZoomMeetActivity
 import `in`.testpress.models.InstituteSettings
@@ -104,7 +107,15 @@ class ZoomMeetHandler(
         }
     }
 
+    private fun registerCallbacks() {
+        MeetingCommonCallback.register()
+        MeetingUserCallback.register()
+        MeetingShareCallback.register()
+        MeetingChatCallback.register()
+    }
+
     private fun registerMeetingServiceListener() {
+        registerCallbacks()
         MeetingCommonCallback.addListener(this)
     }
 
@@ -205,9 +216,17 @@ class ZoomMeetHandler(
         return
     }
 
+    private fun unregisterCallbacks() {
+        MeetingCommonCallback.unregister()
+        MeetingUserCallback.unregister()
+        MeetingShareCallback.unregister()
+        MeetingChatCallback.unregister()
+    }
+
     fun removeListeners() {
         if (zoomSDK.isInitialized) {
             MeetingCommonCallback.removeListener(this)
+            unregisterCallbacks()
         }
     }
 


### PR DESCRIPTION
- Remove direct ZoomSDK calls from callback object init blocks to prevent premature access crashes (NullPointerException) during class loading
- Implement idempotent registration with @ Volatile isRegistered guards to prevent duplicate listener registration
- Fix IllegalStateException in VideoConferenceFragment during async profile loads by checking isAdded and catching detachment exceptions
- Secure null-safety for all inMeetingService and meetingService access inside listener callbacks
- Enable loudspeaker default and auto-connect VoIP settings when joining a Zoom meeting