### PR TITLE
feat: Add support for assignment content type

### DIFF
--- a/course/src/main/java/in/testpress/course/domain/DomainContent.kt
+++ b/course/src/main/java/in/testpress/course/domain/DomainContent.kt
@@ -356,7 +356,7 @@ fun DomainContent.getGreenDaoContentAttempts(context: Context): List<CourseAttem
 }
 
 enum class ContentType {
-    Exam, Quiz, Video, Attachment, Notes, LiveStream, Unknown
+    Exam, Quiz, Video, Attachment, Notes, LiveStream, Assignment, Unknown
 }
 
 inline fun <reified T : Enum<T>> String.asEnumOrDefault(defaultValue: T? = null): T? =

--- a/course/src/main/java/in/testpress/course/fragments/AssignmentFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/AssignmentFragment.kt
@@ -1,0 +1,58 @@
+package `in`.testpress.course.fragments
+
+import `in`.testpress.core.TestpressCallback
+import `in`.testpress.core.TestpressException
+import `in`.testpress.core.TestpressSdk
+import `in`.testpress.course.R
+import `in`.testpress.fragments.WebViewFragment
+import `in`.testpress.models.SSOUrl
+import `in`.testpress.network.TestpressApiClient
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+
+class AssignmentFragment : BaseContentDetailFragment() {
+
+    override var isBookmarkEnabled = false
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        return inflater.inflate(R.layout.assignment_content_layout, container, false)
+    }
+
+    override fun display() {
+        val session = TestpressSdk.getTestpressSession(requireContext())
+        val baseUrl = session?.instituteSettings?.baseUrl
+        val assignmentUrl = "$baseUrl/courses/${content.courseId}/contents/${content.id}/"
+
+        TestpressApiClient(requireContext(), session).ssourl
+            .enqueue(object : TestpressCallback<SSOUrl>() {
+                override fun onSuccess(result: SSOUrl?) {
+                    if (isAdded) {
+                        val ssoUrl = baseUrl + result?.ssoUrl + "&next=" + assignmentUrl
+                        val webViewFragment = WebViewFragment()
+                        webViewFragment.arguments = Bundle().apply {
+                            putString(WebViewFragment.URL_TO_OPEN, ssoUrl)
+                            putBoolean(WebViewFragment.IS_AUTHENTICATION_REQUIRED, false)
+                            putBoolean(WebViewFragment.ENABLE_SWIPE_REFRESH, true)
+                            putBoolean(WebViewFragment.SHOW_LOADING_BETWEEN_PAGES, true)
+                            putInt(WebViewFragment.CACHE_MODE, android.webkit.WebSettings.LOAD_NO_CACHE)
+                        }
+                        childFragmentManager.beginTransaction()
+                            .replace(R.id.webview_container, webViewFragment)
+                            .commitAllowingStateLoss()
+                    }
+                }
+
+                override fun onException(exception: TestpressException?) {
+                    if (isAdded) {
+                        emptyViewFragment.displayError(exception!!)
+                    }
+                }
+            })
+    }
+}

