### PR TITLE
fix: Prevent concurrent Zoom initialization

### DIFF
--- a/course/src/main/java/in/testpress/course/fragments/VideoConferenceFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/VideoConferenceFragment.kt
@@ -245,6 +245,7 @@ class VideoConferenceFragment : BaseContentDetailFragment() {
         val videoConference = content.videoConference
         
         if (!isConferenceDataValid(videoConference)) {
+            isRetryingAfterFailure = true
             forceReloadContent {
                 val refreshedConference = content.videoConference
                 if (refreshedConference != null && refreshedConference.conferenceId != null && refreshedConference.password != null && !refreshedConference.accessToken.isNullOrBlank()) {
@@ -254,10 +255,12 @@ class VideoConferenceFragment : BaseContentDetailFragment() {
                             performJoinAttempt()
                         }
                     } ?: run {
+                        isRetryingAfterFailure = false
                         hideLoadingAndEnableStartButton()
                         Toast.makeText(context, "Unable to join meeting. Please try again.", Toast.LENGTH_SHORT).show()
                     }
                 } else {
+                    isRetryingAfterFailure = false
                     hideLoadingAndEnableStartButton()
                     val message = if (refreshedConference?.conferenceId == null || refreshedConference?.password == null) {
                         "Meeting has not started yet. Please try again after the meeting starts."
@@ -282,6 +285,7 @@ class VideoConferenceFragment : BaseContentDetailFragment() {
     
     private fun performJoinAttempt() {
         if (videoConferenceHandler == null) {
+            isRetryingAfterFailure = false
             hideLoadingAndEnableStartButton()
             Toast.makeText(context, "Unable to join meeting. Please try again.", Toast.LENGTH_SHORT).show()
             return

--- a/course/src/main/java/in/testpress/course/fragments/VideoConferenceFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/VideoConferenceFragment.kt
@@ -39,6 +39,7 @@ class VideoConferenceFragment : BaseContentDetailFragment() {
     private val maxReloadContent = 3
     private var isRetryingAfterFailure = false
     private var isInitializingVideoConference = false
+    private val pendingInitializationCallbacks = mutableListOf<() -> Unit>()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -132,83 +133,76 @@ class VideoConferenceFragment : BaseContentDetailFragment() {
         videoConference: DomainVideoConferenceContent?,
         onInitComplete: (() -> Unit)? = null
     ) {
+        onInitComplete?.let(pendingInitializationCallbacks::add)
         if (isInitializingVideoConference) return
         isInitializingVideoConference = true
         showLoadingAndDisableStartButton()
         profileDetails?.let {
-            initVideoConferenceHandler(videoConference, it, onInitComplete)
-        } ?: loadProfileAndInitializeConference(videoConference, onInitComplete)
+            initVideoConferenceHandler(videoConference, it)
+        } ?: loadProfileAndInitializeConference(videoConference)
     }
 
-    private fun loadProfileAndInitializeConference(
-        videoConference: DomainVideoConferenceContent?,
-        onInitComplete: (() -> Unit)? = null
-    ) {
+    private fun loadProfileAndInitializeConference(videoConference: DomainVideoConferenceContent?) {
         TestpressUserDetails.getInstance().load(requireContext(), object : TestpressCallback<ProfileDetails>() {
             override fun onSuccess(result: ProfileDetails?) {
                 if (!isAdded) {
-                    isInitializingVideoConference = false
+                    completeVideoConferenceInitialization()
                     return
                 }
                 profileDetails = result
                 profileDetails?.let {
-                    initVideoConferenceHandler(videoConference, it, onInitComplete)
+                    initVideoConferenceHandler(videoConference, it)
                 } ?: run {
-                    isInitializingVideoConference = false
-                    onInitComplete?.invoke()
+                    completeVideoConferenceInitialization()
                 }
             }
 
             override fun onException(exception: TestpressException) {
-                isInitializingVideoConference = false
-                if (!isAdded) return
+                if (!isAdded) {
+                    completeVideoConferenceInitialization()
+                    return
+                }
                 emptyViewFragment.displayError(exception)
-                onInitComplete?.invoke()
+                completeVideoConferenceInitialization()
             }
         })
     }
 
     private fun initVideoConferenceHandler(
         videoConference: DomainVideoConferenceContent?,
-        profileDetails: ProfileDetails,
-        onInitComplete: (() -> Unit)? = null
+        profileDetails: ProfileDetails
     ) {
         if (!isAdded || videoConference == null || videoConference.accessToken.isNullOrBlank()) {
-            isInitializingVideoConference = false
             if (!isRetryingAfterFailure) {
                 hideLoadingAndEnableStartButton()
             }
-            onInitComplete?.invoke()
+            completeVideoConferenceInitialization()
             return
         }
         try {
             videoConferenceHandler = VideoConferenceHandler(requireContext(), videoConference, profileDetails)
             videoConferenceHandler?.init(object : VideoConferenceInitializeListener {
                 override fun onSuccess() {
-                    isInitializingVideoConference = false
                     if (!isRetryingAfterFailure) {
                         hideLoadingAndEnableStartButton()
                     }
-                    onInitComplete?.invoke()
+                    completeVideoConferenceInitialization()
                 }
 
                 override fun onFailure() {
-                    isInitializingVideoConference = false
                     if (!isRetryingAfterFailure) {
                         hideLoadingAndEnableStartButton()
                     }
-                    onInitComplete?.invoke()
+                    completeVideoConferenceInitialization()
                 }
             })
         } catch (e: NoClassDefFoundError) {
-            isInitializingVideoConference = false
             if (!isRetryingAfterFailure) {
                 hideLoadingAndEnableStartButton()
             }
             Toast.makeText(context, "Zoom integration is not enabled in the app, please contact admin", Toast.LENGTH_LONG).show()
-            onInitComplete?.invoke()
+            completeVideoConferenceInitialization()
         } catch (e: Exception) {
-            isInitializingVideoConference = false
             if (!isRetryingAfterFailure) {
                 hideLoadingAndEnableStartButton()
             }
@@ -224,7 +218,16 @@ class VideoConferenceFragment : BaseContentDetailFragment() {
                     }
                 )
             }
-            onInitComplete?.invoke()
+            completeVideoConferenceInitialization()
+        }
+    }
+
+    private fun completeVideoConferenceInitialization() {
+        isInitializingVideoConference = false
+        val callbacks = pendingInitializationCallbacks.toList()
+        pendingInitializationCallbacks.clear()
+        if (isAdded) {
+            callbacks.forEach { it.invoke() }
         }
     }
 

--- a/course/src/main/java/in/testpress/course/fragments/VideoConferenceFragment.kt
+++ b/course/src/main/java/in/testpress/course/fragments/VideoConferenceFragment.kt
@@ -38,6 +38,7 @@ class VideoConferenceFragment : BaseContentDetailFragment() {
     private var reloadContent = 0
     private val maxReloadContent = 3
     private var isRetryingAfterFailure = false
+    private var isInitializingVideoConference = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -127,26 +128,42 @@ class VideoConferenceFragment : BaseContentDetailFragment() {
         startButton.setBackgroundColor(ContextCompat.getColor(requireContext(), R.color.testpress_text_gray))
     }
 
-    private fun initializeVideoConferenceHandler(videoConference: DomainVideoConferenceContent?) {
+    private fun initializeVideoConferenceHandler(
+        videoConference: DomainVideoConferenceContent?,
+        onInitComplete: (() -> Unit)? = null
+    ) {
+        if (isInitializingVideoConference) return
+        isInitializingVideoConference = true
         showLoadingAndDisableStartButton()
         profileDetails?.let {
-            initVideoConferenceHandler(videoConference, it)
-        } ?: loadProfileAndInitializeConference(videoConference)
+            initVideoConferenceHandler(videoConference, it, onInitComplete)
+        } ?: loadProfileAndInitializeConference(videoConference, onInitComplete)
     }
 
-    private fun loadProfileAndInitializeConference(videoConference: DomainVideoConferenceContent?) {
+    private fun loadProfileAndInitializeConference(
+        videoConference: DomainVideoConferenceContent?,
+        onInitComplete: (() -> Unit)? = null
+    ) {
         TestpressUserDetails.getInstance().load(requireContext(), object : TestpressCallback<ProfileDetails>() {
             override fun onSuccess(result: ProfileDetails?) {
-                if (!isAdded) return
+                if (!isAdded) {
+                    isInitializingVideoConference = false
+                    return
+                }
                 profileDetails = result
                 profileDetails?.let {
-                    initVideoConferenceHandler(videoConference, it)
+                    initVideoConferenceHandler(videoConference, it, onInitComplete)
+                } ?: run {
+                    isInitializingVideoConference = false
+                    onInitComplete?.invoke()
                 }
             }
 
             override fun onException(exception: TestpressException) {
+                isInitializingVideoConference = false
                 if (!isAdded) return
                 emptyViewFragment.displayError(exception)
+                onInitComplete?.invoke()
             }
         })
     }
@@ -157,6 +174,7 @@ class VideoConferenceFragment : BaseContentDetailFragment() {
         onInitComplete: (() -> Unit)? = null
     ) {
         if (!isAdded || videoConference == null || videoConference.accessToken.isNullOrBlank()) {
+            isInitializingVideoConference = false
             if (!isRetryingAfterFailure) {
                 hideLoadingAndEnableStartButton()
             }
@@ -167,6 +185,7 @@ class VideoConferenceFragment : BaseContentDetailFragment() {
             videoConferenceHandler = VideoConferenceHandler(requireContext(), videoConference, profileDetails)
             videoConferenceHandler?.init(object : VideoConferenceInitializeListener {
                 override fun onSuccess() {
+                    isInitializingVideoConference = false
                     if (!isRetryingAfterFailure) {
                         hideLoadingAndEnableStartButton()
                     }
@@ -174,6 +193,7 @@ class VideoConferenceFragment : BaseContentDetailFragment() {
                 }
 
                 override fun onFailure() {
+                    isInitializingVideoConference = false
                     if (!isRetryingAfterFailure) {
                         hideLoadingAndEnableStartButton()
                     }
@@ -181,12 +201,14 @@ class VideoConferenceFragment : BaseContentDetailFragment() {
                 }
             })
         } catch (e: NoClassDefFoundError) {
+            isInitializingVideoConference = false
             if (!isRetryingAfterFailure) {
                 hideLoadingAndEnableStartButton()
             }
             Toast.makeText(context, "Zoom integration is not enabled in the app, please contact admin", Toast.LENGTH_LONG).show()
             onInitComplete?.invoke()
         } catch (e: Exception) {
+            isInitializingVideoConference = false
             if (!isRetryingAfterFailure) {
                 hideLoadingAndEnableStartButton()
             }
@@ -225,7 +247,7 @@ class VideoConferenceFragment : BaseContentDetailFragment() {
                 if (refreshedConference != null && refreshedConference.conferenceId != null && refreshedConference.password != null && !refreshedConference.accessToken.isNullOrBlank()) {
                     videoConferenceHandler?.destroy()
                     profileDetails?.let {
-                        initVideoConferenceHandler(refreshedConference, it) {
+                        initializeVideoConferenceHandler(refreshedConference) {
                             performJoinAttempt()
                         }
                     } ?: run {
@@ -275,7 +297,7 @@ class VideoConferenceFragment : BaseContentDetailFragment() {
                         profileDetails?.let {
                             if (videoConference != null && videoConference.conferenceId != null && videoConference.password != null) {
                                 videoConferenceHandler?.destroy()
-                                initVideoConferenceHandler(videoConference, it) {
+                                initializeVideoConferenceHandler(videoConference) {
                                     videoConferenceHandler?.joinMeet(object: VideoConferenceInitializeListener {
                                         override fun onSuccess() {
                                             handleJoinSuccess()


### PR DESCRIPTION
Zoom SDK initialization is asynchronous, but repeated fragment display and retry paths could create new handlers and call initialize again while a previous attempt was still running. After the Zoom SDK upgrade, these overlapping calls surfaced as ZOOM_ERROR_INVALID_ARGUMENTS and prevented users from joining classes.

Track initialization state in VideoConferenceFragment and ignore duplicate attempts until the active attempt completes. Reset the state on every success, failure, invalid-data, profile-loading, and exception path, and route join retries through the same guarded entry point.

This ensures only one Zoom initialization runs per fragment at a time while preserving legitimate retries after completion, preventing the repeated initialization failures without changing backend data or meeting join behavior.

Source Sentry Issue:
https://sentry.testpress.in/organizations/testpress/issues/168024/events/9458fba72e154355a2c7f1576a2f01dd/


## display and retry paths could create new handlers. Why?
display() here is not an Android lifecycle method. It is a custom Testpress method used to render newly loaded content.

It can run multiple times because the fragment reloads content in several situations:

1. Initial screen load

BaseContentDetailFragment observes the content request. Whenever it receives a successful result, it calls:

content = resource.data!!
display()

2. Explicit content refreshes

forceReloadContent() starts another content request. On success, it again calls:

content = resource.data!!
display()
onSuccessCallback.invoke()

Zoom content is force-reloaded when:

- The JWT is expired or invalid.
- The meeting ID, password, or token is missing.
- A join attempt fails.
- The user pulls to refresh.

3. Fragment recreation

Android can destroy and recreate the fragment following navigation, configuration changes, or process/activity recreation. The new fragment loads the content and calls display() again.

## Why this mattered for Zoom

Every successful display() for Zoom content previously did this unconditionally:

initializeVideoConferenceHandler(videoConference)

That creates a new VideoConferenceHandler, and the handler calls the process-wide:

ZoomSDK.getInstance().initialize(...)

Zoom initialization is asynchronous. Calling initialize() does not immediately make zoomSDK.isInitialized true.

The problematic sequence could therefore be:

display()
→ create handler A
→ call Zoom initialize
→ Zoom is still initializing

content reload succeeds
→ display() runs again
→ create handler B
→ Zoom still reports isInitialized == false
→ call Zoom initialize again

The second call happens before the first initialization completes.

There is also a particularly important ordering inside forceReloadContent():

display()
onSuccessCallback.invoke()

During a retry:

1. Refreshed content arrives.
2. display() automatically starts Zoom initialization.
3. The retry callback then tries to initialize Zoom again before joining.

That path reliably presented two initialization requests close together unless they were coordinated.

This also explains the Sentry pattern: the same user, meeting, token, trace, and timestamp produced several initialization-error events. Multiple handler/listener instances were likely reacting to the same logical class-opening
operation.

The implemented guard prevents another initialization from starting while one is active. The follow-up callback queue ensures retry code waits for and reuses that active initialization instead of being discarded.

TODO LINK:
https://app.basecamp.com/4160028/buckets/48341145/card_tables/cards/10203014502