### PR TITLE
build: Increase minSdkVersion to 28

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,9 +50,9 @@ task clean(type: Delete) {
 
 ext {
     compileSdkVersion = 36
-    minSdkVersion = 26
+    minSdkVersion = 28
     targetSdkVersion = 36
-    minSdkVersionForUITest = 26
+    minSdkVersionForUITest = 28
     buildToolsVersion = '30.0.3'
 
     //AndroidX Dependencies


### PR DESCRIPTION
Update minSdkVersion and minSdkVersionForUITest from 26 to 28 in the root build configuration to support newer Android features and align with updated project requirements.