### PR TITLE
fix: Add null safety and token validation to Zoom SDK integration

### DIFF
--- a/course/src/main/AndroidManifest.xml
+++ b/course/src/main/AndroidManifest.xml
@@ -92,6 +92,7 @@
         <activity
             android:name=".ui.ZoomMeetActivity"
             android:configChanges="orientation|keyboardHidden|screenSize"
+            android:hardwareAccelerated="true"
             android:label="Zoom Meet"
             android:theme="@style/ThemeWithBlackText" />
 

--- a/course/src/main/java/in/testpress/course/fragments/VideoConferenceFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/VideoConferenceFragment.kt
@@ -19,7 +19,7 @@ import android.widget.TextView
 import android.widget.Toast
 import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
-import com.auth0.android.jwt.JWT
+import `in`.testpress.course.util.isTokenValid
 import `in`.testpress.core.TestpressCallback
 import `in`.testpress.core.TestpressException
 import io.sentry.Sentry
@@ -86,21 +86,18 @@ class VideoConferenceFragment : BaseContentDetailFragment() {
             return
         }
 
-        if (videoConference == null || videoConference.isZoom()) {
-            videoConference?.accessToken?.let { token ->
-                try {
-                    if (JWT(token).isExpired(10) && reloadContent < maxReloadContent) {
-                        reloadContent++
-                        forceReloadContent()
-                        return
-                    }
-                } catch (e: Exception) {
-                    Sentry.captureException(e)
+        if (videoConference != null && videoConference.isZoom()) {
+            val token = videoConference.accessToken
+            if (!token.isNullOrBlank()) {
+                if (!isTokenValid(token) && reloadContent < maxReloadContent) {
+                    reloadContent++
+                    forceReloadContent()
                     return
                 }
+                initializeVideoConferenceHandler(videoConference)
+            } else {
+                hideLoadingAndEnableStartButton()
             }
-
-            initializeVideoConferenceHandler(videoConference)
         }
 
         startButton.visibility = View.VISIBLE
@@ -159,12 +156,15 @@ class VideoConferenceFragment : BaseContentDetailFragment() {
         profileDetails: ProfileDetails,
         onInitComplete: (() -> Unit)? = null
     ) {
-        if (!isAdded) {
+        if (!isAdded || videoConference == null || videoConference.accessToken.isNullOrBlank()) {
+            if (!isRetryingAfterFailure) {
+                hideLoadingAndEnableStartButton()
+            }
             onInitComplete?.invoke()
             return
         }
         try {
-            videoConferenceHandler = VideoConferenceHandler(requireContext(), videoConference ?: throw NullPointerException("videoConference is null during initialization"), profileDetails)
+            videoConferenceHandler = VideoConferenceHandler(requireContext(), videoConference, profileDetails)
             videoConferenceHandler?.init(object : VideoConferenceInitializeListener {
                 override fun onSuccess() {
                     if (!isRetryingAfterFailure) {
@@ -186,7 +186,7 @@ class VideoConferenceFragment : BaseContentDetailFragment() {
             }
             Toast.makeText(context, "Zoom integration is not enabled in the app, please contact admin", Toast.LENGTH_LONG).show()
             onInitComplete?.invoke()
-        } catch (e: NullPointerException) {
+        } catch (e: Exception) {
             if (!isRetryingAfterFailure) {
                 hideLoadingAndEnableStartButton()
             }
@@ -202,10 +202,6 @@ class VideoConferenceFragment : BaseContentDetailFragment() {
                     }
                 )
             }
-            onInitComplete?.invoke()
-        } catch (e: IllegalStateException) {
-            // Fragment detached from activity mid-initialization (e.g. user navigated away)
-            Sentry.captureException(e)
             onInitComplete?.invoke()
         }
     }
@@ -226,7 +222,7 @@ class VideoConferenceFragment : BaseContentDetailFragment() {
         if (!isConferenceDataValid(videoConference)) {
             forceReloadContent {
                 val refreshedConference = content.videoConference
-                if (refreshedConference != null && refreshedConference.conferenceId != null && refreshedConference.password != null) {
+                if (refreshedConference != null && refreshedConference.conferenceId != null && refreshedConference.password != null && !refreshedConference.accessToken.isNullOrBlank()) {
                     videoConferenceHandler?.destroy()
                     profileDetails?.let {
                         initVideoConferenceHandler(refreshedConference, it) {
@@ -252,17 +248,11 @@ class VideoConferenceFragment : BaseContentDetailFragment() {
     }
     
     private fun isConferenceDataValid(videoConference: DomainVideoConferenceContent?): Boolean {
-        if (videoConference?.conferenceId == null || videoConference.password == null) {
+        if (videoConference?.conferenceId == null || videoConference.password == null || videoConference.accessToken.isNullOrBlank()) {
             return false
         }
         
-        return videoConference.accessToken?.let { token ->
-            try {
-                !JWT(token).isExpired(10)
-            } catch (e: Exception) {
-                false
-            }
-        } ?: false
+        return isTokenValid(videoConference.accessToken)
     }
     
     private fun performJoinAttempt() {

--- a/course/src/main/java/in/testpress/course/util/VideoConferenceUtils.kt
+++ b/course/src/main/java/in/testpress/course/util/VideoConferenceUtils.kt
@@ -1,0 +1,16 @@
+package `in`.testpress.course.util
+
+import com.auth0.android.jwt.JWT
+import io.sentry.Sentry
+
+fun isTokenValid(token: String?, leewayInSeconds: Long = 10): Boolean {
+    if (token.isNullOrBlank()) {
+        return false
+    }
+    return try {
+        !JWT(token).isExpired(leewayInSeconds)
+    } catch (e: Exception) {
+        Sentry.captureException(e)
+        false
+    }
+}

--- a/course/src/main/java/in/testpress/course/util/ZoomMeetHandler.kt
+++ b/course/src/main/java/in/testpress/course/util/ZoomMeetHandler.kt
@@ -36,25 +36,47 @@ class ZoomMeetHandler(
     private var activityUsableErrorLogged: Boolean = false
 
     fun init(callback: VideoConferenceInitializeListener) {
-        zoomSDK = ZoomSDK.getInstance()
-        activity = context as Activity
+        val currentActivity = context as? Activity
+        if (currentActivity == null) {
+            callback.onFailure()
+            return
+        }
+        activity = currentActivity
         this.onInitializeCallback = callback
-        zoomSDK.initialize(context, this, getInitializationParams())
+        zoomSDK = ZoomSDK.getInstance()
+
+        if (!isTokenValid(videoConference.accessToken)) {
+            logZoomInitializationFailure(ZoomError.ZOOM_ERROR_INVALID_ARGUMENTS, -1)
+            callback.onFailure()
+            return
+        }
 
         if (zoomSDK.isInitialized) {
             registerMeetingServiceListener()
             setIsCustomizedMeetingUIEnabled()
             configureMeetingUi()
+            callback.onSuccess()
+            return
         }
+
+        val initParams = getInitializationParams()
+        if (initParams == null) {
+            callback.onFailure()
+            return
+        }
+
+        zoomSDK.initialize(context, this, initParams)
     }
 
     private fun setIsCustomizedMeetingUIEnabled(){
-        val instituteSettings: InstituteSettings =
-            TestpressSdk.getTestpressSession(context)!!.instituteSettings
-        useCustomMeetingUi = instituteSettings.isCustomMeetingUIEnabled
-        zoomSDK.meetingSettingsHelper.isCustomizedMeetingUIEnabled = useCustomMeetingUi
-        zoomSDK.meetingSettingsHelper.setAutoConnectVoIPWhenJoinMeeting(true)
-        zoomSDK.meetingSettingsHelper.setMuteMyMicrophoneWhenJoinMeeting(true)
+        val instituteSettings: InstituteSettings? =
+            TestpressSdk.getTestpressSession(context)?.instituteSettings
+        useCustomMeetingUi = instituteSettings?.isCustomMeetingUIEnabled == true
+        zoomSDK.meetingSettingsHelper?.let { helper ->
+            helper.isCustomizedMeetingUIEnabled = useCustomMeetingUi
+            helper.setAutoConnectVoIPWhenJoinMeeting(true)
+            helper.setMuteMyMicrophoneWhenJoinMeeting(true)
+        }
     }
 
     private fun configureMeetingUi() {
@@ -63,9 +85,13 @@ class ZoomMeetHandler(
         }
     }
 
-    fun getInitializationParams(): ZoomSDKInitParams {
+    fun getInitializationParams(): ZoomSDKInitParams? {
+        val token = videoConference.accessToken
+        if (token.isNullOrBlank()) {
+            return null
+        }
         val initParams = ZoomSDKInitParams()
-        initParams.jwtToken = videoConference.accessToken
+        initParams.jwtToken = token
         initParams.enableLog = true
         initParams.logSize = 50
         initParams.domain = "zoom.us"
@@ -73,7 +99,8 @@ class ZoomMeetHandler(
     }
 
     fun goToMeet(onInitializeCallback: VideoConferenceInitializeListener) {
-        if (zoomSDK.isInitialized) {
+        this.onInitializeCallback = onInitializeCallback
+        if (::zoomSDK.isInitialized && zoomSDK.isInitialized) {
             onInitializeCallback.onSuccess()
             joinMeeting()
         } else {
@@ -88,24 +115,27 @@ class ZoomMeetHandler(
                 }
             })
         }
-
     }
 
     private fun joinMeeting() {
+        if (!::zoomSDK.isInitialized || !zoomSDK.isInitialized) {
+            onInitializeCallback?.onFailure()
+            return
+        }
         zoomSDK.meetingService?.let { meetingService ->
             if (meetingService.meetingStatus == MeetingStatus.MEETING_STATUS_IDLE) {
                 startMeeting()
             } else {
                 returnToMeeting()
             }
-        }
+        } ?: onInitializeCallback?.onFailure()
     }
 
     private fun returnToMeeting(){
         if (useCustomMeetingUi) {
             showCustomMeetingUI(true)
-        }else{
-            zoomSDK.meetingService.returnToMeeting(context)
+        } else {
+            zoomSDK.meetingService?.returnToMeeting(context)
         }
     }
 
@@ -226,22 +256,30 @@ class ZoomMeetHandler(
     }
 
     fun removeListeners() {
-        if (zoomSDK.isInitialized) {
+        if (::zoomSDK.isInitialized && zoomSDK.isInitialized) {
             MeetingCommonCallback.removeListener(this)
             unregisterCallbacks()
         }
     }
 
     fun startMeeting() {
+        if (!::zoomSDK.isInitialized || !zoomSDK.isInitialized) {
+            onInitializeCallback?.onFailure()
+            return
+        }
         configureMeetingUi()
 
         val meetingService = zoomSDK.meetingService
+        if (meetingService == null) {
+            onInitializeCallback?.onFailure()
+            return
+        }
         val ret = meetingService.joinMeetingWithParams(
             context,
             getMeetingParameters(),
             getMeetingOptions()
         )
-        zoomSDK.zoomUIService.hideMeetingInviteUrl(true)
+        zoomSDK.zoomUIService?.hideMeetingInviteUrl(true)
     }
 
     private fun getMeetingOptions(): JoinMeetingOptions {

--- a/course/src/main/java/in/testpress/course/util/ZoomMeetHandler.kt
+++ b/course/src/main/java/in/testpress/course/util/ZoomMeetHandler.kt
@@ -279,6 +279,9 @@ class ZoomMeetHandler(
             getMeetingParameters(),
             getMeetingOptions()
         )
+        if (ret != MeetingError.MEETING_ERROR_SUCCESS) {
+            onInitializeCallback?.onFailure()
+        }
         zoomSDK.zoomUIService?.hideMeetingInviteUrl(true)
     }
 


### PR DESCRIPTION
- Crash logs identified NullPointerExceptions and IllegalStateExceptions during Zoom SDK initialization and activity detachment.
- Fixed crashes by safely casting the context to an Activity, adding null checks around ZoomSDK services, verifying property initialization via  `::zoomSDK.isInitialized`, and gracefully invoking failure callbacks.
- Centralized JWT verification helper in a utility file and handled token  decoding exceptions safely with Sentry reporting to prevent crashes on expired or invalid tokens.