### PR TITLE
feat: Handle Fermion live stream lifecycle events

### DIFF
--- a/core/src/main/java/in/testpress/fragments/WebViewFragment.kt
+++ b/core/src/main/java/in/testpress/fragments/WebViewFragment.kt
@@ -223,6 +223,8 @@ class WebViewFragment : Fragment(), EmptyViewListener {
     interface Listener {
         fun onWebViewInitializationSuccess()
         fun shouldOverrideUrlLoading(url: String?): Boolean = false
+        fun onPageStarted(url: String?) {}
+        fun onPageFinished(url: String?) {}
     }
 
     companion object {

--- a/core/src/main/java/in/testpress/util/webview/CustomWebViewClient.kt
+++ b/core/src/main/java/in/testpress/util/webview/CustomWebViewClient.kt
@@ -55,12 +55,14 @@ class CustomWebViewClient(val fragment: WebViewFragment) : AndroidWebViewClient(
 
     override fun onPageStarted(view: AndroidWebView?, url: String?, favicon: Bitmap?) {
         if (fragment.showLoadingBetweenPages) fragment.showLoading()
+        fragment.listener?.onPageStarted(url)
     }
 
     override fun onPageFinished(view: AndroidWebView?, url: String?) {
         fragment.hideLoading()
         fragment.hideEmptyViewShowWebView()
         checkWebViewHasError()
+        fragment.listener?.onPageFinished(url)
     }
 
     override fun onReceivedError(

--- a/course/src/main/java/in/testpress/course/fragments/FermionLiveStreamFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/FermionLiveStreamFragment.kt
@@ -30,6 +30,7 @@ class FermionLiveStreamFragment : Fragment() {
     private var fermionHost: String? = null
     private var fermionPath: String? = null
     private var fermionPageLoaded = false
+    private var hasNotifiedLeave = false
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -50,30 +51,31 @@ class FermionLiveStreamFragment : Fragment() {
     }
 
     private fun fetchSsoUrlAndLoad() {
+        val currentStreamUrl = streamUrl ?: return
         val session = TestpressSdk.getTestpressSession(requireContext())
         if (session != null) {
             TestpressApiClient(requireContext(), session).ssourl.enqueue(object : TestpressCallback<SSOUrl>() {
                 override fun onSuccess(result: SSOUrl?) {
                     val ssoUrl = result?.ssoUrl
                     if (!ssoUrl.isNullOrBlank()) {
-                        val loginUrl = buildSsoLoginUrl(ssoUrl, session.instituteSettings.baseUrl)
+                        val loginUrl = buildSsoLoginUrl(ssoUrl, session.instituteSettings.baseUrl, currentStreamUrl)
                         loadInWebViewFragment(loginUrl)
                     } else {
-                        loadInWebViewFragment(streamUrl!!)
+                        loadInWebViewFragment(currentStreamUrl)
                     }
                 }
 
                 override fun onException(exception: TestpressException?) {
-                    loadInWebViewFragment(streamUrl!!)
+                    loadInWebViewFragment(currentStreamUrl)
                 }
             })
         } else {
-            loadInWebViewFragment(streamUrl!!)
+            loadInWebViewFragment(currentStreamUrl)
         }
     }
 
-    private fun buildSsoLoginUrl(ssoUrl: String, baseUrl: String): String {
-        val nextUrl = Uri.encode(streamUrl)
+    private fun buildSsoLoginUrl(ssoUrl: String, baseUrl: String, targetUrl: String): String {
+        val nextUrl = Uri.encode(targetUrl)
         val separator = if (ssoUrl.contains("?")) "&" else "?"
         val cleanBaseUrl = baseUrl.trimEnd('/')
         val cleanSsoUrl = if (ssoUrl.startsWith("/")) ssoUrl else "/$ssoUrl"
@@ -86,6 +88,7 @@ class FermionLiveStreamFragment : Fragment() {
         fermionHost = streamUrl?.let { Uri.parse(it).host }
         fermionPath = streamUrl?.let { Uri.parse(it).path?.trimEnd('/') }
         fermionPageLoaded = false
+        hasNotifiedLeave = false
 
         val webViewFragment = createWebViewFragment(urlToLoad)
         childFragmentManager.beginTransaction()
@@ -116,15 +119,16 @@ class FermionLiveStreamFragment : Fragment() {
 
             override fun onPageStarted(url: String?) {
                 if (fermionPageLoaded && !isStillOnFermionPage(url)) {
-                    webViewFragment.webView.stopLoading()
                     notifyMeetingLeft()
                 }
             }
 
             override fun onPageFinished(url: String?) {
-                val urlPath = url?.let { Uri.parse(it).path?.trimEnd('/') }
+                val uri = url?.let { Uri.parse(it) }
+                val urlHost = uri?.host
+                val urlPath = uri?.path?.trimEnd('/')
                 when {
-                    urlPath == fermionPath -> {
+                    urlHost == fermionHost && urlPath == fermionPath -> {
                         fermionPageLoaded = true
                         webViewFragment.webView.evaluateJavascript(
                             buildPostMessageListenerScript(fermionHost), null
@@ -148,12 +152,22 @@ class FermionLiveStreamFragment : Fragment() {
 
     private fun isStillOnFermionPage(url: String?): Boolean {
         if (url == null) return true
-        return Uri.parse(url).path?.trimEnd('/') == fermionPath
+        val uri = Uri.parse(url)
+        val path = uri.path ?: return false
+        // Use prefix match, not exact match: Fermion uses SPA routing internally
+        // and may push sub-routes within the meeting room (e.g. /live-room/10622/stage/).
+        // An exact path check would mistake those internal navigations for a leave event.
+        return uri.host == fermionHost &&
+               (path.trimEnd('/') == fermionPath || path.startsWith("$fermionPath/"))
     }
 
     private fun buildPostMessageListenerScript(fermionHost: String?): String {
         val originCheck = if (fermionHost != null) {
-            "if (!event.origin.includes('$fermionHost')) return;"
+            """
+                try {
+                    if (new URL(event.origin).hostname !== '$fermionHost') return;
+                } catch(e) { return; }
+            """.trimIndent()
         } else {
             ""
         }
@@ -178,8 +192,14 @@ class FermionLiveStreamFragment : Fragment() {
 
     /** Notifies the parent that the user has left the meeting. */
     private fun notifyMeetingLeft() {
+        if (hasNotifiedLeave) return
+        hasNotifiedLeave = true
         activity?.runOnUiThread {
-            listener?.onMeetingLeft() ?: activity?.finish()
+            if (listener != null) {
+                listener?.onMeetingLeft()
+            } else {
+                activity?.finish()
+            }
         }
     }
 

--- a/course/src/main/java/in/testpress/course/fragments/FermionLiveStreamFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/FermionLiveStreamFragment.kt
@@ -1,24 +1,35 @@
 package `in`.testpress.course.fragments
 
+import android.annotation.SuppressLint
+import android.net.Uri
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.webkit.PermissionRequest
-import android.webkit.WebChromeClient
-import android.webkit.WebResourceRequest
-import android.webkit.WebView
-import android.webkit.WebViewClient
+import android.webkit.JavascriptInterface
+import android.webkit.WebSettings
 import androidx.fragment.app.Fragment
+import `in`.testpress.core.TestpressCallback
+import `in`.testpress.core.TestpressException
+import `in`.testpress.core.TestpressSdk
 import `in`.testpress.course.R
-import `in`.testpress.util.webview.BaseWebChromeClient
+import `in`.testpress.fragments.WebViewFragment
+import `in`.testpress.models.SSOUrl
+import `in`.testpress.network.TestpressApiClient
+import `in`.testpress.util.BaseJavaScriptInterface
 
 class FermionLiveStreamFragment : Fragment() {
 
-    private var initialLoadComplete = false
+    /** Implement in the parent to handle navigation when the user leaves the Fermion meeting. */
+    interface Listener {
+        fun onMeetingLeft()
+    }
+
+    var listener: Listener? = null
     private var streamUrl: String? = null
-    private var webView: WebView? = null
-    private var chromeClient: BaseWebChromeClient? = null
+    private var fermionHost: String? = null
+    private var fermionPath: String? = null
+    private var fermionPageLoaded = false
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -35,109 +46,153 @@ class FermionLiveStreamFragment : Fragment() {
             view.findViewById<View>(R.id.error_message).visibility = View.VISIBLE
             return
         }
-        setupWebView()
+        fetchSsoUrlAndLoad()
     }
 
-    private fun setupWebView() {
-        val container = requireView() as ViewGroup
-        chromeClient = buildChromeClient()
-        webView = WebView(requireContext()).apply {
-            configureSettings()
-            webChromeClient = chromeClient
-            webViewClient = buildWebViewClient()
-            streamUrl?.let { loadUrl(it) }
+    private fun fetchSsoUrlAndLoad() {
+        val session = TestpressSdk.getTestpressSession(requireContext())
+        if (session != null) {
+            TestpressApiClient(requireContext(), session).ssourl.enqueue(object : TestpressCallback<SSOUrl>() {
+                override fun onSuccess(result: SSOUrl?) {
+                    val ssoUrl = result?.ssoUrl
+                    if (!ssoUrl.isNullOrBlank()) {
+                        val loginUrl = buildSsoLoginUrl(ssoUrl, session.instituteSettings.baseUrl)
+                        loadInWebViewFragment(loginUrl)
+                    } else {
+                        loadInWebViewFragment(streamUrl!!)
+                    }
+                }
+
+                override fun onException(exception: TestpressException?) {
+                    loadInWebViewFragment(streamUrl!!)
+                }
+            })
+        } else {
+            loadInWebViewFragment(streamUrl!!)
         }
-        container.addView(webView, ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT)
     }
 
-    private fun WebView.configureSettings() {
-        settings.javaScriptEnabled = true
-        settings.domStorageEnabled = true
-        settings.loadWithOverviewMode = true
-        settings.useWideViewPort = true
-        settings.allowFileAccess = false
-        settings.mediaPlaybackRequiresUserGesture = false
+    private fun buildSsoLoginUrl(ssoUrl: String, baseUrl: String): String {
+        val nextUrl = Uri.encode(streamUrl)
+        val separator = if (ssoUrl.contains("?")) "&" else "?"
+        val cleanBaseUrl = baseUrl.trimEnd('/')
+        val cleanSsoUrl = if (ssoUrl.startsWith("/")) ssoUrl else "/$ssoUrl"
+        return "$cleanBaseUrl$cleanSsoUrl${separator}next=$nextUrl"
     }
 
-    private fun buildChromeClient() = object : BaseWebChromeClient(this) {
-        override fun onPermissionRequest(request: PermissionRequest?) {
-            if (request == null) return
-            val expectedHost = streamUrl?.let { android.net.Uri.parse(it).host }
-            val requestHost = request.origin.host
+    @SuppressLint("AddJavascriptInterface")
+    private fun loadInWebViewFragment(urlToLoad: String) {
+        if (!isAdded) return
+        fermionHost = streamUrl?.let { Uri.parse(it).host }
+        fermionPath = streamUrl?.let { Uri.parse(it).path?.trimEnd('/') }
+        fermionPageLoaded = false
 
-            if (expectedHost == null || requestHost != expectedHost) {
-                request.deny()
-                return
+        val webViewFragment = createWebViewFragment(urlToLoad)
+        childFragmentManager.beginTransaction()
+            .replace(R.id.fermion_webview_container, webViewFragment)
+            .commitAllowingStateLoss()
+    }
+
+    private fun createWebViewFragment(urlToLoad: String): WebViewFragment {
+        return WebViewFragment().apply {
+            arguments = Bundle().apply {
+                putString(WebViewFragment.URL_TO_OPEN, urlToLoad)
+                putBoolean(WebViewFragment.IS_AUTHENTICATION_REQUIRED, true)
+                putBoolean(WebViewFragment.ALLOW_NON_INSTITUTE_URL_IN_WEB_VIEW, true)
+                putInt(WebViewFragment.CACHE_MODE, WebSettings.LOAD_NO_CACHE)
+            }
+            listener = createWebViewListener(this)
+        }
+    }
+
+    private fun createWebViewListener(webViewFragment: WebViewFragment): WebViewFragment.Listener {
+        return object : WebViewFragment.Listener {
+            override fun onWebViewInitializationSuccess() {
+                webViewFragment.addJavascriptInterface(
+                    FermionBridge { notifyMeetingLeft() },
+                    "FermionAndroid"
+                )
             }
 
-            val allowedResources = arrayOf(
-                PermissionRequest.RESOURCE_VIDEO_CAPTURE,
-                PermissionRequest.RESOURCE_AUDIO_CAPTURE
-            )
-            val filteredResources = request.resources.filter { it in allowedResources }.toTypedArray()
-            if (filteredResources.isNotEmpty()) {
-                request.grant(filteredResources)
-            } else {
-                request.deny()
+            override fun onPageStarted(url: String?) {
+                if (fermionPageLoaded && !isStillOnFermionPage(url)) {
+                    webViewFragment.webView.stopLoading()
+                    notifyMeetingLeft()
+                }
+            }
+
+            override fun onPageFinished(url: String?) {
+                val urlPath = url?.let { Uri.parse(it).path?.trimEnd('/') }
+                when {
+                    urlPath == fermionPath -> {
+                        fermionPageLoaded = true
+                        webViewFragment.webView.evaluateJavascript(
+                            buildPostMessageListenerScript(fermionHost), null
+                        )
+                    }
+                    fermionPageLoaded && !isStillOnFermionPage(url) -> {
+                        notifyMeetingLeft()
+                    }
+                }
+            }
+
+            override fun shouldOverrideUrlLoading(url: String?): Boolean {
+                if (fermionPageLoaded && !isStillOnFermionPage(url)) {
+                    notifyMeetingLeft()
+                    return true
+                }
+                return false
             }
         }
     }
 
-    private fun buildWebViewClient() = object : WebViewClient() {
-        override fun onPageFinished(view: WebView, url: String) {
-            initialLoadComplete = true
-            view.evaluateJavascript(VIEWPORT_FIT_SCRIPT, null)
-        }
+    private fun isStillOnFermionPage(url: String?): Boolean {
+        if (url == null) return true
+        return Uri.parse(url).path?.trimEnd('/') == fermionPath
+    }
 
-        override fun shouldOverrideUrlLoading(view: WebView, request: WebResourceRequest): Boolean {
-            return handleNavigation(request.url.toString())
+    private fun buildPostMessageListenerScript(fermionHost: String?): String {
+        val originCheck = if (fermionHost != null) {
+            "if (!event.origin.includes('$fermionHost')) return;"
+        } else {
+            ""
         }
+        return """
+            (function() {
+                if (window._fermionAndroidListenerAttached) return;
+                window._fermionAndroidListenerAttached = true;
+                window.addEventListener('message', function(event) {
+                    $originCheck
+                    var payload = event.data;
+                    if (!payload || typeof payload !== 'object') return;
+                    var type = payload.type;
+                    if (type === 'webrtc:left-stage' || type === 'webrtc:livestream-ended') {
+                        if (window.FermionAndroid) {
+                            window.FermionAndroid.onLeave();
+                        }
+                    }
+                });
+            })();
+        """.trimIndent()
+    }
 
-        @Suppress("DEPRECATION")
-        override fun shouldOverrideUrlLoading(view: WebView, url: String): Boolean {
-            return handleNavigation(url)
+    /** Notifies the parent that the user has left the meeting. */
+    private fun notifyMeetingLeft() {
+        activity?.runOnUiThread {
+            listener?.onMeetingLeft() ?: activity?.finish()
         }
     }
 
-    private fun handleNavigation(url: String): Boolean {
-        val currentUri = streamUrl?.let { android.net.Uri.parse(it) }
-        val newUri = android.net.Uri.parse(url)
-
-        if (initialLoadComplete && currentUri != null && isAdded) {
-            val isSamePage = currentUri.host == newUri.host && currentUri.path == newUri.path
-
-            if (!isSamePage) {
-                requireActivity().finish()
-                return true
-            }
+    /** JavaScript interface that receives leave events from the Fermion embed. */
+    inner class FermionBridge(private val onLeave: () -> Unit) : BaseJavaScriptInterface(requireActivity()) {
+        @JavascriptInterface
+        fun onLeave() {
+            onLeave()
         }
-        return false
-    }
-
-    override fun onDestroyView() {
-        super.onDestroyView()
-        chromeClient?.cleanup()
-        chromeClient = null
-        webView?.destroy()
-        webView = null
     }
 
     companion object {
         const val ARG_STREAM_URL = "ARG_STREAM_URL"
         const val ARG_TITLE = "ARG_TITLE"
-
-        private val VIEWPORT_FIT_SCRIPT = """
-            (function() {
-                var meta = document.querySelector('meta[name="viewport"]');
-                if (!meta) {
-                    meta = document.createElement('meta');
-                    meta.name = 'viewport';
-                    document.head.appendChild(meta);
-                }
-                meta.content = 'width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no';
-                document.documentElement.style.cssText += 'width:100%!important;height:100%!important;overflow:hidden!important;';
-                document.body.style.cssText += 'width:100%!important;height:100%!important;overflow:hidden!important;margin:0!important;padding:0!important;';
-            })();
-        """.trimIndent()
     }
 }

--- a/course/src/main/java/in/testpress/course/fragments/LiveStreamFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/LiveStreamFragment.kt
@@ -173,10 +173,10 @@ class LiveStreamFragment : BaseContentDetailFragment(), LiveStreamCallbackListen
     }
 
     private fun setupFermionPlayer() {
-        val streamUrl = content.liveStream?.streamUrl
+        val fermionUrl = content.liveStream?.fermionUrl
         val container = view?.findViewById<ViewGroup>(R.id.fermion_player_container)
 
-        if (streamUrl == null || container == null) {
+        if (fermionUrl == null || container == null) {
             displayErrorNotice()
             return
         }
@@ -184,8 +184,13 @@ class LiveStreamFragment : BaseContentDetailFragment(), LiveStreamCallbackListen
 
         val fermionFragment = FermionLiveStreamFragment()
         fermionFragment.arguments = Bundle().apply {
-            putString(ARG_STREAM_URL, streamUrl)
+            putString(ARG_STREAM_URL, fermionUrl)
             putString(ARG_TITLE, content.title ?: "")
+        }
+        fermionFragment.listener = object : FermionLiveStreamFragment.Listener {
+            override fun onMeetingLeft() {
+                activity?.finish()
+            }
         }
         childFragmentManager.beginTransaction()
             .replace(R.id.fermion_player_container, fermionFragment)

--- a/course/src/main/res/layout/fragment_fermion_live_stream.xml
+++ b/course/src/main/res/layout/fragment_fermion_live_stream.xml
@@ -13,4 +13,9 @@
         android:visibility="gone"
         android:text="@string/testpress_error_loading_contents" />
 
+    <FrameLayout
+        android:id="@+id/fermion_webview_container"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
 </FrameLayout>


### PR DESCRIPTION
- Refactored FermionLiveStreamFragment to use the shared WebViewFragment for consistent web view behavior.
- Added a JavaScript interface (FermionBridge) to listen for Fermion post messages like `webrtc:left-stage` and `webrtc:livestream-ended`.
- Implemented navigation detection to automatically close the stream when the user navigates away from the Fermion page.
- Updated LiveStreamFragment to use the new fermionUrl property and handle meeting exit events.
- Added listener support to WebViewFragment for page loading events.

https://app.basecamp.com/4160028/buckets/48341145/card_tables/cards/10190910761#__recording_10199441339