--- a/course/src/main/java/in/testpress/course/fragments/AssignmentFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/AssignmentFragment.kt
@@ -27,7 +27,18 @@ class AssignmentFragment : BaseContentDetailFragment() {
     override fun display() {
         val session = TestpressSdk.getTestpressSession(requireContext())
         val baseUrl = session?.instituteSettings?.baseUrl
-        val assignmentUrl = "$baseUrl/courses/${content.courseId}/contents/${content.id}/"
+        if (baseUrl.isNullOrBlank()) {
+            emptyViewFragment.displayError(TestpressException.unexpectedError(Exception("Base URL cannot be null or empty")))
+            return
+        }
+
+        val courseId = content.courseId
+        if (courseId == null) {
+            emptyViewFragment.displayError(TestpressException.unexpectedError(Exception("Course ID cannot be null")))
+            return
+        }
+
+        val assignmentUrl = "$baseUrl/courses/$courseId/contents/${content.id}/"
 
         TestpressApiClient(requireContext(), session).ssourl
             .enqueue(object : TestpressCallback<SSOUrl>() {

--- a/course/src/main/java/in/testpress/course/fragments/ContentLoadingFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/ContentLoadingFragment.kt
@@ -177,6 +177,7 @@ open class ContentFragmentFactory {
                     }
                     return LiveStreamFragment()
                 }
+                "Assignment" -> AssignmentFragment()
                 else -> ContentLoadingFragment()
             }
         }

--- a/course/src/main/java/in/testpress/course/ui/viewholders/ContentListItemViewHolder.kt
+++ b/course/src/main/java/in/testpress/course/ui/viewholders/ContentListItemViewHolder.kt
@@ -21,6 +21,7 @@ class ContentListItemViewHolder(view: View) : BaseContentListItemViewHolder(view
         super.bindContentDetails(content)
         when (content.contentTypeEnum) {
             ContentType.Notes -> contentTypeIcon.setImageResource(R.drawable.writing)
+            ContentType.Assignment -> contentTypeIcon.setImageResource(R.drawable.ic_assignment)
             ContentType.Attachment -> setAttachmentIcon(content)
             else -> contentTypeIcon.setImageResource(R.drawable.ic_live)
         }

--- a/course/src/main/res/drawable/ic_assignment.xml
+++ b/course/src/main/res/drawable/ic_assignment.xml
@@ -1,0 +1,42 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="2"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:pathData="M13.4 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-7.4"/>
+    <path
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="2"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:pathData="M2 6h4"/>
+    <path
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="2"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:pathData="M2 10h4"/>
+    <path
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="2"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:pathData="M2 14h4"/>
+    <path
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="2"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:pathData="M2 18h4"/>
+    <path
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="2"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:pathData="M21.378 5.626a1 1 0 1 0-3.004-3.004l-5.01 5.012a2 2 0 0 0-.506.854l-.837 2.87a.5.5 0 0 0 .62.62l2.87-.837a2 2 0 0 0 .854-.506z"/>
+</vector>

--- a/course/src/main/res/layout/assignment_content_layout.xml
+++ b/course/src/main/res/layout/assignment_content_layout.xml
@@ -20,8 +20,7 @@
     <FrameLayout
         android:id="@+id/empty_view_fragment"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:visibility="gone" />
+        android:layout_height="match_parent" />
 
     <FrameLayout
         android:id="@+id/bottom_navigation_fragment"

--- a/course/src/main/res/layout/assignment_content_layout.xml
+++ b/course/src/main/res/layout/assignment_content_layout.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/main_content"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+        android:id="@+id/swipe_container"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_above="@id/bottom_navigation_fragment">
+
+        <FrameLayout
+            android:id="@+id/webview_container"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
+
+    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+
+    <FrameLayout
+        android:id="@+id/empty_view_fragment"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:visibility="gone" />
+
+    <FrameLayout
+        android:id="@+id/bottom_navigation_fragment"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentBottom="true" />
+</RelativeLayout>

--- a/course/src/test/java/in/testpress/course/fragments/ContentFragmentFactoryTest.kt
+++ b/course/src/test/java/in/testpress/course/fragments/ContentFragmentFactoryTest.kt
@@ -17,6 +17,10 @@ class ContentFragmentFactoryTest {
             attachment = DomainAttachmentContent(1,isRenderable = true)
     )
 
+    private val assignmentContent = DomainContent(3, chapterId = 1,
+            active = true, contentType = "Assignment", hasStarted = true,
+            isLocked = false, isScheduled = false, isCourseAvailable = false)
+
     @Test
     fun whenRenderableFalseAttachmentContentShouldBeReturned() {
         val fragment = ContentFragmentFactory.getFragment(content = attachmentContent)
@@ -27,5 +31,11 @@ class ContentFragmentFactoryTest {
     fun whenRenderableDocumentViewerShouldBeReturned() {
         val fragment = ContentFragmentFactory.getFragment(renderableContent)
         assertTrue(fragment is DocumentViewerFragment)
+    }
+
+    @Test
+    fun whenAssignmentContentAssignmentFragmentShouldBeReturned() {
+        val fragment = ContentFragmentFactory.getFragment(assignmentContent)
+        assertTrue(fragment is AssignmentFragment)
     }
 }


### PR DESCRIPTION
Add support for rendering and interacting with assignments within the course contents. This allows users to view and complete assignments directly inside the application.
Previously, assignment content types were not handled, defaulting to a generic loading state.
- Introduce an assignment fragment that loads the SSO URL in a WebView container to authenticate and display assignment details
- Map the assignment content type to display the assignment icon in list views
- Support assignment fragment instantiation in the content loader factory