### PR TITLE
fix: Prevent premature termination for exams with no configured duration

### DIFF
--- a/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
@@ -218,7 +218,7 @@ public class TestFragment extends BaseFragment implements
         if (exam != null && exam.hasMultipleLanguages()) {
             initializeLanguageFilter();
         }
-        if (hasNoDuration()) {
+        if (!attempt.hasSectionalLock() && hasNoDuration()) {
             timer.setVisibility(View.GONE);
         }
         observeAttemptItemResources();

--- a/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
@@ -218,8 +218,8 @@ public class TestFragment extends BaseFragment implements
         if (exam != null && exam.hasMultipleLanguages()) {
             initializeLanguageFilter();
         }
-        if (exam == null && attempt.getRemainingTime().equals(DEFAULT_EXAM_TIME)) {
-            view.findViewById(R.id.timer).setVisibility(View.GONE);
+        if (hasNoDuration()) {
+            timer.setVisibility(View.GONE);
         }
         observeAttemptItemResources();
         observeSaveAnswerResource();
@@ -729,7 +729,7 @@ public class TestFragment extends BaseFragment implements
                         }
 
                         attemptItemList = listResource.getData();
-                        if (attempt.getRemainingTime() == null || attempt.getRemainingTime().equals("0:00:00")) {
+                        if (!hasNoDuration() && (attempt.getRemainingTime() == null || attempt.getRemainingTime().equals("0:00:00") || attempt.getRemainingTime().equals("00:00:00"))) {
                             endExam();
                             return;
                         }
@@ -1365,7 +1365,25 @@ public class TestFragment extends BaseFragment implements
         questionsListAdapter.setItems(filterItems.toArray());
     }
 
+    boolean hasNoDuration() {
+        if (exam != null) {
+            String duration = exam.getDuration();
+            return duration == null || duration.equals("0:00:00") || duration.equals("00:00:00") || duration.isEmpty();
+        }
+        return attempt != null && (attempt.getRemainingTime() == null ||
+                attempt.getRemainingTime().equals("0:00:00") ||
+                attempt.getRemainingTime().equals("00:00:00") ||
+                attempt.getRemainingTime().equals(DEFAULT_EXAM_TIME));
+    }
+
     void startCountDownTimer() {
+        if (hasNoDuration()) {
+            timer.setVisibility(View.GONE);
+            if (attemptItemList.isEmpty()) {
+                fetchAttemptItems();
+            }
+            return;
+        }
         String remainingTime = attempt.getRemainingTime();
         if (attempt.hasSectionalLock()) {
             AttemptSection section = sections.get(attempt.getCurrentSectionPosition());

--- a/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
@@ -1369,7 +1369,7 @@ public class TestFragment extends BaseFragment implements
         if (exam != null) {
             return isZeroDuration(exam.getDuration());
         }
-        return attempt != null && attempt.getRemainingTime() != null && attempt.getRemainingTime().equals(DEFAULT_EXAM_TIME);
+        return false;
     }
 
     private boolean isZeroDuration(String duration) {
@@ -1385,8 +1385,14 @@ public class TestFragment extends BaseFragment implements
                 return;
             }
             remainingTime = section.getRemainingTime();
-        }
-        if (hasNoDuration()) {
+            if (isZeroDuration(section.getDuration())) {
+                timer.setVisibility(View.GONE);
+                if (attemptItemList.isEmpty()) {
+                    fetchAttemptItems();
+                }
+                return;
+            }
+        } else if (hasNoDuration()) {
             timer.setVisibility(View.GONE);
             if (attemptItemList.isEmpty()) {
                 fetchAttemptItems();

--- a/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
@@ -729,7 +729,7 @@ public class TestFragment extends BaseFragment implements
                         }
 
                         attemptItemList = listResource.getData();
-                        if (!hasNoDuration() && (attempt.getRemainingTime() == null || attempt.getRemainingTime().equals("0:00:00") || attempt.getRemainingTime().equals("00:00:00"))) {
+                        if (!hasNoDuration() && isZeroDuration(attempt.getRemainingTime())) {
                             endExam();
                             return;
                         }
@@ -1367,23 +1367,16 @@ public class TestFragment extends BaseFragment implements
 
     boolean hasNoDuration() {
         if (exam != null) {
-            String duration = exam.getDuration();
-            return duration == null || duration.equals("0:00:00") || duration.equals("00:00:00") || duration.isEmpty();
+            return isZeroDuration(exam.getDuration());
         }
-        return attempt != null && (attempt.getRemainingTime() == null ||
-                attempt.getRemainingTime().equals("0:00:00") ||
-                attempt.getRemainingTime().equals("00:00:00") ||
-                attempt.getRemainingTime().equals(DEFAULT_EXAM_TIME));
+        return attempt != null && attempt.getRemainingTime() != null && attempt.getRemainingTime().equals(DEFAULT_EXAM_TIME);
+    }
+
+    private boolean isZeroDuration(String duration) {
+        return duration == null || duration.equals(INFINITE_EXAM_TIME) || duration.equals("00:00:00") || duration.isEmpty();
     }
 
     void startCountDownTimer() {
-        if (hasNoDuration()) {
-            timer.setVisibility(View.GONE);
-            if (attemptItemList.isEmpty()) {
-                fetchAttemptItems();
-            }
-            return;
-        }
         String remainingTime = attempt.getRemainingTime();
         if (attempt.hasSectionalLock()) {
             AttemptSection section = sections.get(attempt.getCurrentSectionPosition());
@@ -1392,6 +1385,13 @@ public class TestFragment extends BaseFragment implements
                 return;
             }
             remainingTime = section.getRemainingTime();
+        }
+        if (hasNoDuration()) {
+            timer.setVisibility(View.GONE);
+            if (attemptItemList.isEmpty()) {
+                fetchAttemptItems();
+            }
+            return;
         }
         long millisRemainingFetchedInAttempt = formatMillisecond(remainingTime);
 

--- a/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
+++ b/exam/src/main/java/in/testpress/exam/ui/TestFragment.java
@@ -1385,13 +1385,6 @@ public class TestFragment extends BaseFragment implements
                 return;
             }
             remainingTime = section.getRemainingTime();
-            if (isZeroDuration(section.getDuration())) {
-                timer.setVisibility(View.GONE);
-                if (attemptItemList.isEmpty()) {
-                    fetchAttemptItems();
-                }
-                return;
-            }
         } else if (hasNoDuration()) {
             timer.setVisibility(View.GONE);
             if (attemptItemList.isEmpty()) {


### PR DESCRIPTION
**Issue**:
Untimed exams were ending immediately while starting exam, preventing users from taking exams that had no configured time limit.

**Cause**:
Exams without a configured duration were treated as if their allotted time had already expired.

**Fix**:
Correctly identify untimed exams and prevent them from being terminated automatically, while ensuring countdown behavior only applies to timed exams.

TODO - https://3.basecamp.com/4160028/buckets/48341145/card_tables/cards/10156271205